### PR TITLE
chore: remove sdx from changeset

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -10,5 +10,5 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["studio", "@recallnet/ui"]
+  "ignore": ["studio", "@recallnet/ui", "@recallnet/sdkx"]
 }


### PR DESCRIPTION
force `@recallnet/sdx` to _not_ be included in the changeset. it seems the `updateInternalDependencies` will (for some reason) also bump packages, even if they're not explicitly included in the changeset release.