### PR TITLE
feat: default chain base fee multiplier

### DIFF
--- a/.changeset/popular-bulldogs-fry.md
+++ b/.changeset/popular-bulldogs-fry.md
@@ -1,0 +1,5 @@
+---
+"@recallnet/chains": patch
+---
+
+increases base fee multiplier from 1.2 to 120

--- a/packages/chains/src/index.ts
+++ b/packages/chains/src/index.ts
@@ -24,6 +24,9 @@ export type ChainName = "mainnet" | "testnet" | "localnet" | "devnet";
 export const testnet: Chain = defineChain({
   id: Number(TESTNET_CHAIN_ID),
   name: "Recall Testnet",
+  fees: {
+    baseFeeMultiplier: 120,
+  },
   nativeCurrency: {
     name: "Recall",
     symbol: "RECALL",
@@ -46,6 +49,9 @@ export const testnet: Chain = defineChain({
 export const localnet: Chain = defineChain({
   id: Number(LOCALNET_CHAIN_ID),
   name: "Recall Localnet",
+  fees: {
+    baseFeeMultiplier: 120,
+  },
   nativeCurrency: {
     name: "Recall",
     symbol: "RECALL",
@@ -68,6 +74,9 @@ export const localnet: Chain = defineChain({
 export const devnet: Chain = defineChain({
   id: Number(DEVNET_CHAIN_ID),
   name: "Recall Devnet",
+  fees: {
+    baseFeeMultiplier: 120,
+  },
   nativeCurrency: {
     name: "Recall",
     symbol: "RECALL",


### PR DESCRIPTION
## Summary

increases the default [base fee multiplier](https://viem.sh/docs/chains/fees#feesbasefeemultiplier) from 1.2 to 120, which more closely matches what we see with `forge script` contract deployments (i.e., 100x-1000x the default).

## Details

this _should_ resolve [issues mentioned](https://discord.com/channels/1229504999910801469/1229514067169906819/1349548754126245928) about out of gas RPC errors. this happens if the gas estimation is incorrect. it generally doesnt occur for simple txs, but we've seen a couple of users report it:
![image](https://github.com/user-attachments/assets/b9cbe4dd-89c0-4568-a4f2-9469c29cbb96)

note: i personally wasnt able to recreate the issue, and it's not clear why or when this occurs