### PR TITLE
feat: credit approval `to` & `from`

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -45,9 +45,14 @@
     "viem": "^2.21.37"
   },
   "devDependencies": {
-    "@types/node": "^22.10.6",
     "@recall/eslint-config": "workspace:*",
     "@recall/typescript-config": "workspace:*",
-    "tempy": "^3.1.0"
+    "@types/chai": "^5.0.1",
+    "@types/mocha": "^10.0.10",
+    "@types/node": "^22.10.7",
+    "chai": "^5.1.2",
+    "mocha": "^11.0.1",
+    "tempy": "^3.1.0",
+    "ts-node": "^10.9.2"
   }
 }

--- a/packages/sdk/test/contracts.test.ts
+++ b/packages/sdk/test/contracts.test.ts
@@ -2,7 +2,14 @@ import { rejects, strictEqual } from "node:assert";
 import { expect } from "chai";
 import { describe, it } from "mocha";
 import { temporaryWrite } from "tempy";
-import { Account, Address, getAddress, isAddress, isHash, parseEther } from "viem";
+import {
+  Account,
+  Address,
+  getAddress,
+  isAddress,
+  isHash,
+  parseEther,
+} from "viem";
 import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
 import { localnet } from "../src/chains.js";
 import { HokuClient, walletClientFromPrivateKey } from "../src/client.js";
@@ -13,10 +20,11 @@ import {
   CreditManager,
 } from "../src/entities/index.js";
 
-// TODO: once https://github.com/hokunet/contracts/pull/55 is merged, we can remove this.
+// TODO: once https://github.com/hokunet/contracts/pull/56 is merged, we can remove this.
 // Currently, `ipc` localnet deploys a credit and blob manager contract that returns a different
-// value in `getAccount`, `getCreditBalance`, and `getBlob` than what this JS lib expects.
+// value in `getAccount`, `getCreditBalance`, and `getStorageUsage` than what this JS lib expects.
 const CREDIT_MANAGER_ADDRESS = "";
