### PR TITLE
fix: `sdk` exports

### DIFF
--- a/.changeset/eleven-moose-tease.md
+++ b/.changeset/eleven-moose-tease.md
@@ -1,0 +1,5 @@
+---
+"@recallnet/sdk": patch
+---
+
+fixes invalid export path for 'entities' groups

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -15,19 +15,19 @@
   "type": "module",
   "exports": {
     "./account": {
-      "types": "./dist/entities/account.d.ts",
-      "import": "./dist/entities/account.mjs",
-      "require": "./dist/entities/account.cjs"
+      "types": "./dist/account.d.ts",
+      "import": "./dist/account.mjs",
+      "require": "./dist/account.cjs"
     },
     "./blob": {
-      "types": "./dist/entities/blob.d.ts",
-      "import": "./dist/entities/blob.mjs",
-      "require": "./dist/entities/blob.cjs"
+      "types": "./dist/blob.d.ts",
+      "import": "./dist/blob.mjs",
+      "require": "./dist/blob.cjs"
     },
     "./bucket": {
-      "types": "./dist/entities/bucket.d.ts",
-      "import": "./dist/entities/bucket.mjs",
-      "require": "./dist/entities/bucket.cjs"
+      "types": "./dist/bucket.d.ts",
+      "import": "./dist/bucket.mjs",
+      "require": "./dist/bucket.cjs"
     },
     "./client": {
       "types": "./dist/client.d.ts",
@@ -35,9 +35,9 @@
       "require": "./dist/client.cjs"
     },
     "./credit": {
-      "types": "./dist/entities/credit.d.ts",
-      "import": "./dist/entities/credit.mjs",
-      "require": "./dist/entities/credit.cjs"
+      "types": "./dist/credit.d.ts",
+      "import": "./dist/credit.mjs",
+      "require": "./dist/credit.cjs"
     },
     "./ipc": {
       "types": "./dist/ipc.d.ts",

--- a/packages/sdk/src/network.ts
+++ b/packages/sdk/src/network.ts
@@ -93,12 +93,12 @@ export function networkTypeToChain(networkType: NetworkType): Chain {
 
 // Converts a chain to a network type
 export function chainToNetworkType(chain: Chain): NetworkType {
-  switch (chain) {
-    case testnet:
+  switch (chain.id) {
+    case testnet.id:
       return NetworkType.Testnet;
-    case localnet:
+    case localnet.id:
       return NetworkType.Localnet;
-    case devnet:
+    case devnet.id:
       return NetworkType.Devnet;
     default:
       throw new Error("invalid chain");

--- a/packages/sdk/test/client.test.ts
+++ b/packages/sdk/test/client.test.ts
@@ -18,12 +18,19 @@ describe("client", function () {
   });
 
   it("should get client from wallet", () => {
-    const walletClient = walletClientFromPrivateKey(
+    let walletClient = walletClientFromPrivateKey(
       "0x7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6",
       localnet,
     );
-    const client = new RecallClient({ walletClient });
+    let client = new RecallClient({ walletClient });
     strictEqual(client.publicClient.chain.id, localnet.id);
+
+    walletClient = walletClientFromPrivateKey(
+      "0x7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6",
+      testnet,
+    );
+    client = new RecallClient({ walletClient });
+    strictEqual(client.publicClient.chain.id, testnet.id);
   });
 
   it("should get client from public client", () => {

--- a/packages/sdk/test/contracts.test.ts
+++ b/packages/sdk/test/contracts.test.ts
@@ -633,25 +633,22 @@ describe("contracts", function () {
 
     it("should deposit into subnet", async () => {
       const amount = parseEther("1");
-      const { meta, result } = await accountManager.deposit(amount);
+      const { meta } = await accountManager.deposit(amount);
       strictEqual(isHash(meta!.tx!.transactionHash), true);
-      strictEqual(result, true);
     });
 
     it("should withdraw from subnet", async () => {
       const amount = parseEther("1");
-      const { meta, result } = await accountManager.withdraw(amount);
+      const { meta } = await accountManager.withdraw(amount);
       strictEqual(isHash(meta!.tx!.transactionHash), true);
-      strictEqual(result, true);
     });
 
     it("should transfer within subnet", async () => {
       const amount = parseEther("1");
       const to = getAddress("0x9965507d1a55bcc2695c58ba16fb37d819b0a4dc");
       const { result: toBalanceBefore } = await accountManager.balance(to);
-      const { meta, result } = await accountManager.transfer(to, amount);
+      const { meta } = await accountManager.transfer(to, amount);
       strictEqual(isHash(meta!.tx!.transactionHash), true);
-      strictEqual(result, true);
       const { result: toBalanceAfter } = await accountManager.balance(to);
       strictEqual(toBalanceBefore + amount, toBalanceAfter);
     });

--- a/packages/sdk/test/network.test.ts
+++ b/packages/sdk/test/network.test.ts
@@ -1,6 +1,7 @@
 import { expect } from "chai";
 import { describe, it } from "mocha";
 import { strictEqual } from "node:assert";
+import { defineChain } from "viem";
 
 import {
   gatewayManagerFacetAddress,
@@ -8,6 +9,7 @@ import {
   subnetGetterFacetAddress,
 } from "@recallnet/contracts";
 import {
+  DEVNET_CHAIN_ID,
   LOCALNET_CHAIN_ID,
   LOCALNET_EVM_RPC_URL,
   LOCALNET_OBJECT_API_URL,
@@ -16,9 +18,10 @@ import {
   LOCALNET_RPC_URL,
   LOCALNET_SUBNET_ID,
   RPC_TIMEOUT,
+  TESTNET_CHAIN_ID,
 } from "@recallnet/network-constants";
 
-import { Network, NetworkType } from "../src/network.js";
+import { Network, NetworkType, chainToNetworkType } from "../src/network.js";
 
 describe("network", function () {
   let network: Network;
@@ -93,5 +96,52 @@ describe("network", function () {
       config.supplySource,
       recallErc20Address[LOCALNET_PARENT_CHAIN_ID],
     );
+  });
+
+  it("should convert user-defined chains to network type", () => {
+    const chain1 = defineChain({
+      id: LOCALNET_CHAIN_ID,
+      name: "localnet",
+      nativeCurrency: {
+        name: "localnet",
+        symbol: "localnet",
+        decimals: 18,
+      },
+      rpcUrls: {
+        default: { http: ["https://rpc.recall.network"] },
+      },
+    });
+    let net = chainToNetworkType(chain1);
+    strictEqual(net, NetworkType.Localnet);
+
+    const chain2 = defineChain({
+      id: TESTNET_CHAIN_ID,
+      name: "testnet",
+      nativeCurrency: {
+        name: "testnet",
+        symbol: "testnet",
+        decimals: 18,
+      },
+      rpcUrls: {
+        default: { http: ["https://rpc.recall.network"] },
+      },
+    });
+    net = chainToNetworkType(chain2);
+    strictEqual(net, NetworkType.Testnet);
+
+    const chain3 = defineChain({
+      id: DEVNET_CHAIN_ID,
+      name: "devnet",
+      nativeCurrency: {
+        name: "devnet",
+        symbol: "devnet",
+        decimals: 18,
+      },
+      rpcUrls: {
+        default: { http: ["https://rpc.recall.network"] },
+      },
+    });
+    net = chainToNetworkType(chain3);
+    strictEqual(net, NetworkType.Devnet);
   });
 });


### PR DESCRIPTION
the `dist` folder outputs a flat map, which changed recently (used to be nested `entities` folder). this didnt trigger testing errors locally due to legacy `dist` deps, and we dont have a testing CI flow, so it was never caught.