### PR TITLE
Don't url encode entire path

### DIFF
--- a/apps/portal/app/buckets/[address]/_components/object.tsx
+++ b/apps/portal/app/buckets/[address]/_components/object.tsx
@@ -136,7 +136,7 @@ export default function Object({
               />
             )}
             <Link
-              href={`${objectApiUrl}/v1/objects/${bucketAddress}/${encodeURIComponent(path)}`}
+              href={`${objectApiUrl}/v1/objects/${bucketAddress}/${path}`}
               target="_blank"
               className="opacity-20 hover:cursor-pointer hover:opacity-100"
             >


### PR DESCRIPTION
The path usually includes `/` delimiters which shouldn't be encoded because they are the url path structure that the objects api expects in order to look up objects.

Ideally, we'd encode each component of the path, excluding the `/`, and use that to build the URL, but the object api doesn't seem to support URL ecdoded values, so it just returns not found in that case. Basically, we need to fix the object api then we can make more improvements here.

Closes #187 