### PR TITLE
feat: agent toolkit logic tweaks

### DIFF
--- a/.changeset/common-bags-sink.md
+++ b/.changeset/common-bags-sink.md
@@ -1,0 +1,7 @@
+---
+"@recallnet/agent-toolkit": patch
+"@recallnet/chains": patch
+"@recallnet/mcp": patch
+---
+
+enhance agent toolkit and related packages with get_object & add_object string-only usage

--- a/packages/agent-toolkit/README.md
+++ b/packages/agent-toolkit/README.md
@@ -160,8 +160,8 @@ The `RecallAgentToolkit` exposes the following tools:
 | `buy_credit`           | Buy credit for Recall account                                          |
 | `list_buckets`         | List all buckets owned by an address                                   |
 | `get_or_create_bucket` | Get or create a bucket in Recall                                       |
-| `add_object`           | Add an object to a Recall bucket                                       |
-| `get_object`           | Get an object from a Recall bucket                                     |
+| `add_object`           | Add an object to a Recall bucket (as a string)                         |
+| `get_object`           | Get an object from a Recall bucket (as a string)                       |
 | `query_objects`        | Query objects in a Recall bucket                                       |
 
 Each of these also has a corresponding prompt that is used to generate the tool call. For example, the `get_account_info` tool has the following prompt:
@@ -169,17 +169,19 @@ Each of these also has a corresponding prompt that is used to generate the tool 
 ```ts
 import { getAccountInfoPrompt } from "@recallnet/agent-toolkit/shared";
 
-const prompt = getAccountInfoPrompt;
+const prompt = getAccountInfoPrompt();
 console.log(prompt);
 ```
 
 Frameworks will, generally, see the prompt alongside the tool call, which gives the agent context on what the tool does and the arguments it accepts:
 
 ```txt
-This tool will get account information from Recall, including token $RECALL balances, address, and nonce.
+Gets account information from Recall, including token $RECALL balances, address, and nonce.
 
 Arguments:
 - address (str, optional): The address of the account, else, defaults to the connected user's account address.
+
+Returns the account's balance, address, and nonce information.
 ```
 
 ### Examples
