### PR TITLE
fix: remove html error responses

### DIFF
--- a/apps/api/e2e/tests/rate-limiter.test.ts
+++ b/apps/api/e2e/tests/rate-limiter.test.ts
@@ -369,17 +369,33 @@ describe("Rate Limiter Middleware", () => {
           ).toBe(true);
 
           // Verify rate limit headers
-          expect(axiosError.response.headers["retry-after"]).toBeDefined();
-          expect(
-            axiosError.response.headers["x-ratelimit-reset"],
-          ).toBeDefined();
+          const headerKeys = Object.keys(axiosError.response.headers).map(
+            (key) => key.toLowerCase(),
+          );
 
-          // Parse header values
+          // Check for retry-after header (case-insensitive)
+          const hasRetryAfterHeader = headerKeys.includes("retry-after");
+          expect(hasRetryAfterHeader).toBe(true);
+
+          // Check for x-ratelimit-reset header (case-insensitive)
+          const hasRateLimitResetHeader =
+            headerKeys.includes("x-ratelimit-reset");
+          expect(hasRateLimitResetHeader).toBe(true);
+
+          // Find the actual header keys (preserving original case for logging)
+          const retryAfterKey = Object.keys(axiosError.response.headers).find(
+            (key) => key.toLowerCase() === "retry-after",
+          );
+          const rateLimitResetKey = Object.keys(
+            axiosError.response.headers,
+          ).find((key) => key.toLowerCase() === "x-ratelimit-reset");
+
+          // Parse header values (using the actual keys)
           const retryAfter = parseInt(
-            axiosError.response.headers["retry-after"] as string,
+            axiosError.response.headers[retryAfterKey as string] as string,
           );
           const resetTime = parseInt(
-            axiosError.response.headers["x-ratelimit-reset"] as string,
+            axiosError.response.headers[rateLimitResetKey as string] as string,
           );
 
           // Verify they contain meaningful values

--- a/apps/api/src/middleware/errorHandler.ts
+++ b/apps/api/src/middleware/errorHandler.ts
@@ -1,4 +1,4 @@
-import { Request, Response } from "express";
+import { NextFunction, Request, Response } from "express";
 
 /**
  * Custom error class with HTTP status code
@@ -17,7 +17,13 @@ export class ApiError extends Error {
 /**
  * Global error handler middleware
  */
-const errorHandler = (err: Error | ApiError, req: Request, res: Response) => {
+const errorHandler = (
+  err: Error | ApiError,
+  req: Request,
+  res: Response,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  next: NextFunction,
+) => {
   console.error(`Error: ${err.message}`);
   console.error(err.stack);
 


### PR DESCRIPTION
# Summary

- Somehow with the turbo-related changes some of my error responses were defaulting to html
- Fixed by standardizing in error handler 