### PR TITLE
Enforce Zero Lint Warnings for Portal App

### DIFF
--- a/apps/portal/app/buckets/[address]/_components/bucket.tsx
+++ b/apps/portal/app/buckets/[address]/_components/bucket.tsx
@@ -63,7 +63,6 @@ export default function Bucket({ bucketAddress }: { bucketAddress: Address }) {
 
   function mainContent() {
     if (isObject) {
-      const name = pathParts[pathParts.length - 1] ?? "unknown";
       const parentPath =
         pathParts.slice(0, -1).join(delimiter) +
         (pathParts.length > 1 ? delimiter : "");

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -7,7 +7,7 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint",
+    "lint": "next lint --max-warnings 0",
     "clean": "rm -rf .turbo .next node_modules",
     "test": "vitest run",
     "docs:check": "typedoc --emit none",


### PR DESCRIPTION
**Purpose:**

This PR enforces a stricter linting policy for the `apps/portal` package by requiring zero warnings (`--max-warnings 0`). This helps maintain higher code quality and prevents potential issues introduced by unused variables or other minor lint violations.

**Changes:**

1.  **Updated `package.json`:** Modified the `lint` script in `apps/portal/package.json` to include the `--max-warnings 0` flag:
    ```diff
    -     "lint": "next lint",
    +     "lint": "next lint --max-warnings 0",
    ```
2.  **Fixed Lint Warning:** Running the updated lint command revealed an unused variable (`name`) within the `mainContent` function in `apps/portal/app/buckets/[address]/_components/bucket.tsx`. This variable has been removed.

**Verification:**

-   The `pnpm lint` command now runs successfully for the `apps/portal` package with the `--max-warnings 0` flag enabled, confirming there are no remaining lint warnings or errors in the files touched by recent development.
