### PR TITLE
feat: update `contracts` event for testnet v0.1.4

### DIFF
--- a/.changeset/afraid-parents-peel.md
+++ b/.changeset/afraid-parents-peel.md
@@ -1,0 +1,6 @@
+---
+"@recallnet/contracts": patch
+"@recallnet/sdk": patch
+---
+
+the `MachineInitialized` event signature changed to include a `kind` param, in addition to the existing `machineAddress`–so this accounts for the different event signature

--- a/packages/chains/package.json
+++ b/packages/chains/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@recallnet/network-constants": "workspace:*",
-    "viem": "^2.21.37"
+    "viem": "^2.22.9"
   },
   "devDependencies": {
     "@recallnet/eslint-config": "workspace:*",

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1394,6 +1394,7 @@ export const iMachineFacadeAbi = [
     type: "event",
     anonymous: false,
     inputs: [
+      { name: "kind", internalType: "uint8", type: "uint8", indexed: true },
       {
         name: "owner",
         internalType: "address",
@@ -1413,6 +1414,7 @@ export const iMachineFacadeAbi = [
     type: "event",
     anonymous: false,
     inputs: [
+      { name: "kind", internalType: "uint8", type: "uint8", indexed: true },
       {
         name: "machineAddress",
         internalType: "address",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -127,7 +127,7 @@
     "@sindresorhus/fnv1a": "^3.1.0",
     "file-type": "^19.6.0",
     "uint8arrays": "^5.1.0",
-    "viem": "^2.21.37"
+    "viem": "^2.22.9"
   },
   "devDependencies": {
     "@recallnet/eslint-config": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -240,7 +240,7 @@ importers:
         specifier: workspace:*
         version: link:../network-constants
       viem:
-        specifier: ^2.21.37
+        specifier: ^2.22.9
         version: 2.22.9(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1)
     devDependencies:
       '@recallnet/eslint-config':
@@ -405,7 +405,7 @@ importers:
         specifier: ^5.1.0
         version: 5.1.0
       viem:
-        specifier: ^2.21.37
+        specifier: ^2.22.9
         version: 2.22.9(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1)
     devDependencies:
       '@recallnet/eslint-config':
@@ -3946,6 +3946,7 @@ packages:
 
   lodash.get@4.4.2:
     resolution: {integrity: sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==}
+    deprecated: This package is deprecated. Use the optional chaining (?.) operator instead.
 
   lodash.isequal@4.5.0:
     resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}


### PR DESCRIPTION
note: we'll want to merge / release packages once the new testnet is up. the changes include:
- bump the `contracts` submodule, which includes the changed `MachineInitialized` event. this event is only used by the `sdk` package's `createBucket` event parsing.
- update the `sdk` and `chains` packages to use `viem@^2.22.9` since this is what other monorepo packages are using

closes https://github.com/recallnet/js-recall/issues/59. 