### PR TITLE
feat: allow hex or non-hex private key

### DIFF
--- a/.changeset/evil-areas-divide.md
+++ b/.changeset/evil-areas-divide.md
@@ -1,0 +1,5 @@
+---
+"@recallnet/sdk": patch
+---
+
+allow string valued private keys, and let clients instantiate w/o 'chains' package import

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -25,7 +25,7 @@ import { SubnetId } from "./ipc/subnet.js";
 // Creates a public client for the given chain
 export const createPublicClientForChain: (
   chain: Chain,
-) => PublicClient<Transport, Chain> = (chain: Chain) =>
+) => PublicClient<Transport, Chain> = (chain: Chain = testnet) =>
   createPublicClient({
     chain,
     transport: http(),

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -88,14 +88,33 @@ export class RecallClient {
     this.contractOverrides = config.contractOverrides ?? {};
   }
 
-  // Creates a RecallClient from a chain
-  static fromChain(chain: Chain = testnet) {
+  // Creates a RecallClient with read & write capabilities from a private key
+  static fromPrivateKey(
+    privateKey: string,
+    chain: Chain = testnet,
+    contractOverrides?: ContractOverrides,
+  ): RecallClient {
+    const walletClient = walletClientFromPrivateKey(privateKey, chain);
+    const publicClient = createPublicClientForChain(chain);
     return new RecallClient({
-      publicClient: createPublicClient({ chain, transport: http() }),
+      publicClient,
+      walletClient,
+      contractOverrides,
     });
   }
 
-  // Creates a RecallClient from a chain name
+  // Creates a public RecallClient from a chain
+  static fromChain(
+    chain: Chain = testnet,
+    contractOverrides?: ContractOverrides,
+  ) {
+    return new RecallClient({
+      publicClient: createPublicClient({ chain, transport: http() }),
+      contractOverrides,
+    });
+  }
+
+  // Creates a public RecallClient from a chain name
   static fromChainName(chainName: ChainName = "testnet") {
     return new RecallClient({
       publicClient: createPublicClient({

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -9,6 +9,7 @@ import {
   createPublicClient,
   createWalletClient,
   http,
+  isHex,
 } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
 import "viem/window";
@@ -32,11 +33,12 @@ export const createPublicClientForChain: (
 
 // Creates a wallet client for the given chain with a private key
 export const walletClientFromPrivateKey = (
-  privateKey: Hex,
-  chain: Chain,
+  privateKey: string,
+  chain: Chain = testnet,
 ): WalletClient<Transport, Chain, Account> => {
+  const hexPrivateKey = isHex(privateKey) ? privateKey : `0x${privateKey}`;
   return createWalletClient({
-    account: privateKeyToAccount(privateKey),
+    account: privateKeyToAccount(hexPrivateKey as Hex),
     chain,
     transport: http(),
   });


### PR DESCRIPTION
- Alter the `walletClientFromPrivateKey` to allow for a raw string value that can be `0x` or non-`0x` prefixed, making it more flexible for ppl to use. (Before, it only worked if `0x` prefixed.)
- Add a new static `fromPrivateKey` method so that you can just instantiate a `RecallClient` from a private key value, instead of having to set up the wallet client and pass that in the constructor.
- Make `testnet` the default chain in `fromPrivateKey`, `walletClientFromPrivateKey`, and `createPublicClientForChain`. This eliminates the need to also install/import the `@recallnet/chains` package, unless you want to override the default.