### PR TITLE
fix: better card layouts, fix wallet disconnect redirect

### DIFF
--- a/apps/studio/app/billing/_components/account.tsx
+++ b/apps/studio/app/billing/_components/account.tsx
@@ -228,7 +228,7 @@ export function Account() {
           </CardDescription>
         </CardHeader>
         <CardContent>
-          <div className="flex shrink-0 flex-wrap justify-around gap-8">
+          <div className="my-5 flex shrink-0 flex-wrap justify-around gap-8">
             <Metric
               title="Credit Available"
               value={
@@ -284,7 +284,7 @@ export function Account() {
           </CardDescription>
         </CardHeader>
         <CardContent>
-          <div className="flex shrink-0 flex-wrap justify-around gap-8">
+          <div className="my-8 flex shrink-0 flex-wrap justify-around gap-8">
             <Metric
               title="Balance"
               value={data ? recallToDisplay(data.value) : undefined}
@@ -304,7 +304,7 @@ export function Account() {
           </CardDescription>
         </CardHeader>
         <CardContent>
-          <div className="flex shrink-0 flex-wrap justify-around gap-8">
+          <div className="my-8 flex shrink-0 flex-wrap justify-around gap-8">
             <Metric
               title="Capacity Used"
               value={capacityUsedDisplayData?.val.toString()}

--- a/apps/studio/app/billing/_components/approval.tsx
+++ b/apps/studio/app/billing/_components/approval.tsx
@@ -156,33 +156,11 @@ export function Approval({ type, creditSponsor, approval }: Props) {
           <span title="Copy address" onClick={handleCopy}>
             <Copy className="size-4 cursor-pointer opacity-20 hover:opacity-100" />
           </span>
-        </CardTitle>
-      </CardHeader>
-      <CardContent className="">
-        <div className="flex items-center gap-8">
-          <div className="flex grow flex-col gap-4">
-            <div className="flex shrink-0 flex-wrap justify-around gap-8">
-              <Metric
-                title="Credits used"
-                value={`${creditUsedDisplay}/${creditLimitDisplay}`}
-                subtitle="GB Months"
-              />
-              <Metric
-                title="Gas used"
-                value={`${gasFeeUsedDisplay}/${gasFeeLimitDisplay}`}
-                subtitle="$RECALL"
-              />
-              <Metric
-                title={`Expire${blockDiff || 1 < 0 ? "d" : "s"}`}
-                value={ttlDisplay}
-                valueTooltip={expiryIso}
-              />
-            </div>
-          </div>
           {type === "to" && (
             <div
               title="Revoke approval"
               onClick={pending ? undefined : handleRevoke}
+              className="ml-auto"
             >
               {pending ? (
                 <Loader2 className="animate-spin" />
@@ -197,6 +175,7 @@ export function Approval({ type, creditSponsor, approval }: Props) {
               onClick={
                 isSponsor ? undefined : pending ? undefined : handleSetSponsor
               }
+              className="ml-auto"
             >
               {pending ? (
                 <Loader2 className="animate-spin" />
@@ -210,6 +189,27 @@ export function Approval({ type, creditSponsor, approval }: Props) {
               )}
             </div>
           )}
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="">
+        <div className="flex grow flex-col gap-4">
+          <div className="my-4 flex shrink-0 flex-wrap justify-around gap-8">
+            <Metric
+              title="Credits used"
+              value={`${creditUsedDisplay}/${creditLimitDisplay}`}
+              subtitle="GB Months"
+            />
+            <Metric
+              title="Gas used"
+              value={`${gasFeeUsedDisplay}/${gasFeeLimitDisplay}`}
+              subtitle="$RECALL"
+            />
+            <Metric
+              title={`Expire${blockDiff || 1 < 0 ? "d" : "s"}`}
+              value={ttlDisplay}
+              valueTooltip={expiryIso}
+            />
+          </div>
         </div>
       </CardContent>
     </Card>

--- a/apps/studio/app/billing/_components/billing-tabs.tsx
+++ b/apps/studio/app/billing/_components/billing-tabs.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { useAccount } from "wagmi";
 
 import { ScrollArea, ScrollBar } from "@recall/ui/components/scroll-area";
@@ -12,40 +12,31 @@ import {
   TabsTrigger,
 } from "@recall/ui/components/tabs";
 
+import { useHashmark } from "@/hooks/useHashmark";
+import { usePrevious } from "@/hooks/usePrevious";
+
 import { Account } from "./account";
 import { ApprovalsFrom } from "./approvals-from";
 import { ApprovalsTo } from "./approvals-to";
 
-const useHash = () => {
-  const [hash, setHash] = useState("");
-  useEffect(() => {
-    setHash(window.location.hash);
-    const onHashChange = () => {
-      setHash(window.location.hash);
-    };
-    window.addEventListener("hashchange", onHashChange);
-    return () => window.removeEventListener("hashchange", onHashChange);
-  }, []);
-  return hash;
-};
-
 export function BillingTabs() {
   const { isConnected } = useAccount();
+  const { prev: prevConnected, current: connected } = usePrevious(isConnected);
 
   const router = useRouter();
 
-  const hash = useHash();
-
-  useEffect(() => {
-    if (!isConnected) {
-      router.push("/");
-    }
-  }, [isConnected, router]);
+  const hash = useHashmark();
 
   const handleTabChange = (value: string) => {
     window.location.hash = value;
     router.push(`/billing#${value}`);
   };
+
+  useEffect(() => {
+    if (prevConnected && !connected) {
+      router.push("/");
+    }
+  }, [prevConnected, connected, router]);
 
   return (
     <Tabs value={hash.slice(1) || "account"} onValueChange={handleTabChange}>

--- a/apps/studio/app/billing/_components/metric.tsx
+++ b/apps/studio/app/billing/_components/metric.tsx
@@ -13,7 +13,7 @@ export default function Metric({
     <div className="flex flex-col items-center">
       {title && <span className="text-muted-foreground text-xs">{title}</span>}
       {value && (
-        <span title={valueTooltip} className="text-xl font-medium">
+        <span title={valueTooltip} className="text-2xl font-medium">
           {value}
         </span>
       )}

--- a/apps/studio/hooks/useHashmark.ts
+++ b/apps/studio/hooks/useHashmark.ts
@@ -1,0 +1,14 @@
+import { useEffect, useState } from "react";
+
+export function useHashmark() {
+  const [hash, setHash] = useState("");
+  useEffect(() => {
+    setHash(window.location.hash);
+    const onHashChange = () => {
+      setHash(window.location.hash);
+    };
+    window.addEventListener("hashchange", onHashChange);
+    return () => window.removeEventListener("hashchange", onHashChange);
+  }, []);
+  return hash;
+}

--- a/apps/studio/hooks/usePrevious.ts
+++ b/apps/studio/hooks/usePrevious.ts
@@ -1,0 +1,10 @@
+import { useEffect, useRef } from "react";
+
+export function usePrevious<T>(value: T) {
+  const prevValueRef = useRef(value);
+  useEffect(() => {
+    prevValueRef.current = value;
+  }, [value]);
+
+  return { prev: prevValueRef.current, current: value };
+}


### PR DESCRIPTION
The layout of the cards in the billing section was bothering me, so fixed that. On some pages that only make sense if your wallet is connected, we want to redirect to the home page if you disconnect your wallet. This logic was broken for the billing page, so I fixed that.