### PR TITLE
Buckets improvements + DX improvements

### DIFF
--- a/apps/portal/app/buckets/_components/add-object-dialog.tsx
+++ b/apps/portal/app/buckets/_components/add-object-dialog.tsx
@@ -116,16 +116,16 @@ export default function AddObjectDialog({
   const { addFile, isPending, isSuccess, error } = useAddFile();
 
   function onSubmit(values: z.infer<typeof formSchema>) {
-    console.log(values);
-    if (fromAddress === undefined || typeof values.metadata === "string")
-      return;
+    if (fromAddress === undefined) return;
+    const metadata =
+      typeof values.metadata === "string" ? undefined : values.metadata;
     addFile({
       bucket: bucketAddress,
       from: fromAddress,
       key: values.key,
       file: values.file,
       options: {
-        metadata: values.metadata,
+        metadata,
         overwrite: values.overwrite,
         ttl: BigInt(values.ttl),
         onUploadProgress: (progress) => {

--- a/apps/portal/app/buckets/_components/bucket.tsx
+++ b/apps/portal/app/buckets/_components/bucket.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Loader2 } from "lucide-react";
+import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { Fragment, useEffect, useState } from "react";
 import { Address } from "viem";
@@ -86,13 +87,17 @@ export default function Bucket({
         <Breadcrumb>
           <BreadcrumbList>
             <BreadcrumbItem>
-              <BreadcrumbLink href={`/buckets`}>Buckets</BreadcrumbLink>
+              <BreadcrumbLink asChild>
+                <Link href="/buckets">Buckets</Link>
+              </BreadcrumbLink>
             </BreadcrumbItem>
             <BreadcrumbSeparator />
             <BreadcrumbItem>
               {prefixParts.length ? (
-                <BreadcrumbLink href={`/buckets/${bucketAddress}`}>
-                  {displayAddress(bucketAddress)}
+                <BreadcrumbLink asChild>
+                  <Link href={`/buckets/${bucketAddress}`}>
+                    {displayAddress(bucketAddress)}
+                  </Link>
                 </BreadcrumbLink>
               ) : (
                 displayAddress(bucketAddress)
@@ -105,10 +110,12 @@ export default function Bucket({
                   {index === prefixParts.length - 1 ? (
                     part
                   ) : (
-                    <BreadcrumbLink
-                      href={`/buckets/${bucketAddress}/${prefixParts.slice(0, index + 1).join("/")}`}
-                    >
-                      {part}
+                    <BreadcrumbLink asChild>
+                      <Link
+                        href={`/buckets/${bucketAddress}/${prefixParts.slice(0, index + 1).join("/")}`}
+                      >
+                        {part}
+                      </Link>
                     </BreadcrumbLink>
                   )}
                 </BreadcrumbItem>

--- a/apps/portal/app/buckets/_components/buckets.tsx
+++ b/apps/portal/app/buckets/_components/buckets.tsx
@@ -70,7 +70,6 @@ export default function Buckets() {
     }
   }, [createBucketError, createBucketTxnError, listBucketsError, toast]);
 
-  const listPending = listBucketsPending;
   const createPending = createBucketPending || createBucketTxnLoading;
 
   const handleCreateBucket = () => {
@@ -111,7 +110,7 @@ export default function Buckets() {
             values.
           </span>
           <DialogFooter>
-            <Button onClick={handleCreateBucket}>
+            <Button onClick={handleCreateBucket} disabled={createPending}>
               Submit {createPending && <Loader2 className="animate-spin" />}
             </Button>
           </DialogFooter>
@@ -127,12 +126,12 @@ export default function Buckets() {
       {buckets?.map((bucket) => (
         <BucketCard key={bucket.addr} bucket={bucket} />
       ))}
-      {listPending && (
+      {listBucketsPending && (
         <div className="flex flex-1 items-center justify-center">
           <Loader2 className="animate-spin" />
         </div>
       )}
-      {!listPending && !buckets && (
+      {!listBucketsPending && !buckets?.length && (
         <div className="text-muted-foreground flex flex-1 items-center justify-center">
           No buckets to display.
         </div>

--- a/apps/portal/lib/convert-matadata.ts
+++ b/apps/portal/lib/convert-matadata.ts
@@ -18,6 +18,7 @@ export function arrayToRecord(
 }
 
 export function dislpayToRecord(metadata: string) {
+  if (!metadata) return undefined;
   return JSON.parse(metadata) as Record<string, string>;
 }
 

--- a/packages/address-utils/package.json
+++ b/packages/address-utils/package.json
@@ -7,7 +7,7 @@
   "exports": {
     "./display": {
       "types": "./dist/display.d.ts",
-      "import": "./dist/display.mjs",
+      "import": "./dist/display.js",
       "require": "./dist/display.cjs"
     }
   },
@@ -15,7 +15,7 @@
     "dist"
   ],
   "scripts": {
-    "dev": "tsup --watch",
+    "dev": "tsc --watch",
     "build": "tsup",
     "lint": "eslint . --max-warnings 0",
     "clean": "rm -rf .turbo node_modules dist"

--- a/packages/address-utils/tsup.config.ts
+++ b/packages/address-utils/tsup.config.ts
@@ -6,6 +6,6 @@ export default defineConfig({
   dts: true,
   clean: true,
   outExtension: ({ format }) => ({
-    js: format === "esm" ? ".mjs" : ".cjs",
+    js: format === "esm" ? ".js" : ".cjs",
   }),
 });

--- a/packages/bigint-utils/package.json
+++ b/packages/bigint-utils/package.json
@@ -7,17 +7,17 @@
   "exports": {
     "./constants": {
       "types": "./dist/constants.d.ts",
-      "import": "./dist/constants.mjs",
+      "import": "./dist/constants.js",
       "require": "./dist/constants.cjs"
     },
     "./conversions": {
       "types": "./dist/conversions.d.ts",
-      "import": "./dist/conversions.mjs",
+      "import": "./dist/conversions.js",
       "require": "./dist/conversions.cjs"
     },
     "./format-atto-rcl": {
       "types": "./dist/format-atto-rcl.d.ts",
-      "import": "./dist/format-atto-rcl.mjs",
+      "import": "./dist/format-atto-rcl.js",
       "require": "./dist/format-atto-rcl.cjs"
     }
   },
@@ -25,7 +25,7 @@
     "dist"
   ],
   "scripts": {
-    "dev": "tsup --watch",
+    "dev": "tsc --watch",
     "build": "tsup",
     "lint": "eslint . --max-warnings 0",
     "clean": "rm -rf .turbo node_modules dist"

--- a/packages/bigint-utils/tsup.config.ts
+++ b/packages/bigint-utils/tsup.config.ts
@@ -6,6 +6,6 @@ export default defineConfig({
   dts: true,
   clean: true,
   outExtension: ({ format }) => ({
-    js: format === "esm" ? ".mjs" : ".cjs",
+    js: format === "esm" ? ".js" : ".cjs",
   }),
 });

--- a/packages/chains/package.json
+++ b/packages/chains/package.json
@@ -16,7 +16,7 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
+      "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     }
   },
@@ -24,7 +24,7 @@
     "dist"
   ],
   "scripts": {
-    "dev": "tsup --watch",
+    "dev": "tsc --watch",
     "build": "tsup",
     "clean": "rm -rf .turbo node_modules dist"
   },

--- a/packages/chains/tsup.config.ts
+++ b/packages/chains/tsup.config.ts
@@ -6,6 +6,6 @@ export default defineConfig({
   dts: true,
   clean: true,
   outExtension: ({ format }) => ({
-    js: format === "esm" ? ".mjs" : ".cjs",
+    js: format === "esm" ? ".js" : ".cjs",
   }),
 });

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -9,7 +9,7 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
+      "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     }
   },
@@ -17,7 +17,7 @@
     "dist"
   ],
   "scripts": {
-    "dev": "tsup --watch",
+    "dev": "tsc --watch",
     "generate": "wagmi generate && tsc",
     "build": "tsup",
     "lint": "eslint . --max-warnings 0",

--- a/packages/contracts/tsup.config.ts
+++ b/packages/contracts/tsup.config.ts
@@ -6,6 +6,6 @@ export default defineConfig({
   dts: true,
   clean: true,
   outExtension: ({ format }) => ({
-    js: format === "esm" ? ".mjs" : ".cjs",
+    js: format === "esm" ? ".js" : ".cjs",
   }),
 });

--- a/packages/fvm/package.json
+++ b/packages/fvm/package.json
@@ -16,17 +16,17 @@
   "exports": {
     "./address": {
       "types": "./dist/address.d.ts",
-      "import": "./dist/address.mjs",
+      "import": "./dist/address.js",
       "require": "./dist/address.cjs"
     },
     "./artifacts": {
       "types": "./dist/artifacts.d.ts",
-      "import": "./dist/artifacts.mjs",
+      "import": "./dist/artifacts.js",
       "require": "./dist/artifacts.cjs"
     },
     "./utils": {
       "types": "./dist/utils.d.ts",
-      "import": "./dist/utils.mjs",
+      "import": "./dist/utils.js",
       "require": "./dist/utils.cjs"
     }
   },
@@ -34,7 +34,7 @@
     "dist"
   ],
   "scripts": {
-    "dev": "tsup --watch",
+    "dev": "tsc --watch",
     "build": "tsup",
     "test": "pnpm test:mocha",
     "test:mocha": "mocha --exit",

--- a/packages/fvm/tsup.config.ts
+++ b/packages/fvm/tsup.config.ts
@@ -10,6 +10,6 @@ export default defineConfig({
   dts: true,
   clean: true,
   outExtension: ({ format }) => ({
-    js: format === "esm" ? ".mjs" : ".cjs",
+    js: format === "esm" ? ".js" : ".cjs",
   }),
 });

--- a/packages/network-constants/package.json
+++ b/packages/network-constants/package.json
@@ -16,7 +16,7 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
+      "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     }
   },
@@ -24,7 +24,7 @@
     "dist"
   ],
   "scripts": {
-    "dev": "tsup --watch",
+    "dev": "tsc --watch",
     "build": "tsup",
     "clean": "rm -rf .turbo node_modules dist"
   },

--- a/packages/network-constants/tsup.config.ts
+++ b/packages/network-constants/tsup.config.ts
@@ -6,6 +6,6 @@ export default defineConfig({
   dts: true,
   clean: true,
   outExtension: ({ format }) => ({
-    js: format === "esm" ? ".mjs" : ".cjs",
+    js: format === "esm" ? ".js" : ".cjs",
   }),
 });

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -16,52 +16,52 @@
   "exports": {
     "./account": {
       "types": "./dist/account.d.ts",
-      "import": "./dist/account.mjs",
+      "import": "./dist/account.js",
       "require": "./dist/account.cjs"
     },
     "./blob": {
       "types": "./dist/blob.d.ts",
-      "import": "./dist/blob.mjs",
+      "import": "./dist/blob.js",
       "require": "./dist/blob.cjs"
     },
     "./bucket": {
       "types": "./dist/bucket.d.ts",
-      "import": "./dist/bucket.mjs",
+      "import": "./dist/bucket.js",
       "require": "./dist/bucket.cjs"
     },
     "./client": {
       "types": "./dist/client.d.ts",
-      "import": "./dist/client.mjs",
+      "import": "./dist/client.js",
       "require": "./dist/client.cjs"
     },
     "./credit": {
       "types": "./dist/credit.d.ts",
-      "import": "./dist/credit.mjs",
+      "import": "./dist/credit.js",
       "require": "./dist/credit.cjs"
     },
     "./errors": {
       "types": "./dist/errors.d.ts",
-      "import": "./dist/errors.mjs",
+      "import": "./dist/errors.js",
       "require": "./dist/errors.cjs"
     },
     "./ipc": {
       "types": "./dist/ipc.d.ts",
-      "import": "./dist/ipc.mjs",
+      "import": "./dist/ipc.js",
       "require": "./dist/ipc.cjs"
     },
     "./network": {
       "types": "./dist/network.d.ts",
-      "import": "./dist/network.mjs",
+      "import": "./dist/network.js",
       "require": "./dist/network.cjs"
     },
     "./provider": {
       "types": "./dist/provider.d.ts",
-      "import": "./dist/provider.mjs",
+      "import": "./dist/provider.js",
       "require": "./dist/provider.cjs"
     },
     "./utils": {
       "types": "./dist/utils.d.ts",
-      "import": "./dist/utils.mjs",
+      "import": "./dist/utils.js",
       "require": "./dist/utils.cjs"
     }
   },
@@ -69,7 +69,7 @@
     "dist"
   ],
   "scripts": {
-    "dev": "tsup --watch",
+    "dev": "tsc --watch",
     "build": "tsup",
     "test": "pnpm test:mocha",
     "test:mocha": "mocha --exit",

--- a/packages/sdk/tsup.config.ts
+++ b/packages/sdk/tsup.config.ts
@@ -16,6 +16,6 @@ export default defineConfig({
   dts: true,
   clean: true,
   outExtension: ({ format }) => ({
-    js: format === "esm" ? ".mjs" : ".cjs",
+    js: format === "esm" ? ".js" : ".cjs",
   }),
 });

--- a/packages/sdkx/package.json
+++ b/packages/sdkx/package.json
@@ -7,17 +7,17 @@
   "exports": {
     "./react/buckets": {
       "types": "./dist/react/buckets.d.ts",
-      "import": "./dist/react/buckets.mjs",
-      "require": "./dist/react/buckets.cjs"
+      "import": "./dist/react/buckets.js",
+      "require": "./dist/react/buckets.js"
     },
     "./react/credits": {
       "types": "./dist/react/credits.d.ts",
-      "import": "./dist/react/credits.mjs",
+      "import": "./dist/react/credits.js",
       "require": "./dist/react/credits.cjs"
     },
     "./actions/credits": {
       "types": "./dist/actions/credits.d.ts",
-      "import": "./dist/actions/credits.mjs",
+      "import": "./dist/actions/credits.js",
       "require": "./dist/actions/credits.cjs"
     }
   },
@@ -25,7 +25,7 @@
     "dist"
   ],
   "scripts": {
-    "dev": "tsup --watch",
+    "dev": "tsc --watch",
     "build": "tsup",
     "lint": "eslint . --max-warnings 0",
     "clean": "rm -rf .turbo node_modules dist"

--- a/packages/sdkx/tsup.config.ts
+++ b/packages/sdkx/tsup.config.ts
@@ -10,6 +10,6 @@ export default defineConfig({
   dts: true,
   clean: true,
   outExtension: ({ format }) => ({
-    js: format === "esm" ? ".mjs" : ".cjs",
+    js: format === "esm" ? ".js" : ".cjs",
   }),
 });


### PR DESCRIPTION
- Use NextJS `Link` component in breadcrumb so we get partial page loads on breadcrumb navigation (vs reloading entire page)
- Better pending state when creating a bucket, properly detect no buckets to display
- Allow bucket metadata to be undefined
- Allow object metadata to be undefined
- Use `tsc` in dev mode for better IDE support of click to navigate to source. 
- Use `.js` for esm build file extensions to be consistent with above bullet when in dev mode. 