### PR TITLE
fix: match pnpm veresion 9.12.3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 9
+          version: 9.12.3 # Note: matches exact version from root `package.json`
 
       - name: Install Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
fixes error from CI—the `package.json` explicity uses pnpm `9.12.3`, but the release flow was using `9`:
```
Error: Multiple versions of pnpm specified:
    - version 9 in the GitHub Action config with the key "version"
    - version pnpm@9.12.3 in the package.json with the key "packageManager"
  Remove one of these versions to avoid version mismatch errors like ERR_PNPM_BAD_PM_VERSION
      at readTarget (/home/runner/work/_actions/pnpm/action-setup/v4/dist/index.js:1:4742)
      at runSelfInstaller (/home/runner/work/_actions/pnpm/action-setup/v4/dist/index.js:1:3930)
      at async install (/home/runner/work/_actions/pnpm/action-setup/v4/dist/index.js:1:3[15](https://github.com/recallnet/js-recall/actions/runs/13439717454/job/37550797438#step:3:16)4)
      at async main (/home/runner/work/_actions/pnpm/action-setup/v4/dist/index.js:1:445)
  Error: Error: Multiple versions of pnpm specified:
    - version 9 in the GitHub Action config with the key "version"
    - version pnpm@9.12.3 in the package.json with the key "packageManager"
  Remove one of these versions to avoid version mismatch errors like ERR_PNPM_BAD_PM_VERSION
```
(not sure why this is a problem only for the release flow since the other GH workflow specifies pnpm `9` too)