+const BLOB_MANAGER_ADDRESS = "";
 
 // TODO: these tests are somewhat dependent on one another, so we should refactor to be independent
 describe("contracts", function () {
@@ -50,13 +58,16 @@ describe("contracts", function () {
     it("should list buckets", async () => {
       let { result: buckets } = await bucketManager.list(account.address);
       expect(buckets).to.be.an("array");
-      strictEqual(buckets[0].kind, 0);
+      strictEqual(buckets[0]?.kind, 0);
 
       // at a specific block number
       const latestBlock = await client.publicClient.getBlockNumber();
-      ({ result: buckets } = await bucketManager.list(account.address, latestBlock));
+      ({ result: buckets } = await bucketManager.list(
+        account.address,
+        latestBlock
+      ));
       expect(buckets).to.be.an("array");
-      strictEqual(buckets[0].kind, 0);
+      strictEqual(buckets[0]?.kind, 0);
 
       // "non-existent" account in FVM world, and it has not created any buckets
       const randomAccount = privateKeyToAccount(generatePrivateKey());
@@ -68,9 +79,11 @@ describe("contracts", function () {
     it("should override default contract address", async () => {
       const bucketManagerAddr = client.bucketManager().getContract().address;
       const overrideBucketManager = client.bucketManager(bucketManagerAddr);
-      const { result: buckets } = await overrideBucketManager.list(account.address);
+      const { result: buckets } = await overrideBucketManager.list(
+        account.address
+      );
       expect(buckets).to.be.an("array");
-      strictEqual(buckets[0].kind, 0);
+      strictEqual(buckets[0]?.kind, 0);
     });
 
     describe("objects", function () {
@@ -92,7 +105,12 @@ describe("contracts", function () {
             foo: "bar",
           },
         };
-        const { meta, result } = await bucketManager.add(bucket, key, path, opts);
+        const { meta, result } = await bucketManager.add(
+          bucket,
+          key,
+          path,
+          opts
+        );
         strictEqual(isHash(meta!.tx!.transactionHash), true);
         strictEqual(result.owner, account.address);
         strictEqual(result.bucket.toLowerCase(), bucket);
@@ -104,7 +122,11 @@ describe("contracts", function () {
         const file = new File([content], "test.txt", {
           type: "text/plain",
         });
-        const { meta, result } = await bucketManager.add(bucket, "hello/test", file);
+        const { meta, result } = await bucketManager.add(
+          bucket,
+          "hello/test",
+          file
+        );
         strictEqual(isHash(meta!.tx!.transactionHash), true);
         strictEqual(result.owner, account.address);
         strictEqual(result.bucket.toLowerCase(), bucket);
@@ -112,13 +134,20 @@ describe("contracts", function () {
       });
 
       it("should get object value without downloading", async () => {
-        let { result: object } = await bucketManager.getObjectValue(bucket, key);
+        let { result: object } = await bucketManager.getObjectValue(
+          bucket,
+          key
+        );
         strictEqual(object.blobHash, blobHash);
         strictEqual(object.size, 6n);
 
         // at a specific block number
         const latestBlock = await client.publicClient.getBlockNumber();
-        ({ result: object } = await bucketManager.getObjectValue(bucket, key, latestBlock));
+        ({ result: object } = await bucketManager.getObjectValue(
+          bucket,
+          key,
+          latestBlock
+        ));
         strictEqual(object.blobHash, blobHash);
         strictEqual(object.size, 6n);
       });
@@ -127,7 +156,10 @@ describe("contracts", function () {
         const missingBucket = "0xff00999999999999999999999999999999999999";
         const object = bucketManager.getObjectValue(missingBucket, key);
         await rejects(object, (err) => {
-          strictEqual((err as Error).message, `Bucket not found: '${missingBucket}'`);
+          strictEqual(
+            (err as Error).message,
+            `Bucket not found: '${missingBucket}'`
+          );
           return true;
         });
       });
@@ -194,7 +226,10 @@ describe("contracts", function () {
         let range: { start?: number; end?: number } = { start: 5, end: 2 };
         let object = bucketManager.get(bucket, key, range);
         await rejects(object, (err) => {
-          strictEqual((err as Error).message, `Invalid range: ${range.start}-${range.end}`);
+          strictEqual(
+            (err as Error).message,
+            `Invalid range: ${range.start}-${range.end}`
+          );
           return true;
         });
 
@@ -223,9 +258,9 @@ describe("contracts", function () {
           result: { objects, commonPrefixes },
         } = await bucketManager.query(bucket, "hello/");
         expect(objects.length).to.be.greaterThan(0);
-        strictEqual(objects[0].key, key);
-        strictEqual(objects[0].state.size, 6n);
-        strictEqual(objects[0].state.blobHash, blobHash);
+        strictEqual(objects[0]?.key, key);
+        strictEqual(objects[0]?.state?.size, 6n);
+        strictEqual(objects[0]?.state?.blobHash, blobHash);
         strictEqual(commonPrefixes.length, 0);
 
         // no objects with prefix
@@ -239,9 +274,16 @@ describe("contracts", function () {
         const latestBlock = await client.publicClient.getBlockNumber();
         ({
           result: { objects, commonPrefixes },
-        } = await bucketManager.query(bucket, "hello/", "/", "", 1, latestBlock));
+        } = await bucketManager.query(
+          bucket,
+          "hello/",
+          "/",
+          "",
+          1,
+          latestBlock
+        ));
         strictEqual(objects.length, 1);
-        strictEqual(objects[0].key, key);
+        strictEqual(objects[0]?.key, key);
         strictEqual(commonPrefixes.length, 0);
       });
 
@@ -249,13 +291,14 @@ describe("contracts", function () {
         const missingBucket = "0xff00999999999999999999999999999999999999";
         const query = bucketManager.query(missingBucket, "hello/");
         await rejects(query, (err) => {
-          strictEqual((err as Error).message, `Bucket not found: '${missingBucket}'`);
+          strictEqual(
+            (err as Error).message,
+            `Bucket not found: '${missingBucket}'`
+          );
           return true;
         });
       });
 
-      // TODO: although this test passes in isolation, it leads to weird behavior wrt object
-      // availability on the network, causing later tests fail for get/download objects with the same contents
       it("should delete object", async () => {
         const deletedKey = "hello/deleted";
         const path = await temporaryWrite(fileContents);
@@ -287,7 +330,9 @@ describe("contracts", function () {
     let caller: Address;
 
     before(async () => {
-      credits = client.creditManager((CREDIT_MANAGER_ADDRESS as Address) ?? undefined);
+      credits = client.creditManager(
+        (CREDIT_MANAGER_ADDRESS as Address) ?? undefined
+      );
       to = getAddress("0x9965507d1a55bcc2695c58ba16fb37d819b0a4dc");
       caller = getAddress("0x976ea74026e726554db657fa54763abd0c3a0aa9");
     });
@@ -409,7 +454,8 @@ describe("contracts", function () {
       expect(result.creditCommitted).to.be.a("bigint");
       strictEqual(isAddress(result.creditSponsor), true);
       expect(result.lastDebitEpoch).to.not.equal(0n);
-      expect(result.approvals).to.be.an("array");
+      expect(result.approvalsTo).to.be.an("array");
+      expect(result.approvalsFrom).to.be.an("array");
     });
 
     it("should get credit balance", async () => {
@@ -422,23 +468,47 @@ describe("contracts", function () {
     it("should get credit approvals with no filter", async () => {
       await credits.approve(to);
       const {
-        result: { approvals },
+        result: { approvalsTo, approvalsFrom },
       } = await credits.getCreditApprovals(account.address);
-      expect(approvals).to.be.an("array");
-      expect(approvals.length).to.be.greaterThan(0);
-      strictEqual(isAddress(approvals[0].to), true);
+      expect(approvalsTo).to.be.an("array");
+      expect(approvalsTo.length).to.be.greaterThan(0);
+      strictEqual(isAddress(approvalsTo[0]!.addr), true);
+      expect(approvalsFrom).to.be.an("array");
       await credits.revoke(to);
     });
 
     it("should get credit approvals with 'to' filter", async () => {
       await credits.approve(to);
       const {
-        result: { approvals },
-      } = await credits.getCreditApprovals(account.address, to);
-      expect(approvals).to.be.an("array");
-      expect(approvals.length).to.be.greaterThan(0);
-      strictEqual(isAddress(approvals[0].to), true);
-      await credits.revoke(to);
+        result: { approvalsTo },
+      } = await credits.getCreditApprovals(account.address, {
+        filterTo: to,
+      });
+      expect(approvalsTo).to.be.an("array");
+      expect(approvalsTo.length).to.be.greaterThan(0);
+      strictEqual(isAddress(approvalsTo[0]!.addr), true);
+    });
+
+    it("should get credit approvals with 'from' filter", async () => {
+      const approver = walletClientFromPrivateKey(
+        "0x2a871d0798f97d79848a013d4936a73bf4cc922c825d33c1cf7073dff6d409c6",
+        localnet
+      );
+      const approverClient = new HokuClient({ walletClient: approver });
+      const approverCredits = approverClient.creditManager(
+        (CREDIT_MANAGER_ADDRESS as Address) ?? undefined
+      );
+      await approverCredits.approve(account.address);
+      const {
+        result: { approvalsFrom },
+      } = await credits.getCreditApprovals(account.address, {
+        filterFrom: approver.account.address,
+      });
+      expect(approvalsFrom).to.be.an("array");
+      expect(approvalsFrom.length).to.be.greaterThan(0);
+      strictEqual(isAddress(approvalsFrom[0]!.addr), true);
+      strictEqual(approvalsFrom[0]!.addr, approver.account.address);
+      await approverCredits.revoke(account.address);
     });
 
     it("should get credit stats", async () => {
@@ -447,7 +517,10 @@ describe("contracts", function () {
       expect(Number(stats.creditCommitted)).to.be.greaterThan(0);
       expect(Number(stats.creditSold)).to.be.greaterThan(0);
       expect(Number(stats.creditDebited)).to.be.greaterThan(0);
-      strictEqual(stats.tokenCreditRate, 1000000000000000000000000000000000000n);
+      strictEqual(
+        stats.tokenCreditRate,
+        1000000000000000000000000000000000000n
+      );
       expect(Number(stats.numAccounts)).to.be.greaterThan(0);
     });
   });
@@ -462,7 +535,9 @@ describe("contracts", function () {
     const blobHash = "rzghyg4z3p6vbz5jkgc75lk64fci7kieul65o6hk6xznx7lctkmq";
 
     before(async () => {
-      blobs = client.blobManager();
+      blobs = client.blobManager(
+        (BLOB_MANAGER_ADDRESS as Address) ?? undefined
+      );
     });
 
     it("should get added blobs", async () => {
@@ -508,7 +583,10 @@ describe("contracts", function () {
       expect(Number(stats.creditSold)).to.be.greaterThan(0);
       expect(Number(stats.creditCommitted)).to.be.greaterThan(0);
       expect(Number(stats.creditDebited)).to.be.greaterThan(0);
-      strictEqual(stats.tokenCreditRate, 1000000000000000000000000000000000000n);
+      strictEqual(
+        stats.tokenCreditRate,
+        1000000000000000000000000000000000000n
+      );
       expect(Number(stats.numAccounts)).to.be.greaterThan(0);
       expect(stats.numBlobs).to.be.a("bigint");
       expect(stats.numResolving).to.be.a("bigint");
@@ -517,7 +595,11 @@ describe("contracts", function () {
     // TODO: this assumes the blob already exists on the network since the objects API has no way
     // to add a blob. Thus, we're taking advantage of its pre-existence on the network to "add" it.
     it("should add blob", async () => {
-      const { meta, result } = await blobs.addBlob(blobHash, subscriptionId, size);
+      const { meta, result } = await blobs.addBlob(
+        blobHash,
+        subscriptionId,
+        size
+      );
       strictEqual(isHash(meta!.tx!.transactionHash), true);
       strictEqual(result.blobHash, blobHash);
     });
@@ -530,13 +612,22 @@ describe("contracts", function () {
     });
 
     it("should get blob status", async () => {
-      const { result } = await blobs.getBlobStatus(account.address, blobHash, subscriptionId);
+      const { result } = await blobs.getBlobStatus(
+        account.address,
+        blobHash,
+        subscriptionId
+      );
       expect(result).to.be.equal(2); // resolved
     });
 
     // TODO: this assumes the new blob already exists on the network / iroh node
     it("should overwrite blob", async () => {
-      const { meta, result } = await blobs.overwriteBlob(blobHash, blobHash, subscriptionId, size);
+      const { meta, result } = await blobs.overwriteBlob(
+        blobHash,
+        blobHash,
+        subscriptionId,
+        size
+      );
       strictEqual(isHash(meta!.tx!.transactionHash), true);
       strictEqual(result.newHash, blobHash);
     });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,52 @@ importers:
         specifier: ^5.7.3
         version: 5.7.3
 
+  apps/studio:
+    dependencies:
+      '@recall/ui':
+        specifier: workspace:*
+        version: link:../../packages/ui
+      lucide-react:
+        specifier: 0.456.0
+        version: 0.456.0(react@19.0.0)
+      next:
+        specifier: ^15.1.0
+        version: 15.1.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      next-themes:
+        specifier: ^0.4.3
+        version: 0.4.4(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      react:
+        specifier: ^19.0.0
+        version: 19.0.0
+      react-dom:
+        specifier: ^19.0.0
+        version: 19.0.0(react@19.0.0)
+    devDependencies:
+      '@recall/eslint-config':
+        specifier: workspace:^
+        version: link:../../packages/eslint-config
+      '@recall/typescript-config':
+        specifier: workspace:*
+        version: link:../../packages/typescript-config
+      '@types/node':
+        specifier: ^20
+        version: 20.17.10
+      '@types/react':
+        specifier: 18.3.0
+        version: 18.3.0
+      '@types/react-dom':
+        specifier: 18.3.1
+        version: 18.3.1
+      postcss:
+        specifier: ^8
+        version: 8.4.49
+      tailwindcss:
+        specifier: ^3.4.1
+        version: 3.4.16(ts-node@10.9.2(@types/node@20.17.10)(typescript@5.7.3))
+      typescript:
+        specifier: ^5.7.3
+        version: 5.7.3
+
   apps/web:
     dependencies:
       '@recall/ui':
@@ -195,12 +241,27 @@ importers:
       '@recall/typescript-config':
         specifier: workspace:*
         version: link:../typescript-config
+      '@types/chai':
+        specifier: ^5.0.1
+        version: 5.0.1
+      '@types/mocha':
+        specifier: ^10.0.10
+        version: 10.0.10
       '@types/node':
-        specifier: ^22.10.6
+        specifier: ^22.10.7
         version: 22.10.7
+      chai:
+        specifier: ^5.1.2
+        version: 5.1.2
+      mocha:
+        specifier: ^11.0.1
+        version: 11.0.1
       tempy:
         specifier: ^3.1.0
         version: 3.1.0
+      ts-node:
+        specifier: ^10.9.2
+        version: 10.9.2(@types/node@22.10.7)(typescript@5.7.3)
 
   packages/typescript-config: {}
 
@@ -1034,6 +1095,10 @@ packages:
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
 
+  ansi-colors@4.1.3:
+    resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
+    engines: {node: '>=6'}
+
   ansi-escapes@4.3.2:
     resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
     engines: {node: '>=8'}
@@ -1155,6 +1220,9 @@ packages:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
+  browser-stdout@1.3.1:
+    resolution: {integrity: sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==}
+
   browserslist@4.24.3:
     resolution: {integrity: sha512-1CPmv8iobE2fyRMV97dAcMVegvvWKxmq94hkLiAkUGwKVTyDLw33K+ZxiFrREKmmps4rIw6grcCFCnTMSZ/YiA==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
@@ -1203,6 +1271,10 @@ packages:
   camelcase-css@2.0.1:
     resolution: {integrity: sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==}
     engines: {node: '>= 6'}
+
+  camelcase@6.3.0:
+    resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
+    engines: {node: '>=10'}
 
   caniuse-lite@1.0.30001688:
     resolution: {integrity: sha512-Nmqpru91cuABu/DTCXbM2NSRHzM2uVHfPnhJ/1zEAJx/ILBRVmz3pzH4N7DZqbdG0gWClsCC05Oj0mJ/1AWMbA==}
@@ -1274,6 +1346,9 @@ packages:
 
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
+
+  cliui@7.0.4:
+    resolution: {integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==}
 
   clone@1.0.4:
     resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
@@ -1364,6 +1439,10 @@ packages:
       supports-color:
         optional: true
 
+  decamelize@4.0.0:
+    resolution: {integrity: sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==}
+    engines: {node: '>=10'}
+
   dedent@0.7.0:
     resolution: {integrity: sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==}
 
@@ -1406,6 +1485,10 @@ packages:
 
   diff@4.0.2:
     resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
+    engines: {node: '>=0.3.1'}
+
+  diff@5.2.0:
+    resolution: {integrity: sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==}
     engines: {node: '>=0.3.1'}
 
   dir-glob@3.0.1:
@@ -1640,6 +1723,10 @@ packages:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
     engines: {node: '>=16'}
 
+  flat@5.0.2:
+    resolution: {integrity: sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==}
+    hasBin: true
+
   flatted@3.3.2:
     resolution: {integrity: sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA==}
 
@@ -1674,6 +1761,10 @@ packages:
 
   functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
+
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
 
   get-intrinsic@1.2.6:
     resolution: {integrity: sha512-qxsEs+9A+u85HhllWJJFicJfPDhRmjzoYdl64aMWW9yRIJmSyxdn8IEkuIM530/7T+lv0TIHd8L6Q/ra0tEoeA==}
@@ -1775,6 +1866,10 @@ packages:
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
+
+  he@1.2.0:
+    resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
+    hasBin: true
 
   header-case@1.0.1:
     resolution: {integrity: sha512-i0q9mkOeSuhXw6bGgiQCCBgY/jlZuV/7dZXyZ9c6LcBrqwvT8eT719E9uxE5LiZftdl+z81Ugbg/VvXV4OJOeQ==}
@@ -1928,6 +2023,10 @@ packages:
 
   is-path-inside@3.0.3:
     resolution: {integrity: sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==}
+    engines: {node: '>=8'}
+
+  is-plain-obj@2.1.0:
+    resolution: {integrity: sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==}
     engines: {node: '>=8'}
 
   is-regex@1.2.1:
@@ -2126,6 +2225,10 @@ packages:
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
 
+  minimatch@5.1.6:
+    resolution: {integrity: sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==}
+    engines: {node: '>=10'}
+
   minimatch@9.0.5:
     resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -2139,6 +2242,11 @@ packages:
 
   mkdirp@0.5.6:
     resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==}
+    hasBin: true
+
+  mocha@11.0.1:
+    resolution: {integrity: sha512-+3GkODfsDG71KSCQhc4IekSW+ItCK/kiez1Z28ksWvYhKXV/syxMlerR/sC7whDp7IyreZ4YxceMLdTs5hQE8A==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     hasBin: true
 
   ms@2.1.3:
@@ -2454,6 +2562,9 @@ packages:
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
+  randombytes@2.1.0:
+    resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
+
   rc@1.2.8:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
     hasBin: true
@@ -2501,6 +2612,10 @@ packages:
 
   registry-url@3.1.0:
     resolution: {integrity: sha512-ZbgR5aZEdf4UKZVBPYIgaglBmSF2Hi94s2PcIHhRGFjKYu+chjJdYfHn4rt3hB6eCKLJ8giVIIfgMa1ehDfZKA==}
+    engines: {node: '>=0.10.0'}
+
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
 
   resolve-from@4.0.0:
@@ -2575,6 +2690,9 @@ packages:
 
   sentence-case@2.1.1:
     resolution: {integrity: sha512-ENl7cYHaK/Ktwk5OTD+aDbQ3uC8IByu/6Bkg+HDv8Mm+XnBnppVNalcfJTNsp1ibstKh030/JKQQWglDvtKwEQ==}
+
+  serialize-javascript@6.0.2:
+    resolution: {integrity: sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==}
 
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
@@ -2735,6 +2853,10 @@ packages:
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
+
+  supports-color@8.1.1:
+    resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
+    engines: {node: '>=10'}
 
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
@@ -3002,6 +3124,9 @@ packages:
   wordwrap@1.0.0:
     resolution: {integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==}
 
+  workerpool@6.5.1:
+    resolution: {integrity: sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==}
+
   wrap-ansi@6.2.0:
     resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
     engines: {node: '>=8'}
@@ -3029,10 +3154,26 @@ packages:
       utf-8-validate:
         optional: true
 
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+
   yaml@2.6.1:
     resolution: {integrity: sha512-7r0XPzioN/Q9kXBro/XPnA6kznR73DHq+GXh5ON7ZozRO6aMjbmiBuKste2wslTFkC5d1dw0GooOCepZXJ2SAg==}
     engines: {node: '>= 14'}
     hasBin: true
+
+  yargs-parser@20.2.9:
+    resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}
+    engines: {node: '>=10'}
+
+  yargs-unparser@2.0.0:
+    resolution: {integrity: sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==}
+    engines: {node: '>=10'}
+
+  yargs@16.2.0:
+    resolution: {integrity: sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==}
+    engines: {node: '>=10'}
 
   yn@3.1.1:
     resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}
@@ -3144,7 +3285,7 @@ snapshots:
   '@eslint/config-array@0.19.1':
     dependencies:
       '@eslint/object-schema': 2.1.5
-      debug: 4.4.0
+      debug: 4.4.0(supports-color@8.1.1)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -3156,7 +3297,7 @@ snapshots:
   '@eslint/eslintrc@3.2.0':
     dependencies:
       ajv: 6.12.6
-      debug: 4.4.0
+      debug: 4.4.0(supports-color@8.1.1)
       espree: 10.3.0
       globals: 14.0.0
       ignore: 5.3.2
@@ -3577,7 +3718,7 @@ snapshots:
       '@typescript-eslint/types': 8.18.0
       '@typescript-eslint/typescript-estree': 8.18.0(typescript@5.7.3)
       '@typescript-eslint/visitor-keys': 8.18.0
-      debug: 4.4.0
+      debug: 4.4.0(supports-color@8.1.1)
       eslint: 9.17.0(jiti@1.21.6)
       typescript: 5.7.3
     transitivePeerDependencies:
@@ -3589,7 +3730,7 @@ snapshots:
       '@typescript-eslint/types': 8.18.1
       '@typescript-eslint/typescript-estree': 8.18.1(typescript@5.7.3)
       '@typescript-eslint/visitor-keys': 8.18.1
-      debug: 4.4.0
+      debug: 4.4.0(supports-color@8.1.1)
       eslint: 9.17.0(jiti@1.21.6)
       typescript: 5.7.3
     transitivePeerDependencies:
@@ -3609,7 +3750,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 8.18.0(typescript@5.7.3)
       '@typescript-eslint/utils': 8.18.0(eslint@9.17.0(jiti@1.21.6))(typescript@5.7.3)
-      debug: 4.4.0
+      debug: 4.4.0(supports-color@8.1.1)
       eslint: 9.17.0(jiti@1.21.6)
       ts-api-utils: 1.4.3(typescript@5.7.3)
       typescript: 5.7.3
@@ -3620,7 +3761,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 8.18.1(typescript@5.7.3)
       '@typescript-eslint/utils': 8.18.1(eslint@9.17.0(jiti@1.21.6))(typescript@5.7.3)
-      debug: 4.4.0
+      debug: 4.4.0(supports-color@8.1.1)
       eslint: 9.17.0(jiti@1.21.6)
       ts-api-utils: 1.4.3(typescript@5.7.3)
       typescript: 5.7.3
@@ -3635,7 +3776,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.18.0
       '@typescript-eslint/visitor-keys': 8.18.0
-      debug: 4.4.0
+      debug: 4.4.0(supports-color@8.1.1)
       fast-glob: 3.3.2
       is-glob: 4.0.3
       minimatch: 9.0.5
@@ -3649,7 +3790,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.18.1
       '@typescript-eslint/visitor-keys': 8.18.1
-      debug: 4.4.0
+      debug: 4.4.0(supports-color@8.1.1)
       fast-glob: 3.3.2
       is-glob: 4.0.3
       minimatch: 9.0.5
@@ -3750,6 +3891,8 @@ snapshots:
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
+
+  ansi-colors@4.1.3: {}
 
   ansi-escapes@4.3.2:
     dependencies:
@@ -3889,6 +4032,8 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
+  browser-stdout@1.3.1: {}
+
   browserslist@4.24.3:
     dependencies:
       caniuse-lite: 1.0.30001688
@@ -3942,6 +4087,8 @@ snapshots:
       upper-case: 1.1.3
 
   camelcase-css@2.0.1: {}
+
+  camelcase@6.3.0: {}
 
   caniuse-lite@1.0.30001688: {}
 
@@ -4035,6 +4182,12 @@ snapshots:
 
   client-only@0.0.1: {}
 
+  cliui@7.0.4:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+
   clone@1.0.4: {}
 
   clsx@2.1.1: {}
@@ -4112,9 +4265,13 @@ snapshots:
       es-errors: 1.3.0
       is-data-view: 1.0.2
 
-  debug@4.4.0:
+  debug@4.4.0(supports-color@8.1.1):
     dependencies:
       ms: 2.1.3
+    optionalDependencies:
+      supports-color: 8.1.1
+
+  decamelize@4.0.0: {}
 
   dedent@0.7.0: {}
 
@@ -4163,6 +4320,8 @@ snapshots:
   didyoumean@1.2.2: {}
 
   diff@4.0.2: {}
+
+  diff@5.2.0: {}
 
   dir-glob@3.0.1:
     dependencies:
@@ -4392,7 +4551,7 @@ snapshots:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.0
+      debug: 4.4.0(supports-color@8.1.1)
       escape-string-regexp: 4.0.0
       eslint-scope: 8.2.0
       eslint-visitor-keys: 4.2.0
@@ -4515,6 +4674,8 @@ snapshots:
       flatted: 3.3.2
       keyv: 4.5.4
 
+  flat@5.0.2: {}
+
   flatted@3.3.2: {}
 
   for-each@0.3.3:
@@ -4550,6 +4711,8 @@ snapshots:
 
   functions-have-names@1.2.3: {}
 
+  get-caller-file@2.0.5: {}
+
   get-intrinsic@1.2.6:
     dependencies:
       call-bind-apply-helpers: 1.0.1
@@ -4580,7 +4743,7 @@ snapshots:
     dependencies:
       basic-ftp: 5.0.5
       data-uri-to-buffer: 6.0.2
-      debug: 4.4.0
+      debug: 4.4.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -4674,6 +4837,8 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  he@1.2.0: {}
+
   header-case@1.0.1:
     dependencies:
       no-case: 2.3.2
@@ -4682,14 +4847,14 @@ snapshots:
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.0
+      debug: 4.4.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.0
+      debug: 4.4.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -4844,6 +5009,8 @@ snapshots:
   is-path-cwd@2.2.0: {}
 
   is-path-inside@3.0.3: {}
+
+  is-plain-obj@2.1.0: {}
 
   is-regex@1.2.1:
     dependencies:
@@ -5023,6 +5190,10 @@ snapshots:
     dependencies:
       brace-expansion: 1.1.11
 
+  minimatch@5.1.6:
+    dependencies:
+      brace-expansion: 2.0.1
+
   minimatch@9.0.5:
     dependencies:
       brace-expansion: 2.0.1
@@ -5034,6 +5205,29 @@ snapshots:
   mkdirp@0.5.6:
     dependencies:
       minimist: 1.2.8
+
+  mocha@11.0.1:
+    dependencies:
+      ansi-colors: 4.1.3
+      browser-stdout: 1.3.1
+      chokidar: 3.6.0
+      debug: 4.4.0(supports-color@8.1.1)
+      diff: 5.2.0
+      escape-string-regexp: 4.0.0
+      find-up: 5.0.0
+      glob: 10.4.5
+      he: 1.2.0
+      js-yaml: 4.1.0
+      log-symbols: 4.1.0
+      minimatch: 5.1.6
+      ms: 2.1.3
+      serialize-javascript: 6.0.2
+      strip-json-comments: 3.1.1
+      supports-color: 8.1.1
+      workerpool: 6.5.1
+      yargs: 16.2.0
+      yargs-parser: 20.2.9
+      yargs-unparser: 2.0.0
 
   ms@2.1.3: {}
 
@@ -5226,7 +5420,7 @@ snapshots:
     dependencies:
       '@tootallnate/quickjs-emscripten': 0.23.0
       agent-base: 7.1.3
-      debug: 4.4.0
+      debug: 4.4.0(supports-color@8.1.1)
       get-uri: 6.0.4
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
@@ -5359,7 +5553,7 @@ snapshots:
   proxy-agent@6.5.0:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.0
+      debug: 4.4.0(supports-color@8.1.1)
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
       lru-cache: 7.18.3
@@ -5374,6 +5568,10 @@ snapshots:
   punycode@2.3.1: {}
 
   queue-microtask@1.2.3: {}
+
+  randombytes@2.1.0:
+    dependencies:
+      safe-buffer: 5.2.1
 
   rc@1.2.8:
     dependencies:
@@ -5435,6 +5633,8 @@ snapshots:
   registry-url@3.1.0:
     dependencies:
       rc: 1.2.8
+
+  require-directory@2.1.1: {}
 
   resolve-from@4.0.0: {}
 
@@ -5505,6 +5705,10 @@ snapshots:
     dependencies:
       no-case: 2.3.2
       upper-case-first: 1.1.2
+
+  serialize-javascript@6.0.2:
+    dependencies:
+      randombytes: 2.1.0
 
   set-function-length@1.2.2:
     dependencies:
@@ -5603,7 +5807,7 @@ snapshots:
   socks-proxy-agent@8.0.5:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.0
+      debug: 4.4.0(supports-color@8.1.1)
       socks: 2.8.3
     transitivePeerDependencies:
       - supports-color
@@ -5719,6 +5923,10 @@ snapshots:
       has-flag: 3.0.0
 
   supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
+  supports-color@8.1.1:
     dependencies:
       has-flag: 4.0.0
 
@@ -5866,6 +6074,24 @@ snapshots:
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
       '@types/node': 22.10.2
+      acorn: 8.14.0
+      acorn-walk: 8.3.4
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.7.3
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+
+  ts-node@10.9.2(@types/node@22.10.7)(typescript@5.7.3):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.11
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 22.10.7
       acorn: 8.14.0
       acorn-walk: 8.3.4
       arg: 4.1.3
@@ -6088,6 +6314,8 @@ snapshots:
 
   wordwrap@1.0.0: {}
 
+  workerpool@6.5.1: {}
+
   wrap-ansi@6.2.0:
     dependencies:
       ansi-styles: 4.3.0
@@ -6113,7 +6341,28 @@ snapshots:
       bufferutil: 4.0.9
       utf-8-validate: 5.0.10
 
+  y18n@5.0.8: {}
+
   yaml@2.6.1: {}
+
+  yargs-parser@20.2.9: {}
+
+  yargs-unparser@2.0.0:
+    dependencies:
+      camelcase: 6.3.0
+      decamelize: 4.0.0
+      flat: 5.0.2
+      is-plain-obj: 2.1.0
+
+  yargs@16.2.0:
+    dependencies:
+      cliui: 7.0.4
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 20.2.9
 
   yn@3.1.1: {}
 


### PR DESCRIPTION
Depends on https://github.com/hokunet/contracts/pull/56

The changes here are mainly to make the `getAccount` and `getCreditBalance` methods to handle `approvalsTo` and `approvalsFrom`. The rest of the diff is from auto-formatting changes, and some dev deps to get the tests to work.