### PR TITLE
chore: release workflow changes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,53 @@
+# Publishes packages to npm *directly after* merging a version PR via `version.yml`
+name: Publish
+
+on:
+  push:
+    paths:
+      - "**/CHANGELOG.md" # Only run when changelog is updated
+    branches:
+      - main
+
+env:
+  NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID: fe319abf1a1b0d76b39894e5e17aff0c
+  NEXT_PUBLIC_CHAIN_NAME: testnet
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 9
+
+      - name: Install Dependencies
+        run: pnpm install
+
+      - name: Build
+        run: pnpm build
+
+      # See the automated release feature for more details: https://github.com/changesets/action#with-publishing
+      - name: Publish to npm
+        id: changesets
+        uses: changesets/action@v1
+        with:
+          publish: pnpm publish-packages
+          commit: "chore: publish packages"
+          title: "chore: publish packages"
+          setupGitUser: true
+          createGithubReleases: ${{ github.ref == 'refs/heads/main' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,12 +4,12 @@ on:
   push:
     paths:
       - ".changeset/**"
-      - "packages/**"
     branches:
       - main
 
 env:
   NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID: fe319abf1a1b0d76b39894e5e17aff0c
+  NEXT_PUBLIC_CHAIN_NAME: testnet
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
@@ -37,13 +37,7 @@ jobs:
       - name: Build
         run: pnpm build
 
-      - name: Create Release Pull Request or Publish to npm
-        id: changesets
+      - name: Create Release Pull Request
         uses: changesets/action@v1
-        with:
-          publish: pnpm publish-packages
-          commit: "ci(changesets): version packages"
-          setupGitUser: false
         env:
-          # NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -1,4 +1,5 @@
-name: Release
+# Creates version PR upon changeset updates merging into main
+name: Version
 
 on:
   push:
@@ -14,8 +15,8 @@ env:
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
-  release:
-    name: Release
+  version:
+    name: Version
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
@@ -39,5 +40,10 @@ jobs:
 
       - name: Create Release Pull Request
         uses: changesets/action@v1
+        with:
+          version: pnpm version
+          commit: "chore: version packages"
+          title: "chore: version packages"
+          setupGitUser: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
     "format:check": "prettier --check \"**/*.{ts,tsx,md}\"",
     "clean": "turbo clean && rm -rf node_modules",
-    "publish-packages": "turbo run build lint && changeset version && changeset publish"
+    "changeset": "changeset",
+    "version": "changeset version",
+    "publish-packages": "changeset publish"
   },
   "devDependencies": {
     "@changesets/changelog-github": "^0.5.0",


### PR DESCRIPTION
- We use `version.yml` to auto-create version PRs whenever the `.changesets` directory is updated upon merging to main.
   - This only happens if you stage a new release via the `pnpm changeset` command locally, which will create markdown file(s) in `.changesets` that describe the semver change and relevant packages.
   - When you merge these `.changesets` markdown files to main, a PR is opened, which deletes these changeset files, creates/updates the `CHANGELOG.md` files with their contents, and updates each package's `package.json` file's semver accordingly.
   - If an existing version PR is open, and you merge more staged changesets into main, it'll automatically keep updating the PR.
   - An example of what this looks like is https://github.com/recallnet/js-recall/pull/57. 
- Upon merging the PR from `version.yml`, the `publish.yml` workflow _should_ auto-trigger since it only runs when changes to `CHANGELOG.md` occur.
   - This will publish directly to npm. It [assumes the previous commit](https://github.com/changesets/changesets/blob/main/packages/cli/README.md#publish) is the output from `changeset version`.
   - I'm assuming this should work—the PR linked below only tested out the versioning step, and the only way to really test the publishing is to "do it in prod"
- Optionally, we can [add this bot](https://github.com/apps/changeset-bot) to comment on PRs to remind you to run the `pnpm changeset` command. This is _probably_ useful, but also might get annoying.

See [this PR](https://github.com/recallnet/js-recall/pull/56#issuecomment-2664495538) for details on how some of this works in practice, and the [changeset docs](https://github.com/changesets/changesets/blob/main/docs/automating-changesets.md#how-do-i-run-the-version-and-publish-commands) have more information. There are probably more optimal ways to do this, too, so i'm open to ideas. Alternatively, we could handle all of this manually/locally.