### PR TITLE
Correct use of package.json exports and tsc/tsup output

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,0 +1,18 @@
+// Folder-specific settings
+//
+// For a full list of overridable settings, and general information on folder-specific settings,
+// see the documentation: https://zed.dev/docs/configuring-zed#settings-files
+{
+  "languages": {
+    "JavaScript": {
+      "code_actions_on_format": {
+        "source.fixAll.eslint": true
+      }
+    },
+    "TypeScript": {
+      "code_actions_on_format": {
+        "source.fixAll.eslint": true
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "license": "MIT AND Apache-2.0",
   "scripts": {
     "build": "turbo build",
-    "dev": "turbo dev  --concurrency=20",
+    "dev": "turbo dev --concurrency=20",
     "lint": "turbo lint",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
     "format:check": "prettier --check \"**/*.{ts,tsx,md}\"",

--- a/packages/address-utils/package.json
+++ b/packages/address-utils/package.json
@@ -6,9 +6,14 @@
   "type": "module",
   "exports": {
     "./display": {
-      "types": "./dist/display.d.ts",
-      "import": "./dist/display.js",
-      "require": "./dist/display.cjs"
+      "import": {
+        "types": "./dist/display.d.ts",
+        "default": "./dist/display.js"
+      },
+      "require": {
+        "types": "./dist/display.d.cts",
+        "default": "./dist/display.cjs"
+      }
     }
   },
   "files": [

--- a/packages/bigint-utils/package.json
+++ b/packages/bigint-utils/package.json
@@ -6,19 +6,34 @@
   "type": "module",
   "exports": {
     "./constants": {
-      "types": "./dist/constants.d.ts",
-      "import": "./dist/constants.js",
-      "require": "./dist/constants.cjs"
+      "import": {
+        "types": "./dist/constants.d.ts",
+        "default": "./dist/constants.js"
+      },
+      "require": {
+        "types": "./dist/constants.d.cts",
+        "default": "./dist/constants.cjs"
+      }
     },
     "./conversions": {
-      "types": "./dist/conversions.d.ts",
-      "import": "./dist/conversions.js",
-      "require": "./dist/conversions.cjs"
+      "import": {
+        "types": "./dist/conversions.d.ts",
+        "default": "./dist/conversions.js"
+      },
+      "require": {
+        "types": "./dist/conversions.d.cts",
+        "default": "./dist/conversions.cjs"
+      }
     },
     "./format-atto-rcl": {
-      "types": "./dist/format-atto-rcl.d.ts",
-      "import": "./dist/format-atto-rcl.js",
-      "require": "./dist/format-atto-rcl.cjs"
+      "import": {
+        "types": "./dist/format-atto-rcl.d.ts",
+        "default": "./dist/format-atto-rcl.js"
+      },
+      "require": {
+        "types": "./dist/format-atto-rcl.d.cts",
+        "default": "./dist/format-atto-rcl.cjs"
+      }
     }
   },
   "files": [

--- a/packages/chains/package.json
+++ b/packages/chains/package.json
@@ -15,9 +15,14 @@
   "type": "module",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
     }
   },
   "files": [

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -8,9 +8,14 @@
   "type": "module",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
     }
   },
   "files": [

--- a/packages/fvm/package.json
+++ b/packages/fvm/package.json
@@ -15,19 +15,34 @@
   "type": "module",
   "exports": {
     "./address": {
-      "types": "./dist/address.d.ts",
-      "import": "./dist/address.js",
-      "require": "./dist/address.cjs"
+      "import": {
+        "types": "./dist/address.d.ts",
+        "default": "./dist/address.js"
+      },
+      "require": {
+        "types": "./dist/address.d.cts",
+        "default": "./dist/address.cjs"
+      }
     },
     "./artifacts": {
-      "types": "./dist/artifacts.d.ts",
-      "import": "./dist/artifacts.js",
-      "require": "./dist/artifacts.cjs"
+      "import": {
+        "types": "./dist/artifacts.d.ts",
+        "default": "./dist/artifacts.js"
+      },
+      "require": {
+        "types": "./dist/artifacts.d.cts",
+        "default": "./dist/artifacts.cjs"
+      }
     },
     "./utils": {
-      "types": "./dist/utils.d.ts",
-      "import": "./dist/utils.js",
-      "require": "./dist/utils.cjs"
+      "import": {
+        "types": "./dist/utils.d.ts",
+        "default": "./dist/utils.js"
+      },
+      "require": {
+        "types": "./dist/utils.d.cts",
+        "default": "./dist/utils.cjs"
+      }
     }
   },
   "files": [

--- a/packages/network-constants/package.json
+++ b/packages/network-constants/package.json
@@ -15,9 +15,14 @@
   "type": "module",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
     }
   },
   "files": [

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -15,54 +15,94 @@
   "type": "module",
   "exports": {
     "./account": {
-      "types": "./dist/account.d.ts",
-      "import": "./dist/account.js",
-      "require": "./dist/account.cjs"
+      "import": {
+        "types": "./dist/account.d.ts",
+        "default": "./dist/account.js"
+      },
+      "require": {
+        "types": "./dist/account.d.cts",
+        "default": "./dist/account.cjs"
+      }
     },
     "./blob": {
-      "types": "./dist/blob.d.ts",
-      "import": "./dist/blob.js",
-      "require": "./dist/blob.cjs"
+      "import": {
+        "types": "./dist/blob.d.ts",
+        "default": "./dist/blob.js"
+      },
+      "require": {
+        "types": "./dist/blob.d.cts",
+        "default": "./dist/blob.cjs"
+      }
     },
     "./bucket": {
-      "types": "./dist/bucket.d.ts",
-      "import": "./dist/bucket.js",
-      "require": "./dist/bucket.cjs"
+      "import": {
+        "types": "./dist/bucket.d.ts",
+        "default": "./dist/bucket.js"
+      },
+      "require": {
+        "types": "./dist/bucket.d.cts",
+        "default": "./dist/bucket.cjs"
+      }
     },
     "./client": {
-      "types": "./dist/client.d.ts",
-      "import": "./dist/client.js",
-      "require": "./dist/client.cjs"
+      "import": {
+        "types": "./dist/client.d.ts",
+        "default": "./dist/client.js"
+      },
+      "require": {
+        "types": "./dist/client.d.cts",
+        "default": "./dist/client.cjs"
+      }
     },
     "./credit": {
-      "types": "./dist/credit.d.ts",
-      "import": "./dist/credit.js",
-      "require": "./dist/credit.cjs"
+      "import": {
+        "types": "./dist/credit.d.ts",
+        "default": "./dist/credit.js"
+      },
+      "require": {
+        "types": "./dist/credit.d.cts",
+        "default": "./dist/credit.cjs"
+      }
     },
     "./errors": {
-      "types": "./dist/errors.d.ts",
-      "import": "./dist/errors.js",
-      "require": "./dist/errors.cjs"
+      "import": {
+        "types": "./dist/errors.d.ts",
+        "default": "./dist/errors.js"
+      },
+      "require": {
+        "types": "./dist/errors.d.cts",
+        "default": "./dist/errors.cjs"
+      }
     },
     "./ipc": {
-      "types": "./dist/ipc.d.ts",
-      "import": "./dist/ipc.js",
-      "require": "./dist/ipc.cjs"
-    },
-    "./network": {
-      "types": "./dist/network.d.ts",
-      "import": "./dist/network.js",
-      "require": "./dist/network.cjs"
+      "import": {
+        "types": "./dist/ipc.d.ts",
+        "default": "./dist/ipc.js"
+      },
+      "require": {
+        "types": "./dist/ipc.d.cts",
+        "default": "./dist/ipc.cjs"
+      }
     },
     "./provider": {
-      "types": "./dist/provider.d.ts",
-      "import": "./dist/provider.js",
-      "require": "./dist/provider.cjs"
+      "import": {
+        "types": "./dist/provider.d.ts",
+        "default": "./dist/provider.js"
+      },
+      "require": {
+        "types": "./dist/provider.d.cts",
+        "default": "./dist/provider.cjs"
+      }
     },
     "./utils": {
-      "types": "./dist/utils.d.ts",
-      "import": "./dist/utils.js",
-      "require": "./dist/utils.cjs"
+      "import": {
+        "types": "./dist/utils.d.ts",
+        "default": "./dist/utils.js"
+      },
+      "require": {
+        "types": "./dist/utils.d.cts",
+        "default": "./dist/utils.cjs"
+      }
     }
   },
   "files": [

--- a/packages/sdkx/package.json
+++ b/packages/sdkx/package.json
@@ -6,19 +6,34 @@
   "type": "module",
   "exports": {
     "./react/buckets": {
-      "types": "./dist/react/buckets.d.ts",
-      "import": "./dist/react/buckets.js",
-      "require": "./dist/react/buckets.js"
+      "import": {
+        "types": "./dist/react/buckets.d.ts",
+        "default": "./dist/react/buckets.js"
+      },
+      "require": {
+        "types": "./dist/react/buckets.d.cts",
+        "default": "./dist/react/buckets.cjs"
+      }
     },
     "./react/credits": {
-      "types": "./dist/react/credits.d.ts",
-      "import": "./dist/react/credits.js",
-      "require": "./dist/react/credits.cjs"
+      "import": {
+        "types": "./dist/react/credits.d.ts",
+        "default": "./dist/react/credits.js"
+      },
+      "require": {
+        "types": "./dist/react/credits.d.cts",
+        "default": "./dist/react/credits.cjs"
+      }
     },
     "./actions/credits": {
-      "types": "./dist/actions/credits.d.ts",
-      "import": "./dist/actions/credits.js",
-      "require": "./dist/actions/credits.cjs"
+      "import": {
+        "types": "./dist/actions/credits.d.ts",
+        "default": "./dist/actions/credits.js"
+      },
+      "require": {
+        "types": "./dist/actions/credits.d.cts",
+        "default": "./dist/actions/credits.cjs"
+      }
     }
   },
   "files": [


### PR DESCRIPTION
Something seemed off about our package exports and ts types. I noticed that `tsup` was outputting special ts types for cjs that we weren't referencing. Some research and this tool Are the Types Wrong (https://arethetypeswrong.github.io/?p=@recallnet/sdk@0.0.4 and the cli command `pnpm dlx @arethetypeswrong/cli --pack`) helped me understand what was going on and what the correct configuration should be.