@@ -188,7 +190,7 @@ A few examples of how to use the `RecallAgentToolkit` are available in the [`/ex
 
 1. Clone the repository:
    ```bash
-   git clone https://github.com/recallnet/agent-toolkit
+   git clone https://github.com/recallnet/js-recall
    ```
 2. Install dependencies:
    ```bash
@@ -201,7 +203,7 @@ A few examples of how to use the `RecallAgentToolkit` are available in the [`/ex
 4. Change into the `agent-toolkit`'s `examples` directory and create a `.env` file (based on `.env.example`) with your Recall private key:
 
    ```bash
-   cd packages/agent-toolkit/examples
+   cd js-recall/packages/agent-toolkit/examples
    cp .env.example .env
    ```
 

--- a/packages/agent-toolkit/eslint.config.js
+++ b/packages/agent-toolkit/eslint.config.js
@@ -4,6 +4,14 @@ import { config } from "@recallnet/eslint-config/base";
 export default [
   ...config,
   {
+    rules: {
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        { argsIgnorePattern: "^_" },
+      ],
+    },
+  },
+  {
     ignores: ["examples/**"],
   },
 ];

--- a/packages/agent-toolkit/examples/mcp.ts
+++ b/packages/agent-toolkit/examples/mcp.ts
@@ -136,9 +136,6 @@ export async function main() {
           `Invalid tool: ${tool}. Tool must be in the format of "resource.action".`,
         );
       }
-      if (!configuration.actions) {
-        configuration.actions = {};
-      }
       configuration.actions[resource as Resource] = {
         ...configuration.actions[resource as Resource],
         [action]: true,
@@ -151,9 +148,6 @@ export async function main() {
         throw new Error(
           `Invalid tool: ${tool}. Tool must be in the format of "resource.action".`,
         );
-      }
-      if (!configuration.actions) {
-        configuration.actions = {};
       }
       configuration.actions[resource as Resource] = {
         ...configuration.actions[resource as Resource],

--- a/packages/agent-toolkit/examples/mcp.ts
+++ b/packages/agent-toolkit/examples/mcp.ts
@@ -136,6 +136,9 @@ export async function main() {
           `Invalid tool: ${tool}. Tool must be in the format of "resource.action".`,
         );
       }
+      if (!configuration.actions) {
+        configuration.actions = {};
+      }
       configuration.actions[resource as Resource] = {
         ...configuration.actions[resource as Resource],
         [action]: true,

--- a/packages/agent-toolkit/examples/openai.ts
+++ b/packages/agent-toolkit/examples/openai.ts
@@ -49,7 +49,7 @@ const recallAgentToolkit = new RecallAgentToolkit({
       },
     },
     context: {
-      network: RECALL_NETWORK!,
+      network: RECALL_NETWORK,
     },
   },
 });

--- a/packages/agent-toolkit/package.json
+++ b/packages/agent-toolkit/package.json
@@ -108,6 +108,7 @@
     "@langchain/openai": "^0.4.4",
     "@recallnet/eslint-config": "workspace:*",
     "@recallnet/typescript-config": "workspace:*",
+    "ai": "^4.2.11",
     "dotenv": "^16.4.7",
     "langchain": "^0.3.19",
     "tsup": "^8.3.6",

--- a/packages/agent-toolkit/package.json
+++ b/packages/agent-toolkit/package.json
@@ -80,10 +80,10 @@
     "zod": "^3.24.1"
   },
   "peerDependencies": {
-    "@langchain/core": "^0.3.42",
-    "@modelcontextprotocol/sdk": "^1.7.0",
-    "ai": "^4.1.61",
-    "openai": "^4.87.3",
+    "@langchain/core": "^0.3.44",
+    "@modelcontextprotocol/sdk": "^1.9.0",
+    "ai": "^4.3.4",
+    "openai": "^4.93.0",
     "zod-to-json-schema": "^3.24.4"
   },
   "peerDependenciesMeta": {
@@ -104,13 +104,13 @@
     }
   },
   "devDependencies": {
-    "@ai-sdk/openai": "^1.2.5",
-    "@langchain/openai": "^0.4.4",
+    "@ai-sdk/openai": "^1.3.9",
+    "@langchain/openai": "^0.5.5",
     "@recallnet/eslint-config": "workspace:*",
     "@recallnet/typescript-config": "workspace:*",
-    "ai": "^4.2.11",
+    "ai": "^4.3.4",
     "dotenv": "^16.4.7",
-    "langchain": "^0.3.19",
+    "langchain": "^0.3.21",
     "tsup": "^8.3.6",
     "typescript": "^5.7.3"
   }

--- a/packages/agent-toolkit/src/ai-sdk/toolkit.ts
+++ b/packages/agent-toolkit/src/ai-sdk/toolkit.ts
@@ -22,10 +22,23 @@ import RecallTool from "./tool.js";
  * ```
  */
 export default class RecallAgentToolkit {
+  /**
+   * The Recall API instance used to interact with the Recall network.
+   * @private
+   */
   private _recall: RecallAPI;
 
+  /**
+   * The collection of tools available in this toolkit. Each tool is configured as an
+   * `ai` compatible `Tool`.
+   */
   tools: { [key: string]: CoreTool };
 
+  /**
+   * Create a new RecallAgentToolkit instance.
+   * @param privateKey - The private key of the account to use.
+   * @param configuration - The {@link Configuration} to use.
+   */
   constructor({
     privateKey,
     configuration,

--- a/packages/agent-toolkit/src/ai-sdk/toolkit.ts
+++ b/packages/agent-toolkit/src/ai-sdk/toolkit.ts
@@ -2,7 +2,6 @@ import type { Tool as CoreTool } from "ai";
 
 import RecallAPI from "../shared/api.js";
 import { type Configuration, isToolAllowed } from "../shared/configuration.js";
-import { tools } from "../shared/tools.js";
 import RecallTool from "./tool.js";
 
 /**
@@ -37,9 +36,9 @@ export default class RecallAgentToolkit {
     this._recall = new RecallAPI(privateKey, configuration.context);
     this.tools = {};
 
-    const filteredTools = tools(configuration.context).filter((tool) =>
-      isToolAllowed(tool, configuration),
-    );
+    const filteredTools = this._recall
+      .getTools()
+      .filter((tool) => isToolAllowed(tool, configuration));
 
     filteredTools.forEach((tool) => {
       this.tools[tool.method] = RecallTool(

--- a/packages/agent-toolkit/src/ai-sdk/toolkit.ts
+++ b/packages/agent-toolkit/src/ai-sdk/toolkit.ts
@@ -37,7 +37,7 @@ export default class RecallAgentToolkit {
     this._recall = new RecallAPI(privateKey, configuration.context);
     this.tools = {};
 
-    const filteredTools = tools.filter((tool) =>
+    const filteredTools = tools(configuration.context).filter((tool) =>
       isToolAllowed(tool, configuration),
     );
 

--- a/packages/agent-toolkit/src/langchain/tool.ts
+++ b/packages/agent-toolkit/src/langchain/tool.ts
@@ -38,9 +38,7 @@ class RecallTool extends StructuredTool {
 
   _call(
     arg: z.output<typeof this.schema>,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     _runManager?: CallbackManagerForToolRun,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     _parentConfig?: RunnableConfig,
   ): Promise<string> {
     return this._recall.run(this.method, arg);

--- a/packages/agent-toolkit/src/langchain/toolkit.ts
+++ b/packages/agent-toolkit/src/langchain/toolkit.ts
@@ -36,7 +36,7 @@ export default class RecallAgentToolkit implements BaseToolkit {
   }) {
     this._recall = new RecallAPI(privateKey, configuration.context);
 
-    const filteredTools = tools.filter((tool) =>
+    const filteredTools = tools(configuration.context).filter((tool) =>
       isToolAllowed(tool, configuration),
     );
 

--- a/packages/agent-toolkit/src/langchain/toolkit.ts
+++ b/packages/agent-toolkit/src/langchain/toolkit.ts
@@ -22,10 +22,23 @@ import RecallTool from "./tool.js";
  * ```
  */
 export default class RecallAgentToolkit implements BaseToolkit {
+  /**
+   * The Recall API instance used to interact with the Recall network.
+   * @private
+   */
   private _recall: RecallAPI;
 
+  /**
+   * The collection of tools available in this toolkit. Each tool is configured as a
+   * LangChain `StructuredTool` that can be used in function calling scenarios.
+   */
   tools: RecallTool[];
 
+  /**
+   * Create a new RecallAgentToolkit instance.
+   * @param privateKey - The private key of the account to use.
+   * @param configuration - The {@link Configuration} to use.
+   */
   constructor({
     privateKey,
     configuration,

--- a/packages/agent-toolkit/src/langchain/toolkit.ts
+++ b/packages/agent-toolkit/src/langchain/toolkit.ts
@@ -2,7 +2,6 @@ import { BaseToolkit } from "@langchain/core/tools";
 
 import RecallAPI from "../shared/api.js";
 import { type Configuration, isToolAllowed } from "../shared/configuration.js";
-import { tools } from "../shared/tools.js";
 import RecallTool from "./tool.js";
 
 /**
@@ -36,9 +35,9 @@ export default class RecallAgentToolkit implements BaseToolkit {
   }) {
     this._recall = new RecallAPI(privateKey, configuration.context);
 
-    const filteredTools = tools(configuration.context).filter((tool) =>
-      isToolAllowed(tool, configuration),
-    );
+    const filteredTools = this._recall
+      .getTools()
+      .filter((tool) => isToolAllowed(tool, configuration));
 
     this.tools = filteredTools.map(
       (tool) =>

--- a/packages/agent-toolkit/src/mcp/toolkit.ts
+++ b/packages/agent-toolkit/src/mcp/toolkit.ts
@@ -63,7 +63,6 @@ export default class RecallAgentToolkit extends McpServer {
         tool.parameters.shape,
         async (
           arg: z.infer<typeof tool.parameters>,
-          // eslint-disable-next-line @typescript-eslint/no-unused-vars
           _extra: RequestHandlerExtra,
         ) => {
           const result = await this._recall.run(tool.method, arg);

--- a/packages/agent-toolkit/src/mcp/toolkit.ts
+++ b/packages/agent-toolkit/src/mcp/toolkit.ts
@@ -52,7 +52,7 @@ export default class RecallAgentToolkit extends McpServer {
 
     this._recall = new RecallAPI(privateKey, configuration.context);
 
-    const filteredTools = tools.filter((tool) =>
+    const filteredTools = tools(configuration.context).filter((tool) =>
       isToolAllowed(tool, configuration),
     );
 

--- a/packages/agent-toolkit/src/mcp/toolkit.ts
+++ b/packages/agent-toolkit/src/mcp/toolkit.ts
@@ -4,7 +4,6 @@ import { z } from "zod";
 
 import RecallAPI from "../shared/api.js";
 import { Configuration, isToolAllowed } from "../shared/configuration.js";
-import { tools } from "../shared/tools.js";
 
 /**
  * Recall agent toolkit for the Model Context Protocol.
@@ -52,9 +51,9 @@ export default class RecallAgentToolkit extends McpServer {
 
     this._recall = new RecallAPI(privateKey, configuration.context);
 
-    const filteredTools = tools(configuration.context).filter((tool) =>
-      isToolAllowed(tool, configuration),
-    );
+    const filteredTools = this._recall
+      .getTools()
+      .filter((tool) => isToolAllowed(tool, configuration));
 
     filteredTools.forEach((tool) => {
       this.tool(

--- a/packages/agent-toolkit/src/mcp/toolkit.ts
+++ b/packages/agent-toolkit/src/mcp/toolkit.ts
@@ -29,6 +29,10 @@ import { Configuration, isToolAllowed } from "../shared/configuration.js";
  * ```
  */
 export default class RecallAgentToolkit extends McpServer {
+  /**
+   * The Recall API instance used to interact with the Recall network.
+   * @private
+   */
   private _recall: RecallAPI;
 
   /**

--- a/packages/agent-toolkit/src/openai/toolkit.ts
+++ b/packages/agent-toolkit/src/openai/toolkit.ts
@@ -26,7 +26,16 @@ import { type Configuration, isToolAllowed } from "../shared/configuration.js";
  * ```
  */
 export default class RecallAgentToolkit {
+  /**
+   * The Recall API instance used to interact with the Recall network.
+   * @private
+   */
   private _recall: RecallAPI;
+
+  /**
+   * The collection of tools available in this toolkit. Each tool is configured as an OpenAI
+   * `ChatCompletionTool` that can be used in function calling scenarios.
+   */
   tools: ChatCompletionTool[];
 
   /**

--- a/packages/agent-toolkit/src/openai/toolkit.ts
+++ b/packages/agent-toolkit/src/openai/toolkit.ts
@@ -14,7 +14,7 @@ import { tools } from "../shared/tools.js";
  * @example
  * ```ts
  * const toolkit = new RecallAgentToolkit({
- *   secretKey: "0x...",
+ *   privateKey: "0x...",
  *   configuration: {
  *     actions: {
  *       account: {
@@ -44,7 +44,7 @@ export default class RecallAgentToolkit {
   }) {
     this._recall = new RecallAPI(privateKey, configuration.context);
 
-    const filteredTools = tools.filter((tool) =>
+    const filteredTools = tools(configuration.context).filter((tool) =>
       isToolAllowed(tool, configuration),
     );
 
@@ -69,13 +69,15 @@ export default class RecallAgentToolkit {
    * @returns A promise that resolves to a tool message object containing the result of the tool
    * execution with the proper format for the OpenAI API
    */
-  async handleToolCall(toolCall: ChatCompletionMessageToolCall) {
+  async handleToolCall(
+    toolCall: ChatCompletionMessageToolCall,
+  ): Promise<ChatCompletionToolMessageParam> {
     const args = JSON.parse(toolCall.function.arguments);
     const response = await this._recall.run(toolCall.function.name, args);
     return {
       role: "tool",
       tool_call_id: toolCall.id,
       content: response,
-    } as ChatCompletionToolMessageParam;
+    };
   }
 }

--- a/packages/agent-toolkit/src/openai/toolkit.ts
+++ b/packages/agent-toolkit/src/openai/toolkit.ts
@@ -7,7 +7,6 @@ import { zodToJsonSchema } from "zod-to-json-schema";
 
 import RecallAPI from "../shared/api.js";
 import { type Configuration, isToolAllowed } from "../shared/configuration.js";
-import { tools } from "../shared/tools.js";
 
 /**
  * An OpenAI compatible toolkit for the Recall agent.
@@ -44,9 +43,9 @@ export default class RecallAgentToolkit {
   }) {
     this._recall = new RecallAPI(privateKey, configuration.context);
 
-    const filteredTools = tools(configuration.context).filter((tool) =>
-      isToolAllowed(tool, configuration),
-    );
+    const filteredTools = this._recall
+      .getTools()
+      .filter((tool) => isToolAllowed(tool, configuration));
 
     this.tools = filteredTools.map((tool) => ({
       type: "function",

--- a/packages/agent-toolkit/src/shared/api.ts
+++ b/packages/agent-toolkit/src/shared/api.ts
@@ -56,6 +56,14 @@ export default class RecallAPI {
   }
 
   /**
+   * Get the tools available to the `RecallAPI` instance.
+   * @returns The tools available to the `RecallAPI` instance.
+   */
+  getTools() {
+    return this._tools;
+  }
+
+  /**
    * Run a method on the Recall network.
    * @param method - The method to run.
    * @param arg - The arguments to pass to the method.

--- a/packages/agent-toolkit/src/shared/api.ts
+++ b/packages/agent-toolkit/src/shared/api.ts
@@ -53,8 +53,7 @@ export default class RecallAPI {
     serializer: (data: unknown) => string = jsonStringify,
   ) {
     const chain =
-      context?.network !== undefined &&
-      checkChainName(context.network as ChainName)
+      context?.network !== undefined && checkChainName(context.network)
         ? getChain(context.network as ChainName)
         : testnet;
     const walletClient = walletClientFromPrivateKey(privateKey as Hex, chain);

--- a/packages/agent-toolkit/src/shared/configuration.ts
+++ b/packages/agent-toolkit/src/shared/configuration.ts
@@ -5,8 +5,7 @@ import type { Tool } from "./tools.js";
  * action called `bucket.read` will only be allowed if a tool has defined the `bucket` as its
  * resource and has the `read` permission set.
  */
-// TODO: implement documentation resource
-export type Resource = "account" | "bucket" /*| "documentation"*/;
+export type Resource = "account" | "bucket";
 
 /**
  * Permissions are used alongside resources to restrict how a tool can be used. Write operations
@@ -54,7 +53,7 @@ export type Context = {
  */
 export type Configuration = {
   actions: Actions;
-  context: Context;
+  context?: Context;
 };
 
 /**

--- a/packages/agent-toolkit/src/shared/functions.ts
+++ b/packages/agent-toolkit/src/shared/functions.ts
@@ -27,7 +27,7 @@ import { Result } from "./util.js";
 export const getAccountInfo = async (
   recall: RecallClient,
   context: Context,
-  params: z.infer<typeof getAccountInfoParameters>,
+  params: z.infer<ReturnType<typeof getAccountInfoParameters>>,
 ): Promise<Result<AccountInfo>> => {
   try {
     const address = params.address ? (params.address as Address) : undefined;
@@ -57,7 +57,7 @@ export const getAccountInfo = async (
 export const listBuckets = async (
   recall: RecallClient,
   context: Context,
-  params: z.infer<typeof listBucketsParameters>,
+  params: z.infer<ReturnType<typeof listBucketsParameters>>,
 ): Promise<Result<ListResult>> => {
   try {
     const address = params.address ? (params.address as Address) : undefined;
@@ -87,7 +87,7 @@ export const listBuckets = async (
 export const getCreditInfo = async (
   recall: RecallClient,
   context: Context,
-  params: z.infer<typeof getCreditInfoParameters>,
+  params: z.infer<ReturnType<typeof getCreditInfoParameters>>,
 ): Promise<Result<CreditAccount>> => {
   try {
     const address = params.address ? (params.address as Address) : undefined;
@@ -117,7 +117,7 @@ export const getCreditInfo = async (
 export const buyCredit = async (
   recall: RecallClient,
   context: Context,
-  params: z.infer<typeof buyCreditParameters>,
+  params: z.infer<ReturnType<typeof buyCreditParameters>>,
 ): Promise<Result<string>> => {
   try {
     const to = params.to ? (params.to as Address) : undefined;
@@ -146,7 +146,7 @@ export const buyCredit = async (
 export const createBucket = async (
   recall: RecallClient,
   context: Context,
-  params: z.infer<typeof createBucketParameters>,
+  params: z.infer<ReturnType<typeof createBucketParameters>>,
 ): Promise<Result<{ bucket: Address; txHash: string }>> => {
   try {
     const metadata = params.metadata ?? {};
@@ -181,7 +181,7 @@ export const createBucket = async (
 export const getOrCreateBucket = async (
   recall: RecallClient,
   context: Context,
-  params: z.infer<typeof getOrCreateBucketParameters>,
+  params: z.infer<ReturnType<typeof getOrCreateBucketParameters>>,
 ): Promise<Result<{ bucket: Address; tx: string }>> => {
   try {
     // Try to find the bucket by alias
@@ -228,7 +228,7 @@ export const getOrCreateBucket = async (
 export const addObject = async (
   recall: RecallClient,
   context: Context,
-  params: z.infer<typeof addObjectParameters>,
+  params: z.infer<ReturnType<typeof addObjectParameters>>,
 ): Promise<Result<{ txHash: string }>> => {
   try {
     const metadata = params.metadata ?? {};
@@ -265,7 +265,7 @@ export const addObject = async (
 export const getObject = async (
   recall: RecallClient,
   context: Context,
-  params: z.infer<typeof getObjectParameters>,
+  params: z.infer<ReturnType<typeof getObjectParameters>>,
 ): Promise<Result<string | Uint8Array>> => {
   try {
     const { result } = await recall
@@ -297,7 +297,7 @@ export const getObject = async (
 export const queryObjects = async (
   recall: RecallClient,
   context: Context,
-  params: z.infer<typeof queryObjectsParameters>,
+  params: z.infer<ReturnType<typeof queryObjectsParameters>>,
 ): Promise<Result<QueryResult>> => {
   try {
     const { result } = await recall

--- a/packages/agent-toolkit/src/shared/functions.ts
+++ b/packages/agent-toolkit/src/shared/functions.ts
@@ -22,6 +22,9 @@ import { Result } from "./util.js";
 
 /**
  * Gets the account information for the current user.
+ * @param recall - The Recall client.
+ * @param _context - The context to provide to the function.
+ * @param params - The function parameters.
  * @returns The account information.
  */
 export const getAccountInfo = async (
@@ -52,6 +55,9 @@ export const getAccountInfo = async (
 
 /**
  * Lists all buckets for the current user.
+ * @param recall - The Recall client.
+ * @param _context - The context to provide to the function.
+ * @param params - The function parameters.
  * @returns The list of buckets.
  */
 export const listBuckets = async (
@@ -82,6 +88,9 @@ export const listBuckets = async (
 
 /**
  * Gets the credit information for the current user.
+ * @param recall - The Recall client.
+ * @param _context - The context to provide to the function.
+ * @param params - The function parameters.
  * @returns The credit information.
  */
 export const getCreditInfo = async (
@@ -112,6 +121,9 @@ export const getCreditInfo = async (
 
 /**
  * Buys credit for the current user.
+ * @param recall - The Recall client.
+ * @param _context - The context to provide to the function.
+ * @param params - The function parameters.
  * @returns The transaction hash of the credit purchase.
  */
 export const buyCredit = async (
@@ -141,6 +153,9 @@ export const buyCredit = async (
 
 /**
  * Creates a new bucket for the current user.
+ * @param recall - The Recall client.
+ * @param _context - The context to provide to the function.
+ * @param params - The function parameters.
  * @returns The bucket address and transaction hash.
  */
 export const createBucket = async (
@@ -176,6 +191,9 @@ export const createBucket = async (
 
 /**
  * Gets or creates a bucket for the current user.
+ * @param recall - The Recall client.
+ * @param _context - The context to provide to the function.
+ * @param params - The function parameters.
  * @returns The bucket address and transaction hash.
  */
 export const getOrCreateBucket = async (
@@ -223,6 +241,9 @@ export const getOrCreateBucket = async (
 
 /**
  * Adds an object to a bucket.
+ * @param recall - The Recall client.
+ * @param _context - The context to provide to the function.
+ * @param params - The function parameters.
  * @returns The transaction hash of the object addition.
  */
 export const addObject = async (
@@ -260,6 +281,9 @@ export const addObject = async (
 
 /**
  * Gets an object from a bucket.
+ * @param recall - The Recall client.
+ * @param _context - The context to provide to the function.
+ * @param params - The function parameters.
  * @returns The object.
  */
 export const getObject = async (
@@ -292,6 +316,9 @@ export const getObject = async (
 
 /**
  * Queries objects in a bucket.
+ * @param recall - The Recall client.
+ * @param _context - The context to provide to the function.
+ * @param params - The function parameters.
  * @returns The query result.
  */
 export const queryObjects = async (

--- a/packages/agent-toolkit/src/shared/functions.ts
+++ b/packages/agent-toolkit/src/shared/functions.ts
@@ -26,7 +26,7 @@ import { Result } from "./util.js";
  */
 export const getAccountInfo = async (
   recall: RecallClient,
-  context: Context,
+  _context: Context,
   params: z.infer<ReturnType<typeof getAccountInfoParameters>>,
 ): Promise<Result<AccountInfo>> => {
   try {
@@ -56,7 +56,7 @@ export const getAccountInfo = async (
  */
 export const listBuckets = async (
   recall: RecallClient,
-  context: Context,
+  _context: Context,
   params: z.infer<ReturnType<typeof listBucketsParameters>>,
 ): Promise<Result<ListResult>> => {
   try {
@@ -86,7 +86,7 @@ export const listBuckets = async (
  */
 export const getCreditInfo = async (
   recall: RecallClient,
-  context: Context,
+  _context: Context,
   params: z.infer<ReturnType<typeof getCreditInfoParameters>>,
 ): Promise<Result<CreditAccount>> => {
   try {
@@ -116,7 +116,7 @@ export const getCreditInfo = async (
  */
 export const buyCredit = async (
   recall: RecallClient,
-  context: Context,
+  _context: Context,
   params: z.infer<ReturnType<typeof buyCreditParameters>>,
 ): Promise<Result<string>> => {
   try {
@@ -145,7 +145,7 @@ export const buyCredit = async (
  */
 export const createBucket = async (
   recall: RecallClient,
-  context: Context,
+  _context: Context,
   params: z.infer<ReturnType<typeof createBucketParameters>>,
 ): Promise<Result<{ bucket: Address; txHash: string }>> => {
   try {
@@ -180,7 +180,7 @@ export const createBucket = async (
  */
 export const getOrCreateBucket = async (
   recall: RecallClient,
-  context: Context,
+  _context: Context,
   params: z.infer<ReturnType<typeof getOrCreateBucketParameters>>,
 ): Promise<Result<{ bucket: Address; tx: string }>> => {
   try {
@@ -227,7 +227,7 @@ export const getOrCreateBucket = async (
  */
 export const addObject = async (
   recall: RecallClient,
-  context: Context,
+  _context: Context,
   params: z.infer<ReturnType<typeof addObjectParameters>>,
 ): Promise<Result<{ txHash: string }>> => {
   try {
@@ -264,7 +264,7 @@ export const addObject = async (
  */
 export const getObject = async (
   recall: RecallClient,
-  context: Context,
+  _context: Context,
   params: z.infer<ReturnType<typeof getObjectParameters>>,
 ): Promise<Result<string | Uint8Array>> => {
   try {
@@ -296,7 +296,7 @@ export const getObject = async (
  */
 export const queryObjects = async (
   recall: RecallClient,
-  context: Context,
+  _context: Context,
   params: z.infer<ReturnType<typeof queryObjectsParameters>>,
 ): Promise<Result<QueryResult>> => {
   try {

--- a/packages/agent-toolkit/src/shared/index.ts
+++ b/packages/agent-toolkit/src/shared/index.ts
@@ -40,6 +40,7 @@ import {
   listBucketsPrompt,
   queryObjectsPrompt,
 } from "./prompts.js";
+import { Tool, tools } from "./tools.js";
 import { Result } from "./util.js";
 
 export {
@@ -72,10 +73,12 @@ export {
   queryObjectsParameters,
   queryObjectsPrompt,
   isToolAllowed,
-  type Configuration,
-  type Resource,
-  type Permission,
+  tools,
   type Actions,
+  type Configuration,
   type Context,
+  type Permission,
+  type Resource,
   type Result,
+  type Tool,
 };

--- a/packages/agent-toolkit/src/shared/parameters.ts
+++ b/packages/agent-toolkit/src/shared/parameters.ts
@@ -11,7 +11,6 @@ const addressSchema = z.string().regex(/^0x[a-fA-F0-9]{40}$/);
  * Parameters for the getAccountInfo function
  * @param address - The address of the account to get account info for (optional)
  */
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export const getAccountInfoParameters = (_context: Context = {}) =>
   z.object({
     address: addressSchema
@@ -23,7 +22,6 @@ export const getAccountInfoParameters = (_context: Context = {}) =>
  * Parameters for the listBuckets function
  * @param address - The address of the account to list buckets for (optional)
  */
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export const listBucketsParameters = (_context: Context = {}) =>
   z.object({
     address: addressSchema
@@ -37,7 +35,6 @@ export const listBucketsParameters = (_context: Context = {}) =>
  * Parameters for the getCreditInfo function
  * @param address - The address of the account to get credit info for (optional)
  */
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export const getCreditInfoParameters = (_context: Context = {}) =>
   z.object({
     address: addressSchema
@@ -50,7 +47,6 @@ export const getCreditInfoParameters = (_context: Context = {}) =>
  * @param amount - The amount of credit to buy
  * @param to - The address of the account to buy credit for (optional)
  */
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export const buyCreditParameters = (_context: Context = {}) =>
   z.object({
     amount: z.string().min(1).describe("The amount of credit to buy"),
@@ -66,7 +62,6 @@ export const buyCreditParameters = (_context: Context = {}) =>
  * @param bucketAlias - The alias of the bucket to create
  * @param metadata - The metadata to store with the bucket (optional)
  */
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export const createBucketParameters = (_context: Context = {}) =>
   z.object({
     bucketAlias: z
@@ -87,7 +82,6 @@ export const createBucketParameters = (_context: Context = {}) =>
  * @param bucketAlias - The alias of the bucket to retrieve or create
  * @param metadata - The metadata to store with the bucket (optional)
  */
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export const getOrCreateBucketParameters = (_context: Context = {}) =>
   z.object({
     bucketAlias: z
@@ -110,7 +104,6 @@ export const getOrCreateBucketParameters = (_context: Context = {}) =>
  * @param metadata - The metadata to store with the object
  * @param overwrite - Whether to overwrite existing data at that key
  */
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export const addObjectParameters = (_context: Context = {}) =>
   z.object({
     bucket: addressSchema.describe("The address of the bucket"),
@@ -137,7 +130,6 @@ export const addObjectParameters = (_context: Context = {}) =>
  * @param key - The key under which the object is stored
  * @param outputType - The type of the output (default: string)
  */
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export const getObjectParameters = (_context: Context = {}) =>
   z.object({
     bucket: addressSchema.describe("The address of the bucket"),
@@ -156,7 +148,6 @@ export const getObjectParameters = (_context: Context = {}) =>
  * @param startKey - The starting key of the objects to query (optional)
  * @param limit - The maximum number of objects to query (optional)
  */
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export const queryObjectsParameters = (_context: Context = {}) =>
   z.object({
     bucket: addressSchema.describe("The address of the bucket"),

--- a/packages/agent-toolkit/src/shared/parameters.ts
+++ b/packages/agent-toolkit/src/shared/parameters.ts
@@ -100,7 +100,7 @@ export const getOrCreateBucketParameters = (_context: Context = {}) =>
  * Parameters for the addObject function
  * @param bucket - The address of the bucket
  * @param key - The key under which to store the object
- * @param data - The data to store as a string, File, or Uint8Array
+ * @param data - The data to store as a string value
  * @param metadata - The metadata to store with the object
  * @param overwrite - Whether to overwrite existing data at that key
  */
@@ -108,9 +108,7 @@ export const addObjectParameters = (_context: Context = {}) =>
   z.object({
     bucket: addressSchema.describe("The address of the bucket"),
     key: z.string().min(1).describe("The key under which to store the object"),
-    data: z
-      .union([z.string(), z.instanceof(File), z.instanceof(Uint8Array)])
-      .describe("The data to store as a string, File, or Uint8Array value"),
+    data: z.string().describe("The data to store as a string value"),
     metadata: z
       .record(
         z.string().min(1).describe("The key of the metadata"),
@@ -128,16 +126,11 @@ export const addObjectParameters = (_context: Context = {}) =>
  * Parameters for the getObject function
  * @param bucket - The address of the bucket
  * @param key - The key under which the object is stored
- * @param outputType - The type of the output (default: string)
  */
 export const getObjectParameters = (_context: Context = {}) =>
   z.object({
     bucket: addressSchema.describe("The address of the bucket"),
     key: z.string().min(1).describe("The key under which the object is stored"),
-    outputType: z
-      .enum(["string", "uint8array"])
-      .optional()
-      .describe("The type of the output (default: string)"),
   });
 
 /**

--- a/packages/agent-toolkit/src/shared/parameters.ts
+++ b/packages/agent-toolkit/src/shared/parameters.ts
@@ -1,5 +1,7 @@
 import { z } from "zod";
 
+import { Context } from "./configuration.js";
+
 /**
  * EVM hex string address (e.g., accounts or buckets).
  */
@@ -9,81 +11,96 @@ const addressSchema = z.string().regex(/^0x[a-fA-F0-9]{40}$/);
  * Parameters for the getAccountInfo function
  * @param address - The address of the account to get account info for (optional)
  */
-export const getAccountInfoParameters = z.object({
-  address: addressSchema
-    .optional()
-    .describe("The address of the account (EVM hex string address)"),
-});
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export const getAccountInfoParameters = (_context: Context = {}) =>
+  z.object({
+    address: addressSchema
+      .optional()
+      .describe("The address of the account (EVM hex string address)"),
+  });
 
 /**
  * Parameters for the listBuckets function
  * @param address - The address of the account to list buckets for (optional)
  */
-export const listBucketsParameters = z.object({
-  address: addressSchema
-    .optional()
-    .describe(
-      "The address of the account to list buckets for (EVM hex string address)",
-    ),
-});
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export const listBucketsParameters = (_context: Context = {}) =>
+  z.object({
+    address: addressSchema
+      .optional()
+      .describe(
+        "The address of the account to list buckets for (EVM hex string address)",
+      ),
+  });
 
 /**
  * Parameters for the getCreditInfo function
  * @param address - The address of the account to get credit info for (optional)
  */
-export const getCreditInfoParameters = z.object({
-  address: addressSchema
-    .optional()
-    .describe("The address of the account (EVM hex string address)"),
-});
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export const getCreditInfoParameters = (_context: Context = {}) =>
+  z.object({
+    address: addressSchema
+      .optional()
+      .describe("The address of the account (EVM hex string address)"),
+  });
 
 /**
  * Parameters for the buyCredit function
  * @param amount - The amount of credit to buy
  * @param to - The address of the account to buy credit for (optional)
  */
-export const buyCreditParameters = z.object({
-  amount: z.string().min(1).describe("The amount of credit to buy"),
-  to: addressSchema
-    .optional()
-    .describe(
-      "The address of the account to buy credit for (EVM hex string address)",
-    ),
-});
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export const buyCreditParameters = (_context: Context = {}) =>
+  z.object({
+    amount: z.string().min(1).describe("The amount of credit to buy"),
+    to: addressSchema
+      .optional()
+      .describe(
+        "The address of the account to buy credit for (EVM hex string address)",
+      ),
+  });
 
 /**
  * Parameters for the createBucket function
  * @param bucketAlias - The alias of the bucket to create
  * @param metadata - The metadata to store with the bucket (optional)
  */
-export const createBucketParameters = z.object({
-  bucketAlias: z.string().min(1).describe("The alias of the bucket to create"),
-  metadata: z
-    .record(
-      z.string().min(1).describe("The key of the metadata"),
-      z.string().min(1).describe("The value of the metadata"),
-    )
-    .optional()
-    .describe("The metadata to store with the bucket"),
-});
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export const createBucketParameters = (_context: Context = {}) =>
+  z.object({
+    bucketAlias: z
+      .string()
+      .min(1)
+      .describe("The alias of the bucket to create"),
+    metadata: z
+      .record(
+        z.string().min(1).describe("The key of the metadata"),
+        z.string().min(1).describe("The value of the metadata"),
+      )
+      .optional()
+      .describe("The metadata to store with the bucket"),
+  });
 
 /**
  * Parameters for the getOrCreateBucket function
  * @param bucketAlias - The alias of the bucket to retrieve or create
  * @param metadata - The metadata to store with the bucket (optional)
  */
-export const getOrCreateBucketParameters = z.object({
-  bucketAlias: z
-    .string()
-    .describe("The alias of the bucket to retrieve or create"),
-  metadata: z
-    .record(
-      z.string().min(1).describe("The key of the metadata"),
-      z.string().min(1).describe("The value of the metadata"),
-    )
-    .optional()
-    .describe("The metadata to store with the bucket"),
-});
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export const getOrCreateBucketParameters = (_context: Context = {}) =>
+  z.object({
+    bucketAlias: z
+      .string()
+      .describe("The alias of the bucket to retrieve or create"),
+    metadata: z
+      .record(
+        z.string().min(1).describe("The key of the metadata"),
+        z.string().min(1).describe("The value of the metadata"),
+      )
+      .optional()
+      .describe("The metadata to store with the bucket"),
+  });
 
 /**
  * Parameters for the addObject function
@@ -93,24 +110,26 @@ export const getOrCreateBucketParameters = z.object({
  * @param metadata - The metadata to store with the object
  * @param overwrite - Whether to overwrite existing data at that key
  */
-export const addObjectParameters = z.object({
-  bucket: addressSchema.describe("The address of the bucket"),
-  key: z.string().min(1).describe("The key under which to store the object"),
-  data: z
-    .union([z.string(), z.instanceof(File), z.instanceof(Uint8Array)])
-    .describe("The data to store as a string, File, or Uint8Array value"),
-  metadata: z
-    .record(
-      z.string().min(1).describe("The key of the metadata"),
-      z.string().min(1).describe("The value of the metadata"),
-    )
-    .optional()
-    .describe("The metadata to store with the object"),
-  overwrite: z
-    .boolean()
-    .optional()
-    .describe("Whether to overwrite existing data at that key"),
-});
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export const addObjectParameters = (_context: Context = {}) =>
+  z.object({
+    bucket: addressSchema.describe("The address of the bucket"),
+    key: z.string().min(1).describe("The key under which to store the object"),
+    data: z
+      .union([z.string(), z.instanceof(File), z.instanceof(Uint8Array)])
+      .describe("The data to store as a string, File, or Uint8Array value"),
+    metadata: z
+      .record(
+        z.string().min(1).describe("The key of the metadata"),
+        z.string().min(1).describe("The value of the metadata"),
+      )
+      .optional()
+      .describe("The metadata to store with the object"),
+    overwrite: z
+      .boolean()
+      .optional()
+      .describe("Whether to overwrite existing data at that key"),
+  });
 
 /**
  * Parameters for the getObject function
@@ -118,14 +137,16 @@ export const addObjectParameters = z.object({
  * @param key - The key under which the object is stored
  * @param outputType - The type of the output (default: string)
  */
-export const getObjectParameters = z.object({
-  bucket: addressSchema.describe("The address of the bucket"),
-  key: z.string().min(1).describe("The key under which the object is stored"),
-  outputType: z
-    .enum(["string", "uint8array"])
-    .optional()
-    .describe("The type of the output (default: string)"),
-});
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export const getObjectParameters = (_context: Context = {}) =>
+  z.object({
+    bucket: addressSchema.describe("The address of the bucket"),
+    key: z.string().min(1).describe("The key under which the object is stored"),
+    outputType: z
+      .enum(["string", "uint8array"])
+      .optional()
+      .describe("The type of the output (default: string)"),
+  });
 
 /**
  * Parameters for the queryObjects function
@@ -135,26 +156,28 @@ export const getObjectParameters = z.object({
  * @param startKey - The starting key of the objects to query (optional)
  * @param limit - The maximum number of objects to query (optional)
  */
-export const queryObjectsParameters = z.object({
-  bucket: addressSchema.describe("The address of the bucket"),
-  prefix: z
-    .string()
-    .min(1)
-    .optional()
-    .describe("The prefix of the objects to query"),
-  delimiter: z
-    .string()
-    .min(1)
-    .optional()
-    .describe("The delimiter of the objects to query"),
-  startKey: z
-    .string()
-    .min(1)
-    .optional()
-    .describe("The starting key of the objects to query"),
-  limit: z
-    .number()
-    .min(1)
-    .optional()
-    .describe("The maximum number of objects to query"),
-});
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export const queryObjectsParameters = (_context: Context = {}) =>
+  z.object({
+    bucket: addressSchema.describe("The address of the bucket"),
+    prefix: z
+      .string()
+      .min(1)
+      .optional()
+      .describe("The prefix of the objects to query"),
+    delimiter: z
+      .string()
+      .min(1)
+      .optional()
+      .describe("The delimiter of the objects to query"),
+    startKey: z
+      .string()
+      .min(1)
+      .optional()
+      .describe("The starting key of the objects to query"),
+    limit: z
+      .number()
+      .min(1)
+      .optional()
+      .describe("The maximum number of objects to query"),
+  });

--- a/packages/agent-toolkit/src/shared/prompts.ts
+++ b/packages/agent-toolkit/src/shared/prompts.ts
@@ -5,10 +5,12 @@ import { Context } from "./configuration.js";
  * @returns The prompt for getting account info
  */
 export const getAccountInfoPrompt = (_context: Context = {}) => `
-This tool will get account information from Recall, including token $RECALL balances, address, and nonce.
+Gets account information from Recall, including token $RECALL balances, address, and nonce.
 
 Arguments:
 - address (str, optional): The address of the account, else, defaults to the connected user's account address.
+
+Returns the account's balance, address and nonce information. 
 `;
 
 /**
@@ -20,6 +22,8 @@ Lists all buckets owned by the connected account in Recall.
 
 Arguments:
 - owner (str, optional): The address of the account, else, defaults to the connected user's account address.
+
+Returns an array of buckets, each containing the bucket's address and metadata (which includes the alias, if present).
 `;
 
 /**
@@ -31,6 +35,8 @@ Gets the credit information for the connected account.
 
 Arguments:
 - address (str, optional): The address of the account, else, defaults to the connected user's account address.
+
+Returns the account's credit balance and credit approval information (used for access control).
 `;
 
 /**
@@ -38,11 +44,13 @@ Arguments:
  * @returns The prompt for buying credit
  */
 export const buyCreditPrompt = (_context: Context = {}) => `
-Buys credit for the connected account.
+Buys credit for the connected account. Use this to purchase storage and computation credits.
 
 Arguments:
-- amount (str): The amount of credit to buy in ETH.
+- amount (str): The amount of credit to buy (denominated in RECALL tokens).
 - to (str, optional): The address of the account to buy credit for, else, defaults to the connected user's account address.
+
+Returns a transaction hash confirming the credit purchase.
 `;
 
 /**
@@ -50,10 +58,12 @@ Arguments:
  * @returns The prompt for creating bucket
  */
 export const createBucketPrompt = (_context: Context = {}) => `
-Creates a new bucket in Recall.
+Creates a new bucket in Recall. Buckets are containers for storing objects and data.
 
 Arguments:
-- bucketAlias (str): The alias to assign to the new bucket.
+- bucketAlias (str): The alias to assign to the new bucket. Choose a descriptive name for your use case.
+
+Returns the new bucket's address (unique identifier) and the transaction hash at which it was created.
 `;
 
 /**
@@ -61,10 +71,12 @@ Arguments:
  * @returns The prompt for getting or creating bucket
  */
 export const getOrCreateBucketPrompt = (_context: Context = {}) => `
-Gets an existing bucket by alias or creates a new one if it doesn't exist.
+Gets an existing bucket by alias, or creates a new one if it doesn't exist. Use this to ensure you have a bucket for storage.
 
 Arguments:
 - bucketAlias (str): The alias of the bucket to retrieve or create.
+
+Returns the bucket's address (unique identifier) and the transaction hash at which it was created.
 `;
 
 /**
@@ -72,13 +84,15 @@ Arguments:
  * @returns The prompt for adding object
  */
 export const addObjectPrompt = (_context: Context = {}) => `
-Adds an object to a bucket in Recall.
+Adds an object to a bucket in Recall. Use this to store data like files, JSON, or raw bytes.
 
 Arguments:
 - bucket (str): The address of the bucket (EVM hex string address).
-- key (str): The key under which to store the object.
-- data (str | Uint8Array): The data to store.
+- key (str): The key under which to store the object. Use a descriptive path-like structure (e.g. "users/profile/avatar.jpg").
+- data (str | Uint8Array): The data to store. Can be a string or binary data.
 - overwrite (bool, optional): Whether to overwrite existing data. Defaults to false.
+
+Returns the transaction hash at which the object was stored.
 `;
 
 /**
@@ -86,12 +100,14 @@ Arguments:
  * @returns The prompt for getting object
  */
 export const getObjectPrompt = (_context: Context = {}) => `
-Gets an object from a bucket in Recall.
+Gets an object from a bucket in Recall. Use this to retrieve previously stored data.
 
 Arguments:
 - bucket (str): The address of the bucket (EVM hex string address).
 - key (str): The key under which the object is stored.
 - outputType (str, optional): The type of output to return ("string" or "uint8array"). Defaults to "uint8array".
+
+Returns the object's data, either as a string or Uint8Array, based on the outputType parameter.
 `;
 
 /**
@@ -99,12 +115,14 @@ Arguments:
  * @returns The prompt for querying objects
  */
 export const queryObjectsPrompt = (_context: Context = {}) => `
-Queries objects from a bucket in Recall.
+Queries objects from a bucket in Recall. Use this to list or search for stored objects matching certain criteria.
 
 Arguments:
 - bucket (str): The address of the bucket (EVM hex string address).
-- prefix (str, optional): The prefix of the objects to query.
-- delimiter (str, optional): The delimiter of the objects to query.
-- startKey (str, optional): The starting key of the objects to query.
+- prefix (str, optional): The prefix of the objects to query (e.g. "users/" to list all user-related objects).
+- delimiter (str, optional): The delimiter of the objects to query (e.g. "/" to group by directory-like structure).
+- startKey (str, optional): The starting key of the objects to query, useful for pagination.
 - limit (int, optional): The maximum number of objects to return.
+
+Returns an array of objects matching the query criteria, including keys, blake3 hashes, sizes, and storage information.
 `;

--- a/packages/agent-toolkit/src/shared/prompts.ts
+++ b/packages/agent-toolkit/src/shared/prompts.ts
@@ -1,6 +1,9 @@
 import { Context } from "./configuration.js";
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
+/**
+ * Prompt for the getAccountInfo function
+ * @returns The prompt for getting account info
+ */
 export const getAccountInfoPrompt = (_context: Context = {}) => `
 This tool will get account information from Recall, including token $RECALL balances, address, and nonce.
 
@@ -8,7 +11,10 @@ Arguments:
 - address (str, optional): The address of the account, else, defaults to the connected user's account address.
 `;
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
+/**
+ * Prompt for the listBuckets function
+ * @returns The prompt for listing buckets
+ */
 export const listBucketsPrompt = (_context: Context = {}) => `
 Lists all buckets owned by the connected account in Recall.
 
@@ -16,7 +22,10 @@ Arguments:
 - owner (str, optional): The address of the account, else, defaults to the connected user's account address.
 `;
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
+/**
+ * Prompt for the getCreditInfo function
+ * @returns The prompt for getting credit info
+ */
 export const getCreditInfoPrompt = (_context: Context = {}) => `
 Gets the credit information for the connected account.
 
@@ -24,7 +33,10 @@ Arguments:
 - address (str, optional): The address of the account, else, defaults to the connected user's account address.
 `;
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
+/**
+ * Prompt for the buyCredit function
+ * @returns The prompt for buying credit
+ */
 export const buyCreditPrompt = (_context: Context = {}) => `
 Buys credit for the connected account.
 
@@ -33,7 +45,10 @@ Arguments:
 - to (str, optional): The address of the account to buy credit for, else, defaults to the connected user's account address.
 `;
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
+/**
+ * Prompt for the createBucket function
+ * @returns The prompt for creating bucket
+ */
 export const createBucketPrompt = (_context: Context = {}) => `
 Creates a new bucket in Recall.
 
@@ -41,7 +56,10 @@ Arguments:
 - bucketAlias (str): The alias to assign to the new bucket.
 `;
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
+/**
+ * Prompt for the getOrCreateBucket function
+ * @returns The prompt for getting or creating bucket
+ */
 export const getOrCreateBucketPrompt = (_context: Context = {}) => `
 Gets an existing bucket by alias or creates a new one if it doesn't exist.
 
@@ -49,7 +67,10 @@ Arguments:
 - bucketAlias (str): The alias of the bucket to retrieve or create.
 `;
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
+/**
+ * Prompt for the addObject function
+ * @returns The prompt for adding object
+ */
 export const addObjectPrompt = (_context: Context = {}) => `
 Adds an object to a bucket in Recall.
 
@@ -60,7 +81,10 @@ Arguments:
 - overwrite (bool, optional): Whether to overwrite existing data. Defaults to false.
 `;
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
+/**
+ * Prompt for the getObject function
+ * @returns The prompt for getting object
+ */
 export const getObjectPrompt = (_context: Context = {}) => `
 Gets an object from a bucket in Recall.
 
@@ -70,7 +94,10 @@ Arguments:
 - outputType (str, optional): The type of output to return ("string" or "uint8array"). Defaults to "uint8array".
 `;
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
+/**
+ * Prompt for the queryObjects function
+ * @returns The prompt for querying objects
+ */
 export const queryObjectsPrompt = (_context: Context = {}) => `
 Queries objects from a bucket in Recall.
 

--- a/packages/agent-toolkit/src/shared/prompts.ts
+++ b/packages/agent-toolkit/src/shared/prompts.ts
@@ -1,25 +1,31 @@
-export const getAccountInfoPrompt = `
+import { Context } from "./configuration.js";
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export const getAccountInfoPrompt = (_context: Context = {}) => `
 This tool will get account information from Recall, including token $RECALL balances, address, and nonce.
 
 Arguments:
 - address (str, optional): The address of the account, else, defaults to the connected user's account address.
 `;
 
-export const listBucketsPrompt = `
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export const listBucketsPrompt = (_context: Context = {}) => `
 Lists all buckets owned by the connected account in Recall.
 
 Arguments:
 - owner (str, optional): The address of the account, else, defaults to the connected user's account address.
 `;
 
-export const getCreditInfoPrompt = `
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export const getCreditInfoPrompt = (_context: Context = {}) => `
 Gets the credit information for the connected account.
 
 Arguments:
 - address (str, optional): The address of the account, else, defaults to the connected user's account address.
 `;
 
-export const buyCreditPrompt = `
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export const buyCreditPrompt = (_context: Context = {}) => `
 Buys credit for the connected account.
 
 Arguments:
@@ -27,21 +33,24 @@ Arguments:
 - to (str, optional): The address of the account to buy credit for, else, defaults to the connected user's account address.
 `;
 
-export const createBucketPrompt = `
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export const createBucketPrompt = (_context: Context = {}) => `
 Creates a new bucket in Recall.
 
 Arguments:
 - bucketAlias (str): The alias to assign to the new bucket.
 `;
 
-export const getOrCreateBucketPrompt = `
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export const getOrCreateBucketPrompt = (_context: Context = {}) => `
 Gets an existing bucket by alias or creates a new one if it doesn't exist.
 
 Arguments:
 - bucketAlias (str): The alias of the bucket to retrieve or create.
 `;
 
-export const addObjectPrompt = `
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export const addObjectPrompt = (_context: Context = {}) => `
 Adds an object to a bucket in Recall.
 
 Arguments:
@@ -51,7 +60,8 @@ Arguments:
 - overwrite (bool, optional): Whether to overwrite existing data. Defaults to false.
 `;
 
-export const getObjectPrompt = `
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export const getObjectPrompt = (_context: Context = {}) => `
 Gets an object from a bucket in Recall.
 
 Arguments:
@@ -60,7 +70,8 @@ Arguments:
 - outputType (str, optional): The type of output to return ("string" or "uint8array"). Defaults to "uint8array".
 `;
 
-export const queryObjectsPrompt = `
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export const queryObjectsPrompt = (_context: Context = {}) => `
 Queries objects from a bucket in Recall.
 
 Arguments:

--- a/packages/agent-toolkit/src/shared/prompts.ts
+++ b/packages/agent-toolkit/src/shared/prompts.ts
@@ -89,7 +89,7 @@ Adds an object to a bucket in Recall. Use this to store data like files, JSON, o
 Arguments:
 - bucket (str): The address of the bucket (EVM hex string address).
 - key (str): The key under which to store the object. Use a descriptive path-like structure (e.g. "users/profile/avatar.jpg").
-- data (str | Uint8Array): The data to store. Can be a string or binary data.
+- data (str): The data to store as a string value.
 - overwrite (bool, optional): Whether to overwrite existing data. Defaults to false.
 
 Returns the transaction hash at which the object was stored.
@@ -105,9 +105,8 @@ Gets an object from a bucket in Recall. Use this to retrieve previously stored d
 Arguments:
 - bucket (str): The address of the bucket (EVM hex string address).
 - key (str): The key under which the object is stored.
-- outputType (str, optional): The type of output to return ("string" or "uint8array"). Defaults to "uint8array".
 
-Returns the object's data, either as a string or Uint8Array, based on the outputType parameter.
+Returns the object's data as a string value.
 `;
 
 /**

--- a/packages/agent-toolkit/src/shared/prompts.ts
+++ b/packages/agent-toolkit/src/shared/prompts.ts
@@ -10,7 +10,7 @@ Gets account information from Recall, including token $RECALL balances, address,
 Arguments:
 - address (str, optional): The address of the account, else, defaults to the connected user's account address.
 
-Returns the account's balance, address and nonce information. 
+Returns the account's balance, address, and nonce information. 
 `;
 
 /**

--- a/packages/agent-toolkit/src/shared/tools.ts
+++ b/packages/agent-toolkit/src/shared/tools.ts
@@ -1,6 +1,19 @@
 import { z } from "zod";
 
-import { Actions } from "./configuration.js";
+import { RecallClient } from "@recallnet/sdk/client";
+
+import { Actions, Context } from "./configuration.js";
+import {
+  addObject,
+  buyCredit,
+  createBucket,
+  getAccountInfo,
+  getCreditInfo,
+  getObject,
+  getOrCreateBucket,
+  listBuckets,
+  queryObjects,
+} from "./functions.js";
 import {
   addObjectParameters,
   buyCreditParameters,
@@ -23,6 +36,7 @@ import {
   listBucketsPrompt,
   queryObjectsPrompt,
 } from "./prompts.js";
+import { Result } from "./util.js";
 
 /**
  * A tool is a function that can be called by the agent.
@@ -39,12 +53,20 @@ export type Tool = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   parameters: z.ZodObject<any, any, any, any>;
   actions: Actions;
+  execute: (
+    recall: RecallClient,
+    context: Context,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    params: any,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ) => Promise<Result<any>>;
 };
 
 /**
  * A list of {@link Tool}s that can be used by the agent.
  */
-export const tools: Tool[] = [
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export const tools = (context?: Context): Tool[] => [
   // Account read methods
   {
     method: "get_account_info",
@@ -56,6 +78,7 @@ export const tools: Tool[] = [
         read: true,
       },
     },
+    execute: getAccountInfo,
   },
   {
     method: "get_credit_info",
@@ -67,6 +90,7 @@ export const tools: Tool[] = [
         read: true,
       },
     },
+    execute: getCreditInfo,
   },
   // Account write methods
   {
@@ -79,6 +103,7 @@ export const tools: Tool[] = [
         write: true,
       },
     },
+    execute: buyCredit,
   },
   // Bucket read methods
   {
@@ -91,6 +116,7 @@ export const tools: Tool[] = [
         read: true,
       },
     },
+    execute: listBuckets,
   },
   {
     method: "get_object",
@@ -102,6 +128,7 @@ export const tools: Tool[] = [
         read: true,
       },
     },
+    execute: getObject,
   },
   {
     method: "query_objects",
@@ -113,6 +140,7 @@ export const tools: Tool[] = [
         read: true,
       },
     },
+    execute: queryObjects,
   },
   // Bucket write methods
   {
@@ -125,6 +153,7 @@ export const tools: Tool[] = [
         write: true,
       },
     },
+    execute: createBucket,
   },
   {
     method: "get_or_create_bucket",
@@ -137,6 +166,7 @@ export const tools: Tool[] = [
         write: true,
       },
     },
+    execute: getOrCreateBucket,
   },
   {
     method: "add_object",
@@ -148,5 +178,6 @@ export const tools: Tool[] = [
         write: true,
       },
     },
+    execute: addObject,
   },
 ];

--- a/packages/agent-toolkit/src/shared/tools.ts
+++ b/packages/agent-toolkit/src/shared/tools.ts
@@ -65,14 +65,13 @@ export type Tool = {
 /**
  * A list of {@link Tool}s that can be used by the agent.
  */
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export const tools = (context?: Context): Tool[] => [
   // Account read methods
   {
     method: "get_account_info",
     name: "Get Account Info",
-    description: getAccountInfoPrompt,
-    parameters: getAccountInfoParameters,
+    description: getAccountInfoPrompt(context),
+    parameters: getAccountInfoParameters(context),
     actions: {
       account: {
         read: true,
@@ -83,8 +82,8 @@ export const tools = (context?: Context): Tool[] => [
   {
     method: "get_credit_info",
     name: "Get Credit Info",
-    description: getCreditInfoPrompt,
-    parameters: getCreditInfoParameters,
+    description: getCreditInfoPrompt(context),
+    parameters: getCreditInfoParameters(context),
     actions: {
       account: {
         read: true,
@@ -96,8 +95,8 @@ export const tools = (context?: Context): Tool[] => [
   {
     method: "buy_credit",
     name: "Buy Credit",
-    description: buyCreditPrompt,
-    parameters: buyCreditParameters,
+    description: buyCreditPrompt(context),
+    parameters: buyCreditParameters(context),
     actions: {
       account: {
         write: true,
@@ -109,8 +108,8 @@ export const tools = (context?: Context): Tool[] => [
   {
     method: "list_buckets",
     name: "List Buckets",
-    description: listBucketsPrompt,
-    parameters: listBucketsParameters,
+    description: listBucketsPrompt(context),
+    parameters: listBucketsParameters(context),
     actions: {
       bucket: {
         read: true,
@@ -121,8 +120,8 @@ export const tools = (context?: Context): Tool[] => [
   {
     method: "get_object",
     name: "Get Object",
-    description: getObjectPrompt,
-    parameters: getObjectParameters,
+    description: getObjectPrompt(context),
+    parameters: getObjectParameters(context),
     actions: {
       bucket: {
         read: true,
@@ -133,8 +132,8 @@ export const tools = (context?: Context): Tool[] => [
   {
     method: "query_objects",
     name: "Query Objects",
-    description: queryObjectsPrompt,
-    parameters: queryObjectsParameters,
+    description: queryObjectsPrompt(context),
+    parameters: queryObjectsParameters(context),
     actions: {
       bucket: {
         read: true,
@@ -146,8 +145,8 @@ export const tools = (context?: Context): Tool[] => [
   {
     method: "create_bucket",
     name: "Create Bucket",
-    description: createBucketPrompt,
-    parameters: createBucketParameters,
+    description: createBucketPrompt(context),
+    parameters: createBucketParameters(context),
     actions: {
       bucket: {
         write: true,
@@ -158,8 +157,8 @@ export const tools = (context?: Context): Tool[] => [
   {
     method: "get_or_create_bucket",
     name: "Get or Create Bucket",
-    description: getOrCreateBucketPrompt,
-    parameters: getOrCreateBucketParameters,
+    description: getOrCreateBucketPrompt(context),
+    parameters: getOrCreateBucketParameters(context),
     actions: {
       bucket: {
         read: true,
@@ -171,8 +170,8 @@ export const tools = (context?: Context): Tool[] => [
   {
     method: "add_object",
     name: "Add Object",
-    description: addObjectPrompt,
-    parameters: addObjectParameters,
+    description: addObjectPrompt(context),
+    parameters: addObjectParameters(context),
     actions: {
       bucket: {
         write: true,

--- a/packages/chains/src/index.ts
+++ b/packages/chains/src/index.ts
@@ -253,16 +253,16 @@ export function getParentChain(chain: Chain): Chain | undefined {
  * const isValid = checkChainName("testnet");
  * // Returns: true
  *
- * const isInvalid = checkChainName("unknown" as ChainName);
+ * const isInvalid = checkChainName("unknown");
  * // Returns: false
  * ```
  *
- * @param chainName - The chain name to check
+ * @param chainName - The chain name to check (e.g., "testnet", "localnet", "devnet")
  * @returns True if the chain name is valid, false otherwise
  */
-export function checkChainName(chainName: ChainName): boolean {
+export function checkChainName(chainName: string): boolean {
   try {
-    getChain(chainName);
+    getChain(chainName as ChainName);
     return true;
   } catch {
     return false;

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -119,8 +119,8 @@ The server exposes the following MCP tools:
 | `list_buckets`         | `bucket.read`   | List all buckets owned by an address                                   |
 | `create_bucket`        | `bucket.write`  | Create a bucket in Recall                                              |
 | `get_or_create_bucket` | `bucket.write`  | Get or create a bucket in Recall (using alias)                         |
-| `add_object`           | `bucket.write`  | Add an object to a Recall bucket                                       |
-| `get_object`           | `bucket.read`   | Get an object from a Recall bucket                                     |
+| `add_object`           | `bucket.write`  | Add an object to a Recall bucket (as a string)                         |
+| `get_object`           | `bucket.read`   | Get an object from a Recall bucket (as a string)                       |
 | `query_objects`        | `bucket.read`   | Query objects in a Recall bucket                                       |
 
 ## Development

--- a/packages/mcp/src/config.ts
+++ b/packages/mcp/src/config.ts
@@ -116,9 +116,6 @@ export function buildMcpConfiguration(config: ValidatedConfig): Configuration {
   if (config.tools.includes("all")) {
     ACCEPTED_TOOLS.forEach((tool) => {
       const [resource, action] = tool.split(".");
-      if (!configuration.actions) {
-        configuration.actions = {};
-      }
       configuration.actions[resource as Resource] = {
         ...configuration.actions[resource as Resource],
         [action as Permission]: true,
@@ -127,9 +124,6 @@ export function buildMcpConfiguration(config: ValidatedConfig): Configuration {
   } else {
     config.tools.forEach((tool) => {
       const [resource, action] = tool.split(".");
-      if (!configuration.actions) {
-        configuration.actions = {};
-      }
       configuration.actions[resource as Resource] = {
         ...configuration.actions[resource as Resource],
         [action as Permission]: true,

--- a/packages/mcp/src/config.ts
+++ b/packages/mcp/src/config.ts
@@ -116,6 +116,9 @@ export function buildMcpConfiguration(config: ValidatedConfig): Configuration {
   if (config.tools.includes("all")) {
     ACCEPTED_TOOLS.forEach((tool) => {
       const [resource, action] = tool.split(".");
+      if (!configuration.actions) {
+        configuration.actions = {};
+      }
       configuration.actions[resource as Resource] = {
         ...configuration.actions[resource as Resource],
         [action as Permission]: true,
@@ -124,6 +127,9 @@ export function buildMcpConfiguration(config: ValidatedConfig): Configuration {
   } else {
     config.tools.forEach((tool) => {
       const [resource, action] = tool.split(".");
+      if (!configuration.actions) {
+        configuration.actions = {};
+      }
       configuration.actions[resource as Resource] = {
         ...configuration.actions[resource as Resource],
         [action as Permission]: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -242,11 +242,11 @@ importers:
   packages/agent-toolkit:
     dependencies:
       '@langchain/core':
-        specifier: ^0.3.42
-        version: 0.3.43(openai@4.89.1(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.2))
+        specifier: ^0.3.44
+        version: 0.3.44(openai@4.93.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.2))
       '@modelcontextprotocol/sdk':
-        specifier: ^1.7.0
-        version: 1.8.0
+        specifier: ^1.9.0
+        version: 1.9.0
       '@recallnet/chains':
         specifier: workspace:*
         version: link:../chains
@@ -254,8 +254,8 @@ importers:
         specifier: workspace:*
         version: link:../sdk
       openai:
-        specifier: ^4.87.3
-        version: 4.89.1(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.2)
+        specifier: ^4.93.0
+        version: 4.93.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.2)
       viem:
         specifier: ^2.22.9
         version: 2.24.1(bufferutil@4.0.9)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.24.2)
@@ -267,11 +267,11 @@ importers:
         version: 3.24.5(zod@3.24.2)
     devDependencies:
       '@ai-sdk/openai':
-        specifier: ^1.2.5
-        version: 1.3.3(zod@3.24.2)
+        specifier: ^1.3.9
+        version: 1.3.9(zod@3.24.2)
       '@langchain/openai':
-        specifier: ^0.4.4
-        version: 0.4.9(@langchain/core@0.3.43(openai@4.89.1(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.2)))(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+        specifier: ^0.5.5
+        version: 0.5.5(@langchain/core@0.3.44(openai@4.93.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.2)))(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       '@recallnet/eslint-config':
         specifier: workspace:*
         version: link:../eslint-config
@@ -279,14 +279,14 @@ importers:
         specifier: workspace:*
         version: link:../typescript-config
       ai:
-        specifier: ^4.2.11
-        version: 4.2.11(react@19.0.0)(zod@3.24.2)
+        specifier: ^4.3.4
+        version: 4.3.4(react@19.0.0)(zod@3.24.2)
       dotenv:
         specifier: ^16.4.7
         version: 16.4.7
       langchain:
-        specifier: ^0.3.19
-        version: 0.3.19(@langchain/core@0.3.43(openai@4.89.1(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.2)))(axios@1.8.4)(handlebars@4.7.8)(openai@4.89.1(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.2))(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+        specifier: ^0.3.21
+        version: 0.3.21(@langchain/core@0.3.44(openai@4.93.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.2)))(axios@1.8.4)(handlebars@4.7.8)(openai@4.93.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.2))(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       tsup:
         specifier: ^8.3.6
         version: 8.4.0(jiti@1.21.7)(postcss@8.5.3)(typescript@5.8.2)(yaml@2.7.0)
@@ -784,30 +784,24 @@ packages:
   '@adraffy/ens-normalize@1.11.0':
     resolution: {integrity: sha512-/3DDPKHqqIqxUULp8yP4zODUY1i+2xvVWsv8A79xGWdCAG+8sb0hRh0Rk2QyOJUnnbyPUAZYcpBuRe3nS2OIUg==}
 
-  '@ai-sdk/openai@1.3.3':
-    resolution: {integrity: sha512-CH57tonLB4DwkwqwnMmTCoIOR7cNW3bP5ciyloI7rBGJS/Bolemsoo+vn5YnwkyT9O1diWJyvYeTh7A4UfiYOw==}
+  '@ai-sdk/openai@1.3.9':
+    resolution: {integrity: sha512-XSkGWewA7UzyJu6Pfkzp4GsIqnyiE3tONlRh9WYBAZkD67bh3LY7wY+CGSuJzMkv/o4dBPT0gpVc9f7nn4D3rw==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.0.0
 
-  '@ai-sdk/provider-utils@2.2.1':
-    resolution: {integrity: sha512-BuExLp+NcpwsAVj1F4bgJuQkSqO/+roV9wM7RdIO+NVrcT8RBUTdXzf5arHt5T58VpK7bZyB2V9qigjaPHE+Dg==}
+  '@ai-sdk/provider-utils@2.2.6':
+    resolution: {integrity: sha512-sUlZ7Gnq84DCGWMQRIK8XVbkzIBnvPR1diV4v6JwPgpn5armnLI/j+rqn62MpLrU5ZCQZlDKl/Lw6ed3ulYqaA==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.23.8
 
-  '@ai-sdk/provider-utils@2.2.3':
-    resolution: {integrity: sha512-o3fWTzkxzI5Af7U7y794MZkYNEsxbjLam2nxyoUZSScqkacb7vZ3EYHLh21+xCcSSzEC161C7pZAGHtC0hTUMw==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.23.8
-
-  '@ai-sdk/provider@1.1.0':
-    resolution: {integrity: sha512-0M+qjp+clUD0R1E5eWQFhxEvWLNaOtGQRUaBn8CUABnSKredagq92hUS9VjOzGsTm37xLfpaxl97AVtbeOsHew==}
+  '@ai-sdk/provider@1.1.2':
+    resolution: {integrity: sha512-ITdgNilJZwLKR7X5TnUr1BsQW6UTX5yFp0h66Nfx8XjBYkWD9W3yugr50GOz3CnE9m/U/Cd5OyEbTMI0rgi6ZQ==}
     engines: {node: '>=18'}
 
-  '@ai-sdk/react@1.2.5':
-    resolution: {integrity: sha512-0jOop3S2WkDOdO4X5I+5fTGqZlNX8/h1T1eYokpkR9xh8Vmrxqw8SsovqGvrddTsZykH8uXRsvI+G4FTyy894A==}
+  '@ai-sdk/react@1.2.8':
+    resolution: {integrity: sha512-S2FzCSi4uTF0JuSN6zYMXyiAWVAzi/Hho8ISYgHpGZiICYLNCP2si4DuXQOsnWef3IXzQPLVoE11C63lILZIkw==}
     engines: {node: '>=18'}
     peerDependencies:
       react: ^18 || ^19 || ^19.0.0-rc
@@ -816,8 +810,8 @@ packages:
       zod:
         optional: true
 
-  '@ai-sdk/ui-utils@1.2.4':
-    resolution: {integrity: sha512-wLTxEZrKZRyBmlVZv8nGXgLBg5tASlqXwbuhoDu0MhZa467ZFREEnosH/OC/novyEHTQXko2zC606xoVbMrUcA==}
+  '@ai-sdk/ui-utils@1.2.7':
+    resolution: {integrity: sha512-OVRxa4SDj0wVsMZ8tGr/whT89oqNtNoXBKmqWC2BRv5ZG6azL2LYZ5ZK35u3lb4l1IE7cWGsLlmq0py0ttsL7A==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.23.8
@@ -1468,12 +1462,12 @@ packages:
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
-  '@langchain/core@0.3.43':
-    resolution: {integrity: sha512-DwiSUwmZqcuOn7j8SFdeOH1nvaUqG7q8qn3LhobdQYEg5PmjLgd2yLr2KzuT/YWMBfjkOR+Di5K6HEdFmouTxg==}
+  '@langchain/core@0.3.44':
+    resolution: {integrity: sha512-3BsSFf7STvPPZyl2kMANgtVnCUvDdyP4k+koP+nY2Tczd5V+RFkuazIn/JOj/xxy/neZjr4PxFU4BFyF1aKXOA==}
     engines: {node: '>=18'}
 
-  '@langchain/openai@0.4.9':
-    resolution: {integrity: sha512-NAsaionRHNdqaMjVLPkFCyjUDze+OqRHghA1Cn4fPoAafz+FXcl9c7LlEl9Xo0FH6/8yiCl7Rw2t780C/SBVxQ==}
+  '@langchain/openai@0.5.5':
+    resolution: {integrity: sha512-QwdZrWcx6FB+UMKQ6+a0M9ZXzeUnZCwXP7ltqCCycPzdfiwxg3TQ6WkSefdEyiPpJcVVq/9HZSxrzGmf18QGyw==}
     engines: {node: '>=18'}
     peerDependencies:
       '@langchain/core': '>=0.3.39 <0.4.0'
@@ -1573,6 +1567,10 @@ packages:
 
   '@modelcontextprotocol/sdk@1.8.0':
     resolution: {integrity: sha512-e06W7SwrontJDHwCawNO5SGxG+nU9AAx+jpHHZqGl/WrDBdWOpvirC+s58VpJTB5QemI4jTRcjWT4Pt3Q1NPQQ==}
+    engines: {node: '>=18'}
+
+  '@modelcontextprotocol/sdk@1.9.0':
+    resolution: {integrity: sha512-Jq2EUCQpe0iyO5FGpzVYDNFR6oR53AIrwph9yWl7uSc7IWUMsrmpmSaTGra5hQNunXpM+9oit85p924jWuHzUA==}
     engines: {node: '>=18'}
 
   '@motionone/animation@10.18.0':
@@ -2692,8 +2690,8 @@ packages:
     resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==}
     engines: {node: '>=8'}
 
-  ai@4.2.11:
-    resolution: {integrity: sha512-XvYFz+I2MNpkNeso/cEvm2q22cuU7B3EdUxGyhpa94gHbb3HEk73d42+UPJqweSBmoXA52mZ9qvb6jt3P4TITQ==}
+  ai@4.3.4:
+    resolution: {integrity: sha512-uMjzrowIqfU8CCCxhx8QGl7ETydHBROeNL0VoEwetkmDCY6Q8ZTacj6jNNqGJOiCk595aUrGR9VHPY9Ylvy1fg==}
     engines: {node: '>=18'}
     peerDependencies:
       react: ^18 || ^19 || ^19.0.0-rc
@@ -4311,8 +4309,8 @@ packages:
   keyvaluestorage-interface@1.0.0:
     resolution: {integrity: sha512-8t6Q3TclQ4uZynJY9IGr2+SsIGwK9JHcO6ootkHCGA0CrQCRy+VkouYNO2xicET6b9al7QKzpebNow+gkpCL8g==}
 
-  langchain@0.3.19:
-    resolution: {integrity: sha512-aGhoTvTBS5ulatA67RHbJ4bcV5zcYRYdm5IH+hpX99RYSFXG24XF3ghSjhYi6sxW+SUnEQ99fJhA5kroVpKNhw==}
+  langchain@0.3.21:
+    resolution: {integrity: sha512-fpor/V/xJRoLM7s1yQGlUE6aZIe6LLm7ciZcstNbBUYdFpCSigvADsW2cqlBCdbMXJxb5I/z9jznjGnmciJ+aw==}
     engines: {node: '>=18'}
     peerDependencies:
       '@langchain/anthropic': '*'
@@ -4765,8 +4763,8 @@ packages:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
     engines: {node: '>=6'}
 
-  openai@4.89.1:
-    resolution: {integrity: sha512-k6t7WfnodIctPo40/9sy7Ww4VypnfkKi/urO2VQx4trCIwgzeroO1jkaCL2f5MyTS1H3HT9X+M2qLsc7NSXwTw==}
+  openai@4.93.0:
+    resolution: {integrity: sha512-2kONcISbThKLfm7T9paVzg+QCE1FOZtNMMUfXyXckUAoXRRS/mTP89JSDHPMp8uM5s0bz28RISbvQjArD6mgUQ==}
     hasBin: true
     peerDependencies:
       ws: ^8.18.0
@@ -4996,6 +4994,10 @@ packages:
 
   pkce-challenge@4.1.0:
     resolution: {integrity: sha512-ZBmhE1C9LcPoH9XZSdwiPtbPHZROwAnMy+kIFQVrnMCxY4Cudlz3gBOpzilgc0jOgRaiT3sIWfpMomW2ar2orQ==}
+    engines: {node: '>=16.20.0'}
+
+  pkce-challenge@5.0.0:
+    resolution: {integrity: sha512-ueGLflrrnvwB3xuo/uGob5pd5FN7l0MsLf0Z87o/UQmRtwjvfylfc9MurIxRAWywCYTgrvpXBcqjV4OfCYGCIQ==}
     engines: {node: '>=16.20.0'}
 
   pngjs@5.0.0:
@@ -6531,44 +6533,37 @@ snapshots:
 
   '@adraffy/ens-normalize@1.11.0': {}
 
-  '@ai-sdk/openai@1.3.3(zod@3.24.2)':
+  '@ai-sdk/openai@1.3.9(zod@3.24.2)':
     dependencies:
-      '@ai-sdk/provider': 1.1.0
-      '@ai-sdk/provider-utils': 2.2.1(zod@3.24.2)
+      '@ai-sdk/provider': 1.1.2
+      '@ai-sdk/provider-utils': 2.2.6(zod@3.24.2)
       zod: 3.24.2
 
-  '@ai-sdk/provider-utils@2.2.1(zod@3.24.2)':
+  '@ai-sdk/provider-utils@2.2.6(zod@3.24.2)':
     dependencies:
-      '@ai-sdk/provider': 1.1.0
+      '@ai-sdk/provider': 1.1.2
       nanoid: 3.3.11
       secure-json-parse: 2.7.0
       zod: 3.24.2
 
-  '@ai-sdk/provider-utils@2.2.3(zod@3.24.2)':
-    dependencies:
-      '@ai-sdk/provider': 1.1.0
-      nanoid: 3.3.11
-      secure-json-parse: 2.7.0
-      zod: 3.24.2
-
-  '@ai-sdk/provider@1.1.0':
+  '@ai-sdk/provider@1.1.2':
     dependencies:
       json-schema: 0.4.0
 
-  '@ai-sdk/react@1.2.5(react@19.0.0)(zod@3.24.2)':
+  '@ai-sdk/react@1.2.8(react@19.0.0)(zod@3.24.2)':
     dependencies:
-      '@ai-sdk/provider-utils': 2.2.3(zod@3.24.2)
-      '@ai-sdk/ui-utils': 1.2.4(zod@3.24.2)
+      '@ai-sdk/provider-utils': 2.2.6(zod@3.24.2)
+      '@ai-sdk/ui-utils': 1.2.7(zod@3.24.2)
       react: 19.0.0
       swr: 2.3.3(react@19.0.0)
       throttleit: 2.1.0
     optionalDependencies:
       zod: 3.24.2
 
-  '@ai-sdk/ui-utils@1.2.4(zod@3.24.2)':
+  '@ai-sdk/ui-utils@1.2.7(zod@3.24.2)':
     dependencies:
-      '@ai-sdk/provider': 1.1.0
-      '@ai-sdk/provider-utils': 2.2.3(zod@3.24.2)
+      '@ai-sdk/provider': 1.1.2
+      '@ai-sdk/provider-utils': 2.2.6(zod@3.24.2)
       zod: 3.24.2
       zod-to-json-schema: 3.24.5(zod@3.24.2)
 
@@ -7178,14 +7173,14 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
 
-  '@langchain/core@0.3.43(openai@4.89.1(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.2))':
+  '@langchain/core@0.3.44(openai@4.93.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.2))':
     dependencies:
       '@cfworker/json-schema': 4.1.1
       ansi-styles: 5.2.0
       camelcase: 6.3.0
       decamelize: 1.2.0
       js-tiktoken: 1.0.19
-      langsmith: 0.3.15(openai@4.89.1(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.2))
+      langsmith: 0.3.15(openai@4.93.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.2))
       mustache: 4.2.0
       p-queue: 6.6.2
       p-retry: 4.6.2
@@ -7195,20 +7190,20 @@ snapshots:
     transitivePeerDependencies:
       - openai
 
-  '@langchain/openai@0.4.9(@langchain/core@0.3.43(openai@4.89.1(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.2)))(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
+  '@langchain/openai@0.5.5(@langchain/core@0.3.44(openai@4.93.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.2)))(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
     dependencies:
-      '@langchain/core': 0.3.43(openai@4.89.1(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.2))
+      '@langchain/core': 0.3.44(openai@4.93.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.2))
       js-tiktoken: 1.0.19
-      openai: 4.89.1(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.2)
+      openai: 4.93.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.2)
       zod: 3.24.2
       zod-to-json-schema: 3.24.5(zod@3.24.2)
     transitivePeerDependencies:
       - encoding
       - ws
 
-  '@langchain/textsplitters@0.1.0(@langchain/core@0.3.43(openai@4.89.1(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.2)))':
+  '@langchain/textsplitters@0.1.0(@langchain/core@0.3.44(openai@4.93.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.2)))':
     dependencies:
-      '@langchain/core': 0.3.43(openai@4.89.1(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.2))
+      '@langchain/core': 0.3.44(openai@4.93.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.2))
       js-tiktoken: 1.0.19
 
   '@lit-labs/ssr-dom-shim@1.3.0': {}
@@ -7403,6 +7398,21 @@ snapshots:
       express: 5.0.1
       express-rate-limit: 7.5.0(express@5.0.1)
       pkce-challenge: 4.1.0
+      raw-body: 3.0.0
+      zod: 3.24.2
+      zod-to-json-schema: 3.24.5(zod@3.24.2)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@modelcontextprotocol/sdk@1.9.0':
+    dependencies:
+      content-type: 1.0.5
+      cors: 2.8.5
+      cross-spawn: 7.0.6
+      eventsource: 3.0.5
+      express: 5.0.1
+      express-rate-limit: 7.5.0(express@5.0.1)
+      pkce-challenge: 5.0.0
       raw-body: 3.0.0
       zod: 3.24.2
       zod-to-json-schema: 3.24.5(zod@3.24.2)
@@ -8860,12 +8870,12 @@ snapshots:
       clean-stack: 2.2.0
       indent-string: 4.0.0
 
-  ai@4.2.11(react@19.0.0)(zod@3.24.2):
+  ai@4.3.4(react@19.0.0)(zod@3.24.2):
     dependencies:
-      '@ai-sdk/provider': 1.1.0
-      '@ai-sdk/provider-utils': 2.2.3(zod@3.24.2)
-      '@ai-sdk/react': 1.2.5(react@19.0.0)(zod@3.24.2)
-      '@ai-sdk/ui-utils': 1.2.4(zod@3.24.2)
+      '@ai-sdk/provider': 1.1.2
+      '@ai-sdk/provider-utils': 2.2.6(zod@3.24.2)
+      '@ai-sdk/react': 1.2.8(react@19.0.0)(zod@3.24.2)
+      '@ai-sdk/ui-utils': 1.2.7(zod@3.24.2)
       '@opentelemetry/api': 1.9.0
       jsondiffpatch: 0.6.0
       zod: 3.24.2
@@ -10731,15 +10741,15 @@ snapshots:
 
   keyvaluestorage-interface@1.0.0: {}
 
-  langchain@0.3.19(@langchain/core@0.3.43(openai@4.89.1(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.2)))(axios@1.8.4)(handlebars@4.7.8)(openai@4.89.1(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.2))(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)):
+  langchain@0.3.21(@langchain/core@0.3.44(openai@4.93.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.2)))(axios@1.8.4)(handlebars@4.7.8)(openai@4.93.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.2))(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)):
     dependencies:
-      '@langchain/core': 0.3.43(openai@4.89.1(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.2))
-      '@langchain/openai': 0.4.9(@langchain/core@0.3.43(openai@4.89.1(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.2)))(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-      '@langchain/textsplitters': 0.1.0(@langchain/core@0.3.43(openai@4.89.1(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.2)))
+      '@langchain/core': 0.3.44(openai@4.93.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.2))
+      '@langchain/openai': 0.5.5(@langchain/core@0.3.44(openai@4.93.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.2)))(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      '@langchain/textsplitters': 0.1.0(@langchain/core@0.3.44(openai@4.93.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.2)))
       js-tiktoken: 1.0.19
       js-yaml: 4.1.0
       jsonpointer: 5.0.1
-      langsmith: 0.3.15(openai@4.89.1(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.2))
+      langsmith: 0.3.15(openai@4.93.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.2))
       openapi-types: 12.1.3
       p-retry: 4.6.2
       uuid: 10.0.0
@@ -10754,7 +10764,7 @@ snapshots:
       - openai
       - ws
 
-  langsmith@0.3.15(openai@4.89.1(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.2)):
+  langsmith@0.3.15(openai@4.93.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.2)):
     dependencies:
       '@types/uuid': 10.0.0
       chalk: 4.1.2
@@ -10764,7 +10774,7 @@ snapshots:
       semver: 7.7.1
       uuid: 10.0.0
     optionalDependencies:
-      openai: 4.89.1(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.2)
+      openai: 4.93.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.2)
 
   levn@0.4.1:
     dependencies:
@@ -11143,7 +11153,7 @@ snapshots:
     dependencies:
       mimic-fn: 2.1.0
 
-  openai@4.89.1(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.2):
+  openai@4.93.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.2):
     dependencies:
       '@types/node': 18.19.84
       '@types/node-fetch': 2.6.12
@@ -11388,6 +11398,8 @@ snapshots:
   pirates@4.0.6: {}
 
   pkce-challenge@4.1.0: {}
+
+  pkce-challenge@5.0.0: {}
 
   pngjs@5.0.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -253,9 +253,6 @@ importers:
       '@recallnet/sdk':
         specifier: workspace:*
         version: link:../sdk
-      ai:
-        specifier: ^4.1.61
-        version: 4.2.6(react@19.0.0)(zod@3.24.2)
       openai:
         specifier: ^4.87.3
         version: 4.89.1(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.24.2)
@@ -281,6 +278,9 @@ importers:
       '@recallnet/typescript-config':
         specifier: workspace:*
         version: link:../typescript-config
+      ai:
+        specifier: ^4.2.11
+        version: 4.2.11(react@19.0.0)(zod@3.24.2)
       dotenv:
         specifier: ^16.4.7
         version: 16.4.7
@@ -796,12 +796,18 @@ packages:
     peerDependencies:
       zod: ^3.23.8
 
+  '@ai-sdk/provider-utils@2.2.3':
+    resolution: {integrity: sha512-o3fWTzkxzI5Af7U7y794MZkYNEsxbjLam2nxyoUZSScqkacb7vZ3EYHLh21+xCcSSzEC161C7pZAGHtC0hTUMw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.23.8
+
   '@ai-sdk/provider@1.1.0':
     resolution: {integrity: sha512-0M+qjp+clUD0R1E5eWQFhxEvWLNaOtGQRUaBn8CUABnSKredagq92hUS9VjOzGsTm37xLfpaxl97AVtbeOsHew==}
     engines: {node: '>=18'}
 
-  '@ai-sdk/react@1.2.2':
-    resolution: {integrity: sha512-rxyNTFjUd3IilVOJFuUJV5ytZBYAIyRi50kFS2gNmSEiG4NHMBBm31ddrxI/i86VpY8gzZVp1/igtljnWBihUA==}
+  '@ai-sdk/react@1.2.5':
+    resolution: {integrity: sha512-0jOop3S2WkDOdO4X5I+5fTGqZlNX8/h1T1eYokpkR9xh8Vmrxqw8SsovqGvrddTsZykH8uXRsvI+G4FTyy894A==}
     engines: {node: '>=18'}
     peerDependencies:
       react: ^18 || ^19 || ^19.0.0-rc
@@ -810,8 +816,8 @@ packages:
       zod:
         optional: true
 
-  '@ai-sdk/ui-utils@1.2.1':
-    resolution: {integrity: sha512-BzvMbYm7LHBlbWuLlcG1jQh4eu14MGpz7L+wrGO1+F4oQ+O0fAjgUSNwPWGlZpKmg4NrcVq/QLmxiVJrx2R4Ew==}
+  '@ai-sdk/ui-utils@1.2.4':
+    resolution: {integrity: sha512-wLTxEZrKZRyBmlVZv8nGXgLBg5tASlqXwbuhoDu0MhZa467ZFREEnosH/OC/novyEHTQXko2zC606xoVbMrUcA==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.23.8
@@ -2686,8 +2692,8 @@ packages:
     resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==}
     engines: {node: '>=8'}
 
-  ai@4.2.6:
-    resolution: {integrity: sha512-vw0tGCUvnmOmzFm4rZI0o+sKx3Lcp7Fo5MrK3T+0ZVws/6+3CtB9ANmaC7DhJfdZFYm+wJuWMylsSEiJMjhJZQ==}
+  ai@4.2.11:
+    resolution: {integrity: sha512-XvYFz+I2MNpkNeso/cEvm2q22cuU7B3EdUxGyhpa94gHbb3HEk73d42+UPJqweSBmoXA52mZ9qvb6jt3P4TITQ==}
     engines: {node: '>=18'}
     peerDependencies:
       react: ^18 || ^19 || ^19.0.0-rc
@@ -6538,24 +6544,31 @@ snapshots:
       secure-json-parse: 2.7.0
       zod: 3.24.2
 
+  '@ai-sdk/provider-utils@2.2.3(zod@3.24.2)':
+    dependencies:
+      '@ai-sdk/provider': 1.1.0
+      nanoid: 3.3.11
+      secure-json-parse: 2.7.0
+      zod: 3.24.2
+
   '@ai-sdk/provider@1.1.0':
     dependencies:
       json-schema: 0.4.0
 
-  '@ai-sdk/react@1.2.2(react@19.0.0)(zod@3.24.2)':
+  '@ai-sdk/react@1.2.5(react@19.0.0)(zod@3.24.2)':
     dependencies:
-      '@ai-sdk/provider-utils': 2.2.1(zod@3.24.2)
-      '@ai-sdk/ui-utils': 1.2.1(zod@3.24.2)
+      '@ai-sdk/provider-utils': 2.2.3(zod@3.24.2)
+      '@ai-sdk/ui-utils': 1.2.4(zod@3.24.2)
       react: 19.0.0
       swr: 2.3.3(react@19.0.0)
       throttleit: 2.1.0
     optionalDependencies:
       zod: 3.24.2
 
-  '@ai-sdk/ui-utils@1.2.1(zod@3.24.2)':
+  '@ai-sdk/ui-utils@1.2.4(zod@3.24.2)':
     dependencies:
       '@ai-sdk/provider': 1.1.0
-      '@ai-sdk/provider-utils': 2.2.1(zod@3.24.2)
+      '@ai-sdk/provider-utils': 2.2.3(zod@3.24.2)
       zod: 3.24.2
       zod-to-json-schema: 3.24.5(zod@3.24.2)
 
@@ -8847,12 +8860,12 @@ snapshots:
       clean-stack: 2.2.0
       indent-string: 4.0.0
 
-  ai@4.2.6(react@19.0.0)(zod@3.24.2):
+  ai@4.2.11(react@19.0.0)(zod@3.24.2):
     dependencies:
       '@ai-sdk/provider': 1.1.0
-      '@ai-sdk/provider-utils': 2.2.1(zod@3.24.2)
-      '@ai-sdk/react': 1.2.2(react@19.0.0)(zod@3.24.2)
-      '@ai-sdk/ui-utils': 1.2.1(zod@3.24.2)
+      '@ai-sdk/provider-utils': 2.2.3(zod@3.24.2)
+      '@ai-sdk/react': 1.2.5(react@19.0.0)(zod@3.24.2)
+      '@ai-sdk/ui-utils': 1.2.4(zod@3.24.2)
       '@opentelemetry/api': 1.9.0
       jsondiffpatch: 0.6.0
       zod: 3.24.2


### PR DESCRIPTION
- alter the add/get object methods to _only_ work with string values input/output values. 
   - e.g., the types were too flexible when adding or getting an object (Uint8Array, File, or string/path), and agents were getting confused on how to write or read data.
- move function call definitions into the `tools` vs handling logic in the `RecallAPI` (this also makes each tool's function more easily).
- include `getTools` on the Recall API so that agent toolkit instances can use it directly when setting up tools.
- allow `prompts` and `parameters` to accept the `context` arg. 
   - we don't do anything with this yet, but it'll set us up for future features, like injecting bucket aliases or competition / agent config data into an agent's prompt.
    ```ts
    export const getOrCreateBucketPrompt = (_context: Context = {}) => `
    Gets an existing bucket by alias, or creates a new one if it doesn't exist. Use this to ensure you have a bucket for storage.
    
    // add some logic to inject the alias as a predefined param, or tell the agent to create their own if one isnt provided
    ...
    ```

- update prompts with some language tweaks, which includes describing the return type shape.
- allow the `context` to be optional. currently, the only thing we use here is the `network`, and we already handle setting a default if the value isnt present. now, the main difference is that you can just omit the `context` key:
    ```ts
    const toolkit = new RecallAgentToolkit({
      privateKey: "0x...",
      configuration: {
        actions: {
          account: {
            read: true,
            write: true,
          },
        },
        context: {} // this is no longer required, so you can remove `context` and just pass `actions`
      },
    });
    ```
- fixup some examples
- update ai-related deps to the the latest
- add more docstrings