### PR TITLE
chore: build consts w/ testnet v0.1.6

### DIFF
--- a/.changeset/huge-lines-thank.md
+++ b/.changeset/huge-lines-thank.md
@@ -1,0 +1,5 @@
+---
+"@recallnet/contracts": patch
+---
+
+update core contracts to testnet v0.1.6 values

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -247,7 +247,7 @@ export const blobManagerAbi = [
 
 */
 export const blobManagerAddress = {
-  2481632: "0x6E3f94065567560c6e1Bbc5e4584127220c15e14",
+  2481632: "0x27594F8412bA08278b15b55C6347605Ee3b2020C",
   248163216: "0x8ce361602B935680E8DeC218b820ff5056BeB7af",
 } as const;
 
@@ -725,7 +725,7 @@ export const bucketManagerAbi = [
 
 */
 export const bucketManagerAddress = {
-  2481632: "0x7a9Cec860adF2C64274D0aD7fbF0b5Bf0426a200",
+  2481632: "0x170a22c76a2Bb7c5F1b0e7067a0ddb7C3452c8e0",
   248163216: "0xeD1DB453C3156Ff3155a97AD217b3087D5Dc5f6E",
 } as const;
 
@@ -1075,7 +1075,7 @@ export const creditManagerAbi = [
 
 */
 export const creditManagerAddress = {
-  2481632: "0x61F50eEC83043a4635956B54EEDf5Eea8CcaBc76",
+  2481632: "0x296042865b783D8E8Fb09F04FFAE2A66a16B85Bc",
   248163216: "0x196dBCBb54b8ec4958c959D8949EBFE87aC2Aaaf",
 } as const;
 
@@ -1093,7 +1093,7 @@ export const creditManagerConfig = {
 
 /**
  * -
- * - [__View Contract on Filecoin Calibration Filscan__](https://calibration.filscan.io/address/0x136066500b332e7D72643EE7690E9C708702c7e6)
+ * - [__View Contract on Filecoin Calibration Filscan__](https://calibration.filscan.io/address/0x2758f99EaB8ea9B8678B5d841851D62Ef18AAB26)
  */
 export const gatewayManagerFacetAbi = [
   {
@@ -1340,11 +1340,11 @@ export const gatewayManagerFacetAbi = [
 
 /**
  * -
- * - [__View Contract on Filecoin Calibration Filscan__](https://calibration.filscan.io/address/0x136066500b332e7D72643EE7690E9C708702c7e6)
+ * - [__View Contract on Filecoin Calibration Filscan__](https://calibration.filscan.io/address/0x2758f99EaB8ea9B8678B5d841851D62Ef18AAB26)
  */
 export const gatewayManagerFacetAddress = {
   31337: "0x9A676e781A523b5d0C0e43731313A708CB607508",
-  314159: "0x136066500b332e7D72643EE7690E9C708702c7e6",
+  314159: "0x2758f99EaB8ea9B8678B5d841851D62Ef18AAB26",
   2481632: "0x77Aa40B105843728088c0132e43FC44348881DA8",
   248163216: "0x77Aa40B105843728088c0132e43FC44348881DA8",
   1942764459484029: "0x77Aa40B105843728088c0132e43FC44348881DA8",
@@ -1352,7 +1352,7 @@ export const gatewayManagerFacetAddress = {
 
 /**
  * -
- * - [__View Contract on Filecoin Calibration Filscan__](https://calibration.filscan.io/address/0x136066500b332e7D72643EE7690E9C708702c7e6)
+ * - [__View Contract on Filecoin Calibration Filscan__](https://calibration.filscan.io/address/0x2758f99EaB8ea9B8678B5d841851D62Ef18AAB26)
  */
 export const gatewayManagerFacetConfig = {
   address: gatewayManagerFacetAddress,
@@ -1406,7 +1406,7 @@ export const iMachineFacadeAbi = [
 
 /**
  * -
- * - [__View Contract on Filecoin Calibration Filscan__](https://calibration.filscan.io/address/0x9E5ea73a639484CcE57F865dC1E582Cd01F3251F)
+ * - [__View Contract on Filecoin Calibration Filscan__](https://calibration.filscan.io/address/0xd1239c6b6f806EC3752df12CEaddD88187BCf1E5)
  */
 export const recallErc20Abi = [
   {
@@ -1508,16 +1508,16 @@ export const recallErc20Abi = [
 
 /**
  * -
- * - [__View Contract on Filecoin Calibration Filscan__](https://calibration.filscan.io/address/0x9E5ea73a639484CcE57F865dC1E582Cd01F3251F)
+ * - [__View Contract on Filecoin Calibration Filscan__](https://calibration.filscan.io/address/0xd1239c6b6f806EC3752df12CEaddD88187BCf1E5)
  */
 export const recallErc20Address = {
   31337: "0x4A679253410272dd5232B3Ff7cF5dbB88f295319",
-  314159: "0x9E5ea73a639484CcE57F865dC1E582Cd01F3251F",
+  314159: "0xd1239c6b6f806EC3752df12CEaddD88187BCf1E5",
 } as const;
 
 /**
  * -
- * - [__View Contract on Filecoin Calibration Filscan__](https://calibration.filscan.io/address/0x9E5ea73a639484CcE57F865dC1E582Cd01F3251F)
+ * - [__View Contract on Filecoin Calibration Filscan__](https://calibration.filscan.io/address/0xd1239c6b6f806EC3752df12CEaddD88187BCf1E5)
  */
 export const recallErc20Config = {
   address: recallErc20Address,
@@ -1530,7 +1530,7 @@ export const recallErc20Config = {
 
 /**
  * -
- * - [__View Contract on Filecoin Calibration Filscan__](https://calibration.filscan.io/address/0xdf3Fe12002826Ff617F2d7500c61B72A8e3E9436)
+ * - [__View Contract on Filecoin Calibration Filscan__](https://calibration.filscan.io/address/0xE8090d55E7ecc0565830845Df67bfD3fA81D4158)
  */
 export const subnetGetterFacetAbi = [
   {
@@ -1661,11 +1661,11 @@ export const subnetGetterFacetAbi = [
 
 /**
  * -
- * - [__View Contract on Filecoin Calibration Filscan__](https://calibration.filscan.io/address/0xdf3Fe12002826Ff617F2d7500c61B72A8e3E9436)
+ * - [__View Contract on Filecoin Calibration Filscan__](https://calibration.filscan.io/address/0xE8090d55E7ecc0565830845Df67bfD3fA81D4158)
  */
 export const subnetGetterFacetAddress = {
   31337: "0x322813Fd9A801c5507c9de605d63CEA4f2CE6c44",
-  314159: "0xdf3Fe12002826Ff617F2d7500c61B72A8e3E9436",
+  314159: "0xE8090d55E7ecc0565830845Df67bfD3fA81D4158",
   2481632: "0x74539671A1D2F1c8f200826bAbA665179F53a1b7",
   248163216: "0x74539671A1D2F1c8f200826bAbA665179F53a1b7",
   1942764459484029: "0x74539671A1D2F1c8f200826bAbA665179F53a1b7",
@@ -1673,7 +1673,7 @@ export const subnetGetterFacetAddress = {
 
 /**
  * -
- * - [__View Contract on Filecoin Calibration Filscan__](https://calibration.filscan.io/address/0xdf3Fe12002826Ff617F2d7500c61B72A8e3E9436)
+ * - [__View Contract on Filecoin Calibration Filscan__](https://calibration.filscan.io/address/0xE8090d55E7ecc0565830845Df67bfD3fA81D4158)
  */
 export const subnetGetterFacetConfig = {
   address: subnetGetterFacetAddress,


### PR DESCRIPTION
the `generate` command has to be manually ran, and not solely `build`—and this didnt happen in https://github.com/recallnet/js-recall/pull/194