### PR TITLE
feat: mcp server

### DIFF
--- a/packages/agent-toolkit/package.json
+++ b/packages/agent-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@recallnet/agent-toolkit",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "license": "MIT OR Apache-2.0",
   "publishConfig": {
     "access": "public"

--- a/packages/agent-toolkit/package.json
+++ b/packages/agent-toolkit/package.json
@@ -1,7 +1,17 @@
 {
   "name": "@recallnet/agent-toolkit",
   "version": "0.0.0",
+  "license": "MIT OR Apache-2.0",
+  "publishConfig": {
+    "access": "public"
+  },
   "description": "Recall agent toolkit with framework agnostic adapters",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/recallnet/js-recall.git",
+    "directory": "packages/agent-toolkit"
+  },
+  "homepage": "https://github.com/recallnet/js-recall/tree/main/packages/agent-toolkit#readme",
   "type": "module",
   "scripts": {
     "dev": "tsc --watch",

--- a/packages/mcp/.env.example
+++ b/packages/mcp/.env.example
@@ -1,2 +1,3 @@
 RECALL_PRIVATE_KEY=0xyour_private_key
 RECALL_NETWORK=testnet
+RECALL_TOOLS=all

--- a/packages/mcp/.env.example
+++ b/packages/mcp/.env.example
@@ -1,0 +1,2 @@
+RECALL_PRIVATE_KEY=0xyour_private_key
+RECALL_NETWORK=testnet

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -1,0 +1,102 @@
+# Recall MCP Server
+
+> Official MCP server for interacting with the Recall network.
+
+## Table of Contents
+
+- [Table of Contents](#table-of-contents)
+- [Background](#background)
+- [Usage](#usage)
+  - [Available tools](#available-tools)
+- [Development](#development)
+- [Contributing](#contributing)
+- [License](#license)
+
+## Background
+
+The `@recallnet/mcp` server allows agents to interact with the Recall network using the [Model Context Protocol (MCP)](https://github.com/modelcontextprotocol). See the [Recall MCP documentation](https://docs.recall.network/tools/mcp) for more information.
+
+## Usage
+
+Run the package with npx. You'll need to provide a Recall private key and optionally a network (e.g., `testnet` or `localnet`).
+
+```bash
+npx @recallnet/mcp --private-key=0x... --network=testnet
+```
+
+Or, set the `RECALL_PRIVATE_KEY` and `RECALL_NETWORK` environment variables:
+
+```bash
+RECALL_PRIVATE_KEY=0x... RECALL_NETWORK=testnet npx @recallnet/mcp
+```
+
+Optionally, you can specify the tools you want to enable. By default, all tools are enabled.
+
+```bash
+npx @recallnet/mcp --private-key=0x... --network=testnet --tools=bucket.read,bucket.write
+```
+
+### Available tools
+
+The server exposes the following MCP tools:
+
+| Tool name              | Tool scope      | Description                                                            |
+| ---------------------- | --------------- | ---------------------------------------------------------------------- |
+| `get_account_info`     | `account.read`  | Get Recall account information (e.g., address, balance)                |
+| `get_credit_info`      | `account.read`  | Get Recall account credit information (e.g., credit available or used) |
+| `buy_credit`           | `account.write` | Buy credit for Recall account                                          |
+| `list_buckets`         | `bucket.read`   | List all buckets owned by an address                                   |
+| `create_bucket`        | `bucket.write`  | Create a bucket in Recall                                              |
+| `get_or_create_bucket` | `bucket.write`  | Get or create a bucket in Recall (using alias)                         |
+| `add_object`           | `bucket.write`  | Add an object to a Recall bucket                                       |
+| `get_object`           | `bucket.read`   | Get an object from a Recall bucket                                     |
+| `query_objects`        | `bucket.read`   | Query objects in a Recall bucket                                       |
+
+## Development
+
+Clone the repository:
+
+```bash
+git clone https://github.com/recallnet/js-recall.git
+```
+
+And change into the `packages/mcp` directory:
+
+```bash
+cd js-recall/packages/mcp
+```
+
+Install dependencies and build the binary:
+
+```bash
+pnpm install
+pnpm build
+```
+
+Run the server directly from the `dist` directory:
+
+```bash
+node dist/index.js --private-key=0x... --network=testnet
+```
+
+The following `pnpm` commands are available:
+
+| Command             | Description                                     |
+| ------------------- | ----------------------------------------------- |
+| `pnpm build`        | Build the binary                                |
+| `pnpm dev`          | Run in development mode                         |
+| `pnpm lint`         | Lint the project with ESLint                    |
+| `pnpm lint:fix`     | Lint the project and fix linting errors         |
+| `pnpm format:check` | Check if the project is formatted with Prettier |
+| `pnpm format`       | Format the project (writes files)               |
+
+## Contributing
+
+PRs accepted.
+
+Small note: If editing the README, please conform to
+the [standard-readme](https://github.com/RichardLitt/standard-readme) specification.
+
+## License
+
+MIT OR Apache-2.0, © 2025 Recall Network Corporation

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -7,6 +7,9 @@
 - [Table of Contents](#table-of-contents)
 - [Background](#background)
 - [Usage](#usage)
+  - [Configure for Cursor or Claude Desktop](#configure-for-cursor-or-claude-desktop)
+    - [Adding to Cursor](#adding-to-cursor)
+    - [Adding to Claude Desktop](#adding-to-claude-desktop)
   - [Available tools](#available-tools)
 - [Development](#development)
 - [Contributing](#contributing)
@@ -35,6 +38,74 @@ Optionally, you can specify the tools you want to enable. By default, all tools 
 ```bash
 npx @recallnet/mcp --private-key=0x... --network=testnet --tools=bucket.read,bucket.write
 ```
+
+### Configure for Cursor or Claude Desktop
+
+#### Adding to Cursor
+
+To add this MCP server to Cursor:
+
+1. In Cursor, go to _Settings > Cursor Settings > MCP_.
+2. Click "Add New Global MCP Server" to open the server JSON configuration in the editor (i.e., the `~/.cursor/mcp.json` file in your home directory).
+3. Add the following configuration:
+
+```json
+{
+  "mcpServers": {
+    "recall-mcp": {
+      "name": "Recall MCP",
+      "type": "command",
+      "command": "npx",
+      "args": ["-y", "@recallnet/mcp"],
+      "env": {
+        "RECALL_PRIVATE_KEY": "0xyour_private_key",
+        "RECALL_NETWORK": "testnet",
+        "RECALL_TOOLS": "all"
+      }
+    }
+  }
+}
+```
+
+4. Save the configuration file and, if needed, refresh the MCP server in _Settings > Cursor Settings > MCP_ (it's in the top right corner of each MCP server).
+
+#### Adding to Claude Desktop
+
+To add this MCP server to Claude Desktop:
+
+1. Locate your Claude Desktop configuration file at:
+
+   - On macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
+   - On Windows: `%APPDATA%\Claude\claude_desktop_config.json`
+   - On Linux: `~/.config/Claude/claude_desktop_config.json`
+
+2. Create or edit the `claude_desktop_config.json` file with the following content:
+
+   ```json
+   {
+     "mcpServers": {
+       "recall-mcp-server": {
+         "name": "Recall MCP",
+         "type": "command",
+         "command": "npx",
+         "args": ["-y", "@recallnet/mcp"],
+         "env": {
+           "RECALL_PRIVATE_KEY": "0xyour_private_key",
+           "RECALL_NETWORK": "testnet",
+           "RECALL_TOOLS": "all"
+         }
+       }
+     }
+   }
+   ```
+
+3. Save the configuration file and restart Claude Desktop.
+
+If you encounter issues with Claude Desktop, check the logs at:
+
+- On macOS: `~/Library/Logs/Claude/`
+- On Windows: `%USERPROFILE%\AppData\Local\Claude\Logs\`
+- On Linux: `~/.local/share/Claude/logs/`
 
 ### Available tools
 

--- a/packages/mcp/eslint.config.js
+++ b/packages/mcp/eslint.config.js
@@ -1,0 +1,4 @@
+import { config } from "@recallnet/eslint-config/base";
+
+/** @type {import("eslint").Linter.Config} */
+export default config;

--- a/packages/mcp/eslint.config.js
+++ b/packages/mcp/eslint.config.js
@@ -1,4 +1,11 @@
 import { config } from "@recallnet/eslint-config/base";
 
-/** @type {import("eslint").Linter.Config} */
-export default config;
+/** @type {import("eslint").Linter.Config[]} */
+export default [
+  ...config,
+  {
+    rules: {
+      "turbo/no-undeclared-env-vars": "off",
+    },
+  },
+];

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@recallnet/mcp",
+  "version": "0.0.0",
+  "license": "MIT OR Apache-2.0",
+  "publishConfig": {
+    "access": "public"
+  },
+  "description": "Recall Model Context Protocol (MCP) server and command line tool",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/recallnet/js-recall.git",
+    "directory": "packages/mcp"
+  },
+  "homepage": "https://github.com/recallnet/js-recall/tree/main/packages/mcp#readme",
+  "type": "module",
+  "bin": "dist/index.js",
+  "scripts": {
+    "dev": "tsc --watch",
+    "build": "tsup && node -e \"require('fs').chmodSync('dist/index.js', '755')\"",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
+    "format": "prettier --write .",
+    "format:check": "prettier --check ."
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.7.0",
+    "@recallnet/agent-toolkit": "workspace:*",
+    "chalk": "^5.4.1",
+    "zod": "^3.24.1"
+  },
+  "devDependencies": {
+    "@recallnet/eslint-config": "workspace:*",
+    "@recallnet/typescript-config": "workspace:*",
+    "@types/node": "^22.13.13",
+    "tsup": "^8.3.6",
+    "typescript": "^5.7.3"
+  }
+}

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -13,10 +13,12 @@
   },
   "homepage": "https://github.com/recallnet/js-recall/tree/main/packages/mcp#readme",
   "type": "module",
-  "bin": "dist/index.js",
+  "bin": {
+    "recall-mcp": "dist/index.js"
+  },
   "scripts": {
     "dev": "tsc --watch",
-    "build": "tsup && node -e \"require('fs').chmodSync('dist/index.js', '755')\"",
+    "build": "tsup && shx chmod +x dist/*.js",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
@@ -32,6 +34,7 @@
     "@recallnet/eslint-config": "workspace:*",
     "@recallnet/typescript-config": "workspace:*",
     "@types/node": "^22.13.13",
+    "shx": "^0.4.0",
     "tsup": "^8.3.6",
     "typescript": "^5.7.3"
   }

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -13,26 +13,27 @@
   },
   "homepage": "https://github.com/recallnet/js-recall/tree/main/packages/mcp#readme",
   "type": "module",
-  "bin": {
-    "recall-mcp": "dist/index.js"
-  },
+  "bin": "dist/index.js",
   "scripts": {
     "dev": "tsc --watch",
     "build": "tsup && shx chmod +x dist/*.js",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
-    "format:check": "prettier --check ."
+    "format:check": "prettier --check .",
+    "clean": "rm -rf .turbo node_modules dist"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.7.0",
     "@recallnet/agent-toolkit": "workspace:*",
     "chalk": "^5.4.1",
+    "minimist": "^1.2.8",
     "zod": "^3.24.1"
   },
   "devDependencies": {
     "@recallnet/eslint-config": "workspace:*",
     "@recallnet/typescript-config": "workspace:*",
+    "@types/minimist": "^1.2.5",
     "@types/node": "^22.13.13",
     "shx": "^0.4.0",
     "tsup": "^8.3.6",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@recallnet/mcp",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "license": "MIT OR Apache-2.0",
   "publishConfig": {
     "access": "public"

--- a/packages/mcp/src/config.ts
+++ b/packages/mcp/src/config.ts
@@ -1,0 +1,139 @@
+import minimist from "minimist";
+import { z } from "zod";
+
+import {
+  Configuration,
+  Permission,
+  Resource,
+} from "@recallnet/agent-toolkit/shared";
+
+/**
+ * List of tools that are accepted by the MCP server in the format `resource.action` (e.g.
+ * `account.read`, `bucket.write`)
+ */
+// Note: in the future, we can make the private key optional to enable read-only MCP servers
+// and expose only the read tools
+export const ACCEPTED_TOOLS = [
+  "account.read",
+  "account.write",
+  "bucket.read",
+  "bucket.write",
+] as const;
+
+/**
+ * List of networks that are accepted by the MCP server
+ */
+export const NETWORKS = ["testnet", "localnet"] as const;
+
+/**
+ * Schema for configuration for CLI arguments and environment variables
+ */
+export const ConfigSchema = z.object({
+  tools: z
+    .array(z.string())
+    .default(["all"])
+    .refine(
+      (tools): tools is Array<(typeof ACCEPTED_TOOLS)[number] | "all"> =>
+        tools.every(
+          (tool) =>
+            tool === "all" ||
+            ACCEPTED_TOOLS.includes(tool as (typeof ACCEPTED_TOOLS)[number]),
+        ),
+      (tools) => ({
+        message: `Invalid tool(s). Each tool must be one of: ${ACCEPTED_TOOLS.join(", ")} or "all". Tools provided: ${tools.join(", ")}`,
+      }),
+    )
+    .describe("List of tools to enable"),
+  privateKey: z
+    .string({
+      required_error:
+        "Private key is required. Set RECALL_PRIVATE_KEY env var or pass --private-key",
+      invalid_type_error: "Private key must be a string",
+    })
+    .min(1, "Private key cannot be empty")
+    .transform((val) => (!val.startsWith("0x") ? `0x${val}` : val))
+    .pipe(
+      z.string().regex(/^0x[a-fA-F0-9]{64}$/, {
+        message:
+          "Private key must be a valid 32-byte hex string (with or without '0x' prefix)",
+      }),
+    ),
+  network: z
+    .enum(NETWORKS, {
+      errorMap: () => ({
+        message: `Network must be one of: ${NETWORKS.join(", ")}`,
+      }),
+    })
+    .optional()
+    .default("testnet")
+    .describe(`Recall network to use (${NETWORKS.join(", ")})`),
+});
+
+/**
+ * Validated configuration object from CLI arguments and environment variables
+ */
+export type ValidatedConfig = z.infer<typeof ConfigSchema>;
+
+/**
+ * Parse and validate both CLI arguments and environment variables
+ * @returns Validated configuration object
+ */
+export function parseAndValidateConfig(): ValidatedConfig {
+  const argv = minimist(process.argv.slice(2), {
+    string: ["private-key", "network", "tools"],
+    alias: {
+      "private-key": "privateKey",
+    },
+  });
+
+  const rawConfig = {
+    privateKey: argv.privateKey || process.env.RECALL_PRIVATE_KEY,
+    network: argv.network || process.env.RECALL_NETWORK,
+    tools: argv.tools?.split(",") || process.env.RECALL_TOOLS?.split(","),
+  };
+
+  try {
+    return ConfigSchema.parse(rawConfig);
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      const issues = error.issues
+        .map((issue) => `  - ${issue.path.join(".")}: ${issue.message}`)
+        .join("\n");
+      throw new Error(`Configuration validation failed:\n${issues}`);
+    }
+    throw error;
+  }
+}
+
+/**
+ * Build MCP configuration from validated config
+ * @param config - Validated configuration object
+ * @returns MCP configuration object
+ */
+export function buildMcpConfiguration(config: ValidatedConfig): Configuration {
+  const configuration: Configuration = { actions: {}, context: {} };
+
+  if (config.tools.includes("all")) {
+    ACCEPTED_TOOLS.forEach((tool) => {
+      const [resource, action] = tool.split(".");
+      configuration.actions[resource as Resource] = {
+        ...configuration.actions[resource as Resource],
+        [action as Permission]: true,
+      };
+    });
+  } else {
+    config.tools.forEach((tool) => {
+      const [resource, action] = tool.split(".");
+      configuration.actions[resource as Resource] = {
+        ...configuration.actions[resource as Resource],
+        [action as Permission]: true,
+      };
+    });
+  }
+
+  if (config.network) {
+    configuration.context = { network: config.network };
+  }
+
+  return configuration;
+}

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -1,0 +1,174 @@
+#!/usr/bin/env node
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import chalk from "chalk";
+
+import { RecallAgentToolkit } from "@recallnet/agent-toolkit/mcp";
+import {
+  Configuration,
+  Permission,
+  Resource,
+} from "@recallnet/agent-toolkit/shared";
+
+/**
+ * Options for the Recall MCP server
+ * @param tools - The tools to enable
+ * @param privateKey - The private key to use
+ * @param network - The Recall network to use: `testnet` or `localnet` (defaults to `testnet`)
+ */
+type Options = {
+  tools?: string[];
+  privateKey?: string;
+  network?: string;
+};
+
+// The server will accept flags for a `--private-key` (hex string), `--tools` (comma separated),
+// and `--network` (e.g., `testnet` or `localnet`)
+const ACCEPTED_ARGS = ["private-key", "tools", "network"];
+
+// Note: since we require a private key, we only expose both read and write tools
+const ACCEPTED_TOOLS = [
+  "account.read",
+  "account.write",
+  "bucket.read",
+  "bucket.write",
+];
+
+// eslint-disable-next-line turbo/no-undeclared-env-vars
+const { RECALL_PRIVATE_KEY, RECALL_NETWORK } = process.env;
+
+/**
+ * Parse the command line arguments
+ * @param args - The command line arguments—one or more of:
+ *  `--tools=all` (or `--tools=resource.action`, like `--tools=account.read`),
+ *  `--private-key=$KEY`, or `--network=$NETWORK`
+ * @returns The parsed options
+ */
+export function parseArgs(args: string[]): Options {
+  const options: Options = {};
+
+  args.forEach((arg) => {
+    if (arg.startsWith("--")) {
+      const [key, value] = arg.slice(2).split("=");
+
+      if (key == "tools") {
+        options.tools = value?.split(",");
+      } else if (key == "private-key") {
+        options.privateKey = value;
+      } else if (key == "network") {
+        options.network = value;
+      } else {
+        throw new Error(
+          `Invalid argument: ${key}. Accepted arguments are: ${ACCEPTED_ARGS.join(
+            ", ",
+          )}`,
+        );
+      }
+    }
+  });
+
+  // Check if the tools argument is present, else, use all tools
+  if (!options.tools) {
+    options.tools = ["all"];
+  }
+
+  // Validate tools against accepted enum values
+  options.tools.forEach((tool: string) => {
+    if (tool == "all") {
+      return;
+    }
+    if (!ACCEPTED_TOOLS.includes(tool.trim())) {
+      throw new Error(
+        `Invalid tool: ${tool}. Accepted tools are: ${ACCEPTED_TOOLS.join(
+          ", ",
+        )}`,
+      );
+    }
+  });
+
+  // Check if API key is either provided in args or set in environment variables
+  const privateKey = options.privateKey || RECALL_PRIVATE_KEY;
+  if (!privateKey) {
+    throw new Error(
+      "Recall private key not provided. Please either pass it as an argument --private-key=$KEY or set the RECALL_PRIVATE_KEY environment variable.",
+    );
+  }
+  options.privateKey = privateKey;
+
+  // If not set, the `RecallAgentToolkit` will default to `testnet`
+  options.network = options.network || RECALL_NETWORK;
+  if (
+    options.network &&
+    options.network !== "testnet" &&
+    options.network !== "localnet"
+  ) {
+    throw new Error(
+      "Invalid network. Please use either 'testnet' or 'localnet'.",
+    );
+  }
+
+  return options;
+}
+
+// Handle errors with special color formatting for clarity purposes since we use console.error
+// for all logging outputs
+function handleError(error: unknown) {
+  console.error(chalk.red("\nError initializing Recall MCP server:\n"));
+  console.error(
+    chalk.yellow(
+      ` ${error instanceof Error ? error.message : String(error)}\n`,
+    ),
+  );
+}
+
+// Main function that parses the command line arguments, creates the `RecallAgentToolkit` instance,
+// and starts the MCP server
+export async function main() {
+  const options = parseArgs(process.argv.slice(2));
+
+  // Create the `RecallAgentToolkit` instance
+  const selectedTools = options.tools!;
+  const configuration: Configuration = { actions: {}, context: {} };
+
+  if (selectedTools.includes("all")) {
+    ACCEPTED_TOOLS.forEach((tool) => {
+      const [resource, action] = tool.split(".");
+      configuration.actions[resource as Resource] = {
+        ...configuration.actions[resource as Resource],
+        [action as Permission]: true,
+      };
+    });
+  } else {
+    selectedTools.forEach((tool) => {
+      const [resource, action] = tool.split(".");
+      if (!resource || !action) {
+        throw new Error(
+          `Invalid tool: ${tool}. Tool must be in the format of "resource.action".`,
+        );
+      }
+      configuration.actions[resource as Resource] = {
+        ...configuration.actions[resource as Resource],
+        [action]: true,
+      };
+    });
+  }
+
+  // Append custom Recall network to configuration if provided
+  if (options.network) {
+    configuration.context = { network: options.network };
+  }
+
+  const server = new RecallAgentToolkit({
+    privateKey: options.privateKey!,
+    configuration: configuration,
+  });
+
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  // We use console.error instead of console.log since console.log will output to stdio, which
+  // will confuse the MCP server
+  console.error(chalk.green("Recall MCP Server running on stdio"));
+}
+
+main().catch((error) => {
+  handleError(error);
+});

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -33,7 +33,6 @@ const ACCEPTED_TOOLS = [
   "bucket.write",
 ];
 
-// eslint-disable-next-line turbo/no-undeclared-env-vars
 const { RECALL_PRIVATE_KEY, RECALL_NETWORK } = process.env;
 
 /**

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -3,113 +3,13 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import chalk from "chalk";
 
 import { RecallAgentToolkit } from "@recallnet/agent-toolkit/mcp";
-import {
-  Configuration,
-  Permission,
-  Resource,
-} from "@recallnet/agent-toolkit/shared";
+
+import { buildMcpConfiguration, parseAndValidateConfig } from "./config.js";
 
 /**
- * Options for the Recall MCP server
- * @param tools - The tools to enable
- * @param privateKey - The private key to use
- * @param network - The Recall network to use: `testnet` or `localnet` (defaults to `testnet`)
+ * Handle errors with special color formatting for clarity purposes (since we use console.error
+ * for all logging outputs)
  */
-type Options = {
-  tools?: string[];
-  privateKey?: string;
-  network?: string;
-};
-
-// The server will accept flags for a `--private-key` (hex string), `--tools` (comma separated),
-// and `--network` (e.g., `testnet` or `localnet`)
-const ACCEPTED_ARGS = ["private-key", "tools", "network"];
-
-// Note: since we require a private key, we only expose both read and write tools
-const ACCEPTED_TOOLS = [
-  "account.read",
-  "account.write",
-  "bucket.read",
-  "bucket.write",
-];
-
-const { RECALL_PRIVATE_KEY, RECALL_NETWORK } = process.env;
-
-/**
- * Parse the command line arguments
- * @param args - The command line arguments—one or more of:
- *  `--tools=all` (or `--tools=resource.action`, like `--tools=account.read`),
- *  `--private-key=$KEY`, or `--network=$NETWORK`
- * @returns The parsed options
- */
-export function parseArgs(args: string[]): Options {
-  const options: Options = {};
-
-  args.forEach((arg) => {
-    if (arg.startsWith("--")) {
-      const [key, value] = arg.slice(2).split("=");
-
-      if (key == "tools") {
-        options.tools = value?.split(",");
-      } else if (key == "private-key") {
-        options.privateKey = value;
-      } else if (key == "network") {
-        options.network = value;
-      } else {
-        throw new Error(
-          `Invalid argument: ${key}. Accepted arguments are: ${ACCEPTED_ARGS.join(
-            ", ",
-          )}`,
-        );
-      }
-    }
-  });
-
-  // Check if the tools argument is present, else, use all tools
-  if (!options.tools) {
-    options.tools = ["all"];
-  }
-
-  // Validate tools against accepted enum values
-  options.tools.forEach((tool: string) => {
-    if (tool == "all") {
-      return;
-    }
-    if (!ACCEPTED_TOOLS.includes(tool.trim())) {
-      throw new Error(
-        `Invalid tool: ${tool}. Accepted tools are: ${ACCEPTED_TOOLS.join(
-          ", ",
-        )}`,
-      );
-    }
-  });
-
-  // Check if API key is either provided in args or set in environment variables
-  const privateKey = options.privateKey || RECALL_PRIVATE_KEY;
-  if (!privateKey) {
-    throw new Error(
-      "Recall private key not provided. Please either pass it as an argument --private-key=$KEY or set the RECALL_PRIVATE_KEY environment variable.",
-    );
-  }
-  options.privateKey = privateKey;
-
-  // If not set, the `RecallAgentToolkit` will default to `testnet`
-  options.network = options.network || RECALL_NETWORK;
-  if (
-    options.network &&
-    options.network !== "testnet" &&
-    options.network !== "localnet"
-  ) {
-    throw new Error(
-      "Invalid network. Please use either 'testnet' or 'localnet'.",
-    );
-  }
-
-  return options;
-}
-
-// Handle errors with special color formatting for clarity purposes since we use console.error
-// for all logging outputs
 function handleError(error: unknown) {
   console.error(chalk.red("\nError initializing Recall MCP server:\n"));
   console.error(
@@ -119,46 +19,17 @@ function handleError(error: unknown) {
   );
 }
 
-// Main function that parses the command line arguments, creates the `RecallAgentToolkit` instance,
-// and starts the MCP server
+/**
+ * Main function that parses the command line arguments, creates the `RecallAgentToolkit` instance,
+ * and starts the MCP server
+ */
 export async function main() {
-  const options = parseArgs(process.argv.slice(2));
-
-  // Create the `RecallAgentToolkit` instance
-  const selectedTools = options.tools!;
-  const configuration: Configuration = { actions: {}, context: {} };
-
-  if (selectedTools.includes("all")) {
-    ACCEPTED_TOOLS.forEach((tool) => {
-      const [resource, action] = tool.split(".");
-      configuration.actions[resource as Resource] = {
-        ...configuration.actions[resource as Resource],
-        [action as Permission]: true,
-      };
-    });
-  } else {
-    selectedTools.forEach((tool) => {
-      const [resource, action] = tool.split(".");
-      if (!resource || !action) {
-        throw new Error(
-          `Invalid tool: ${tool}. Tool must be in the format of "resource.action".`,
-        );
-      }
-      configuration.actions[resource as Resource] = {
-        ...configuration.actions[resource as Resource],
-        [action]: true,
-      };
-    });
-  }
-
-  // Append custom Recall network to configuration if provided
-  if (options.network) {
-    configuration.context = { network: options.network };
-  }
+  const config = parseAndValidateConfig();
+  const mcpConfig = buildMcpConfiguration(config);
 
   const server = new RecallAgentToolkit({
-    privateKey: options.privateKey!,
-    configuration: configuration,
+    privateKey: config.privateKey,
+    configuration: mcpConfig,
   });
 
   const transport = new StdioServerTransport();
@@ -168,6 +39,10 @@ export async function main() {
   console.error(chalk.green("Recall MCP Server running on stdio"));
 }
 
-main().catch((error) => {
+try {
+  main().catch((error) => {
+    handleError(error);
+  });
+} catch (error) {
   handleError(error);
-});
+}

--- a/packages/mcp/tsconfig.json
+++ b/packages/mcp/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@recallnet/typescript-config/base.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules"]
+}

--- a/packages/mcp/tsup.config.ts
+++ b/packages/mcp/tsup.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig([
+  {
+    entry: ["src/index.ts"],
+    outDir: "dist",
+    format: ["esm"],
+    dts: true,
+    sourcemap: true,
+    clean: true,
+  },
+]);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -464,6 +464,9 @@ importers:
       '@types/node':
         specifier: ^22.13.13
         version: 22.13.13
+      shx:
+        specifier: ^0.4.0
+        version: 0.4.0
       tsup:
         specifier: ^8.3.6
         version: 8.3.6(jiti@1.21.6)(postcss@8.4.49)(tsx@4.19.3)(typescript@5.7.3)(yaml@2.6.1)
@@ -3310,6 +3313,10 @@ packages:
   cross-fetch@4.1.0:
     resolution: {integrity: sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==}
 
+  cross-spawn@6.0.6:
+    resolution: {integrity: sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw==}
+    engines: {node: '>=4.8'}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -3766,6 +3773,10 @@ packages:
     resolution: {integrity: sha512-LT/5J605bx5SNyE+ITBDiM3FxffBiq9un7Vx0EwMDM3vg8sWKx/tO2zC+LMqZ+smAM0F2hblaDZUVZF0te2pSw==}
     engines: {node: '>=18.0.0'}
 
+  execa@1.0.0:
+    resolution: {integrity: sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==}
+    engines: {node: '>=6'}
+
   execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
     engines: {node: '>=10'}
@@ -3958,6 +3969,10 @@ packages:
 
   get-nonce@1.0.1:
     resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
+    engines: {node: '>=6'}
+
+  get-stream@4.1.0:
+    resolution: {integrity: sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==}
     engines: {node: '>=6'}
 
   get-stream@6.0.1:
@@ -4165,6 +4180,10 @@ packages:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
 
+  interpret@1.4.0:
+    resolution: {integrity: sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==}
+    engines: {node: '>= 0.10'}
+
   ip-address@9.0.5:
     resolution: {integrity: sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==}
     engines: {node: '>= 12'}
@@ -4288,6 +4307,10 @@ packages:
   is-shared-array-buffer@1.0.3:
     resolution: {integrity: sha512-nA2hv5XIhLR3uVzDDfCIknerhx8XUKnstuOERPNNIinXG7v9u+ohXF67vxm4TPTEPU6lm61ZkwP3c9PCB97rhg==}
     engines: {node: '>= 0.4'}
+
+  is-stream@1.1.0:
+    resolution: {integrity: sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==}
+    engines: {node: '>=0.10.0'}
 
   is-stream@2.0.1:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
@@ -4789,6 +4812,9 @@ packages:
       sass:
         optional: true
 
+  nice-try@1.0.5:
+    resolution: {integrity: sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==}
+
   no-case@2.3.2:
     resolution: {integrity: sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==}
 
@@ -4829,6 +4855,10 @@ packages:
   normalize-range@0.1.2:
     resolution: {integrity: sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==}
     engines: {node: '>=0.10.0'}
+
+  npm-run-path@2.0.2:
+    resolution: {integrity: sha512-lJxZYlT4DW/bRUtFh1MQIWqmLwQfAxnqWG4HhEdjMlkrJYnJn0Jrr2u3mgxqaWsdiBc76TYkTG/mhrnYTuzfHw==}
+    engines: {node: '>=4'}
 
   npm-run-path@4.0.1:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
@@ -5017,6 +5047,10 @@ packages:
   path-is-absolute@1.0.1:
     resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
     engines: {node: '>=0.10.0'}
+
+  path-key@2.0.1:
+    resolution: {integrity: sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==}
+    engines: {node: '>=4'}
 
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
@@ -5428,6 +5462,10 @@ packages:
     resolution: {integrity: sha512-r/H9MzAWtrv8aSVjPCMFpDMl5q66GqtmmRkRjpHTsp4zBAa+snZyiQNlMONiUmEJcsnaw0wCauJ2GWODr/aFkg==}
     engines: {node: '>= 12.13.0'}
 
+  rechoir@0.6.2:
+    resolution: {integrity: sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==}
+    engines: {node: '>= 0.10'}
+
   reflect.getprototypeof@1.0.8:
     resolution: {integrity: sha512-B5dj6usc5dkk8uFliwjwDHM8To5/QwdKz9JcBZ8Ic4G1f0YmeeJTtE/ZTdgRFPAfxZFiUaPhZ1Jcs4qeagItGQ==}
     engines: {node: '>= 0.4'}
@@ -5542,6 +5580,10 @@ packages:
   secure-json-parse@2.7.0:
     resolution: {integrity: sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==}
 
+  semver@5.7.2:
+    resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
+    hasBin: true
+
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
@@ -5597,13 +5639,31 @@ packages:
     resolution: {integrity: sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
 
+  shebang-command@1.2.0:
+    resolution: {integrity: sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==}
+    engines: {node: '>=0.10.0'}
+
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
     engines: {node: '>=8'}
 
+  shebang-regex@1.0.0:
+    resolution: {integrity: sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==}
+    engines: {node: '>=0.10.0'}
+
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  shelljs@0.9.2:
+    resolution: {integrity: sha512-S3I64fEiKgTZzKCC46zT/Ib9meqofLrQVbpSswtjFfAVDW+AZ54WTnAM/3/yENoxz/V1Cy6u3kiiEbQ4DNphvw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  shx@0.4.0:
+    resolution: {integrity: sha512-Z0KixSIlGPpijKgcH6oCMCbltPImvaKy0sGH8AkLRXw1KyzpKtaCTizP2xen+hNDqVF4xxgvA0KXSb9o4Q6hnA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   side-channel-list@1.0.0:
     resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
@@ -5752,6 +5812,10 @@ packages:
   strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
+
+  strip-eof@1.0.0:
+    resolution: {integrity: sha512-7FCwGGmx8mD5xQd3RPUvnSpUXHM3BWuzjtpD4TXsfcZ9EL4azvVVUscFYwD9nx8Kh+uCBC00XBtAykoMHwTh8Q==}
+    engines: {node: '>=0.10.0'}
 
   strip-final-newline@2.0.0:
     resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
@@ -6305,6 +6369,10 @@ packages:
   which-typed-array@1.1.16:
     resolution: {integrity: sha512-g+N+GAWiRj66DngFwHvISJd+ITsyphZvD1vChfVg6cEdnzy53GzB3oy0fUNlvhz7H7+MiqhYr26qxQShCpKTTQ==}
     engines: {node: '>= 0.4'}
+
+  which@1.3.1:
+    resolution: {integrity: sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==}
+    hasBin: true
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -9434,6 +9502,14 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
+  cross-spawn@6.0.6:
+    dependencies:
+      nice-try: 1.0.5
+      path-key: 2.0.1
+      semver: 5.7.2
+      shebang-command: 1.2.0
+      which: 1.3.1
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -10021,6 +10097,16 @@ snapshots:
     dependencies:
       eventsource-parser: 3.0.0
 
+  execa@1.0.0:
+    dependencies:
+      cross-spawn: 6.0.6
+      get-stream: 4.1.0
+      is-stream: 1.1.0
+      npm-run-path: 2.0.2
+      p-finally: 1.0.0
+      signal-exit: 3.0.7
+      strip-eof: 1.0.0
+
   execa@5.1.1:
     dependencies:
       cross-spawn: 7.0.6
@@ -10264,6 +10350,10 @@ snapshots:
       math-intrinsics: 1.0.0
 
   get-nonce@1.0.1: {}
+
+  get-stream@4.1.0:
+    dependencies:
+      pump: 3.0.2
 
   get-stream@6.0.1: {}
 
@@ -10531,6 +10621,8 @@ snapshots:
       hasown: 2.0.2
       side-channel: 1.1.0
 
+  interpret@1.4.0: {}
+
   ip-address@9.0.5:
     dependencies:
       jsbn: 1.1.0
@@ -10640,6 +10732,8 @@ snapshots:
   is-shared-array-buffer@1.0.3:
     dependencies:
       call-bind: 1.0.8
+
+  is-stream@1.1.0: {}
 
   is-stream@2.0.1: {}
 
@@ -11076,6 +11170,8 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
+  nice-try@1.0.5: {}
+
   no-case@2.3.2:
     dependencies:
       lower-case: 1.1.4
@@ -11111,6 +11207,10 @@ snapshots:
   normalize-path@3.0.0: {}
 
   normalize-range@0.1.2: {}
+
+  npm-run-path@2.0.2:
+    dependencies:
+      path-key: 2.0.1
 
   npm-run-path@4.0.1:
     dependencies:
@@ -11333,6 +11433,8 @@ snapshots:
   path-exists@4.0.0: {}
 
   path-is-absolute@1.0.1: {}
+
+  path-key@2.0.1: {}
 
   path-key@3.1.1: {}
 
@@ -11675,6 +11777,10 @@ snapshots:
 
   real-require@0.1.0: {}
 
+  rechoir@0.6.2:
+    dependencies:
+      resolve: 1.22.9
+
   reflect.getprototypeof@1.0.8:
     dependencies:
       call-bind: 1.0.8
@@ -11813,6 +11919,8 @@ snapshots:
 
   secure-json-parse@2.7.0: {}
 
+  semver@5.7.2: {}
+
   semver@6.3.1: {}
 
   semver@7.6.2: {}
@@ -11908,11 +12016,29 @@ snapshots:
       '@img/sharp-win32-x64': 0.33.5
     optional: true
 
+  shebang-command@1.2.0:
+    dependencies:
+      shebang-regex: 1.0.0
+
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
 
+  shebang-regex@1.0.0: {}
+
   shebang-regex@3.0.0: {}
+
+  shelljs@0.9.2:
+    dependencies:
+      execa: 1.0.0
+      fast-glob: 3.3.2
+      interpret: 1.4.0
+      rechoir: 0.6.2
+
+  shx@0.4.0:
+    dependencies:
+      minimist: 1.2.8
+      shelljs: 0.9.2
 
   side-channel-list@1.0.0:
     dependencies:
@@ -12097,6 +12223,8 @@ snapshots:
       ansi-regex: 6.1.0
 
   strip-bom@3.0.0: {}
+
+  strip-eof@1.0.0: {}
 
   strip-final-newline@2.0.0: {}
 
@@ -12751,6 +12879,10 @@ snapshots:
       for-each: 0.3.3
       gopd: 1.2.0
       has-tostringtag: 1.0.2
+
+  which@1.3.1:
+    dependencies:
+      isexe: 2.0.0
 
   which@2.0.2:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -440,6 +440,37 @@ importers:
         specifier: ^5.7.3
         version: 5.7.3
 
+  packages/mcp:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.7.0
+        version: 1.7.0
+      '@recallnet/agent-toolkit':
+        specifier: workspace:*
+        version: link:../agent-toolkit
+      chalk:
+        specifier: ^5.4.1
+        version: 5.4.1
+      zod:
+        specifier: ^3.24.1
+        version: 3.24.1
+    devDependencies:
+      '@recallnet/eslint-config':
+        specifier: workspace:*
+        version: link:../eslint-config
+      '@recallnet/typescript-config':
+        specifier: workspace:*
+        version: link:../typescript-config
+      '@types/node':
+        specifier: ^22.13.13
+        version: 22.13.13
+      tsup:
+        specifier: ^8.3.6
+        version: 8.3.6(jiti@1.21.6)(postcss@8.4.49)(tsx@4.19.3)(typescript@5.7.3)(yaml@2.6.1)
+      typescript:
+        specifier: ^5.7.3
+        version: 5.7.3
+
   packages/network-constants:
     devDependencies:
       '@recallnet/eslint-config':
@@ -2504,6 +2535,9 @@ packages:
 
   '@types/node@22.12.0':
     resolution: {integrity: sha512-Fll2FZ1riMjNmlmJOdAyY5pUbkftXslB5DgEzlIuNaiWhXd00FhWxVC/r4yV/4wBb9JfImTu+jiSvXTkJ7F/gA==}
+
+  '@types/node@22.13.13':
+    resolution: {integrity: sha512-ClsL5nMwKaBRwPcCvH8E7+nU4GxHVx1axNvMZTFHMEfNI7oahimt26P5zjVCRrjiIWj6YFXfE1v3dEp94wLcGQ==}
 
   '@types/react-dom@19.0.3':
     resolution: {integrity: sha512-0Knk+HJiMP/qOZgMyNFamlIjw9OFCsyC2ZbigmEEyXXixgre6IQpm/4V+r3qH4GC1JPvRJKInw+on2rV6YZLeA==}
@@ -8241,6 +8275,10 @@ snapshots:
       undici-types: 6.20.0
 
   '@types/node@22.12.0':
+    dependencies:
+      undici-types: 6.20.0
+
+  '@types/node@22.13.13':
     dependencies:
       undici-types: 6.20.0
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -451,6 +451,9 @@ importers:
       chalk:
         specifier: ^5.4.1
         version: 5.4.1
+      minimist:
+        specifier: ^1.2.8
+        version: 1.2.8
       zod:
         specifier: ^3.24.1
         version: 3.24.1
@@ -461,6 +464,9 @@ importers:
       '@recallnet/typescript-config':
         specifier: workspace:*
         version: link:../typescript-config
+      '@types/minimist':
+        specifier: ^1.2.5
+        version: 1.2.5
       '@types/node':
         specifier: ^22.13.13
         version: 22.13.13
@@ -2511,6 +2517,9 @@ packages:
 
   '@types/minimatch@5.1.2':
     resolution: {integrity: sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==}
+
+  '@types/minimist@1.2.5':
+    resolution: {integrity: sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==}
 
   '@types/mocha@10.0.10':
     resolution: {integrity: sha512-xPyYSz1cMPnJQhl0CLMH68j3gprKZaTjG3s5Vi+fDgx+uhG9NOXwbVt52eFS8ECyXhyKcjDLCBEqBExKuiZb7Q==}
@@ -8314,6 +8323,8 @@ snapshots:
   '@types/json-schema@7.0.15': {}
 
   '@types/minimatch@5.1.2': {}
+
+  '@types/minimist@1.2.5': {}
 
   '@types/mocha@10.0.10': {}
 


### PR DESCRIPTION
## Summary

Add an official `@recallnet/mcp` binary that can be ran with `npx`.

## Details

- The design is, basically, unchanged from the [agent toolkit example](https://github.com/recallnet/js-recall/blob/main/packages/agent-toolkit/examples/mcp.ts) MCP server
- You can test the tool out by building and then running `node dist/index.js --private-key=0x...` (or by setting the RECALL_PRIVATE_KEY env var). Just make sure you're explicit since it won't be read from any `.env.` file.
- The docs are pretty light and just point to the docs site, which we can update later