### PR TITLE
feat: allow teams to reset their api keys

### DIFF
--- a/apps/api/e2e/tests/team.test.ts
+++ b/apps/api/e2e/tests/team.test.ts
@@ -4,6 +4,7 @@ import {
   AdminTeamsListResponse,
   CreateCompetitionResponse,
   PriceResponse,
+  ResetApiKeyResponse,
   TeamMetadata,
   TeamProfileResponse,
   TeamRegistrationResponse,
@@ -454,6 +455,63 @@ describe("Team API", () => {
     for (let i = 0; i < 3; i++) {
       const verifyResponse = await teamClient.getBalance();
       expect(verifyResponse.success).toBe(true);
+    }
+  });
+
+  test("team can reset their API key", async () => {
+    // Setup admin client
+    const adminClient = createTestClient();
+    const adminLoginSuccess = await adminClient.loginAsAdmin(adminApiKey);
+    expect(adminLoginSuccess).toBe(true);
+
+    // Step 1: Register a new team
+    const teamName = `API Reset Team ${Date.now()}`;
+    const email = `api-reset-${Date.now()}@example.com`;
+    const contactPerson = "API Reset Contact";
+
+    // Register the team
+    const { client: teamClient, apiKey: originalApiKey } =
+      await registerTeamAndGetClient(
+        adminClient,
+        teamName,
+        email,
+        contactPerson,
+      );
+
+    // Step 2: Verify initial authentication works
+    const profileResponse = await teamClient.getProfile();
+    expect(profileResponse.success).toBe(true);
+
+    // Step 3: Reset the API key
+    const resetResponse = await teamClient.resetApiKey();
+    expect(resetResponse.success).toBe(true);
+
+    const resetApiKeyResponse = resetResponse as ResetApiKeyResponse;
+    expect(resetApiKeyResponse.apiKey).toBeDefined();
+    expect(resetApiKeyResponse.apiKey).not.toBe(originalApiKey);
+
+    // Step 4: Create a client with the new API key
+    const newApiKey = resetApiKeyResponse.apiKey;
+    const newClient = adminClient.createTeamClient(newApiKey);
+
+    // Step 5: Verify authentication with the new API key works
+    const newProfileResponse = await newClient.getProfile();
+    expect(newProfileResponse.success).toBe(true);
+
+    // Step 6: Verify the old API key no longer works
+    const oldClient = adminClient.createTeamClient(originalApiKey);
+    try {
+      await oldClient.getProfile();
+      // Should not reach here - authentication should fail
+      expect(false).toBe(true); // Force test to fail if we get here
+    } catch (error) {
+      // Expect authentication error
+      expect(error).toBeDefined();
+      if (axios.isAxiosError(error) && error.response) {
+        expect(error.response.status).toBe(401);
+      } else {
+        expect((error as any).status || 401).toBe(401);
+      }
     }
   });
 });

--- a/apps/api/e2e/tests/team.test.ts
+++ b/apps/api/e2e/tests/team.test.ts
@@ -498,7 +498,7 @@ describe("Team API", () => {
     const newProfileResponse = await newClient.getProfile();
     expect(newProfileResponse.success).toBe(true);
 
-    // Step 6: Verify the old API key no longer works
+    // Step 6: Verify the old API key no longer works and provides a helpful error message
     const oldClient = adminClient.createTeamClient(originalApiKey);
     try {
       await oldClient.getProfile();
@@ -509,6 +509,8 @@ describe("Team API", () => {
       expect(error).toBeDefined();
       if (axios.isAxiosError(error) && error.response) {
         expect(error.response.status).toBe(401);
+        // Verify error message is helpful
+        expect(error.response.data.error).toContain("may have been reset");
       } else {
         expect((error as any).status || 401).toBe(401);
       }

--- a/apps/api/e2e/utils/api-client.ts
+++ b/apps/api/e2e/utils/api-client.ts
@@ -17,6 +17,7 @@ import {
   PriceHistoryResponse,
   PriceResponse,
   QuoteResponse,
+  ResetApiKeyResponse,
   SpecificChain,
   StartCompetitionResponse,
   TeamApiKeyResponse,
@@ -753,6 +754,21 @@ export class ApiClient {
       return response.data;
     } catch (error) {
       return this.handleApiError(error, "publicly register team");
+    }
+  }
+
+  /**
+   * Reset the team's API key
+   * @returns A promise that resolves to the reset API key response
+   */
+  async resetApiKey(): Promise<ResetApiKeyResponse | ErrorResponse> {
+    try {
+      const response = await this.axiosInstance.post(
+        "/api/account/reset-api-key",
+      );
+      return response.data as ResetApiKeyResponse;
+    } catch (error) {
+      return this.handleApiError(error, "reset API key");
     }
   }
 }

--- a/apps/api/e2e/utils/api-types.ts
+++ b/apps/api/e2e/utils/api-types.ts
@@ -418,3 +418,10 @@ export interface TeamApiKeyResponse extends ApiResponse {
     apiKey: string;
   };
 }
+
+// Reset API key response
+export interface ResetApiKeyResponse extends ApiResponse {
+  success: true;
+  apiKey: string;
+  previousKey?: string;
+}

--- a/apps/api/openapi/API.md
+++ b/apps/api/openapi/API.md
@@ -1,0 +1,950 @@
+# Trading Simulator API
+
+API for the Trading Simulator - a platform for simulated cryptocurrency trading competitions
+
+## Authentication Guide
+
+This API uses Bearer token authentication. All protected endpoints require the following header:
+
+- **Authorization**: Bearer your-api-key
+
+Where "your-api-key" is the API key provided during team registration.
+
+### Authentication Examples
+
+**cURL Example:**
+
+```bash
+curl -X GET "https://api.example.com/api/account/balances" \
+  -H "Authorization: Bearer abc123def456_ghi789jkl012" \
+  -H "Content-Type: application/json"
+```
+
+**JavaScript Example:**
+
+```javascript
+const fetchData = async () => {
+  const apiKey = "abc123def456_ghi789jkl012";
+  const response = await fetch("https://api.example.com/api/account/balances", {
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+  });
+
+  return await response.json();
+};
+```
+
+For convenience, we provide an API client that handles authentication automatically. See `docs/examples/api-client.ts`.
+
+## Version: 1.0.0
+
+**Contact information:**  
+API Support  
+support@example.com
+
+**License:** [ISC License](https://opensource.org/licenses/ISC)
+
+### /api/account/profile
+
+#### GET
+
+##### Summary:
+
+Get team profile
+
+##### Description:
+
+Get profile information for the authenticated team
+
+##### Parameters
+
+| Name          | Located in | Description                                                    | Required | Schema |
+| ------------- | ---------- | -------------------------------------------------------------- | -------- | ------ |
+| Authorization | header     | Bearer token for authentication (format "Bearer YOUR_API_KEY") | Yes      | string |
+
+##### Responses
+
+| Code | Description                                      |
+| ---- | ------------------------------------------------ |
+| 200  | Team profile                                     |
+| 401  | Unauthorized - Missing or invalid authentication |
+| 404  | Team not found                                   |
+| 500  | Server error                                     |
+
+##### Security
+
+| Security Schema | Scopes |
+| --------------- | ------ |
+| BearerAuth      |        |
+
+#### PUT
+
+##### Summary:
+
+Update team profile
+
+##### Description:
+
+Update profile information for the authenticated team
+
+##### Parameters
+
+| Name          | Located in | Description                                                    | Required | Schema |
+| ------------- | ---------- | -------------------------------------------------------------- | -------- | ------ |
+| Authorization | header     | Bearer token for authentication (format "Bearer YOUR_API_KEY") | Yes      | string |
+
+##### Responses
+
+| Code | Description                                      |
+| ---- | ------------------------------------------------ |
+| 200  | Updated team profile                             |
+| 401  | Unauthorized - Missing or invalid authentication |
+| 404  | Team not found                                   |
+| 500  | Server error                                     |
+
+##### Security
+
+| Security Schema | Scopes |
+| --------------- | ------ |
+| BearerAuth      |        |
+
+### /api/account/reset-api-key
+
+#### POST
+
+##### Summary:
+
+Reset team API key
+
+##### Description:
+
+Reset the API key for the authenticated team. This will invalidate the current API key and generate a new one.
+
+##### Parameters
+
+| Name          | Located in | Description                                                    | Required | Schema |
+| ------------- | ---------- | -------------------------------------------------------------- | -------- | ------ |
+| Authorization | header     | Bearer token for authentication (format "Bearer YOUR_API_KEY") | Yes      | string |
+
+##### Responses
+
+| Code | Description                                      |
+| ---- | ------------------------------------------------ |
+| 200  | API key reset successfully                       |
+| 401  | Unauthorized - Missing or invalid authentication |
+| 404  | Team not found                                   |
+| 500  | Server error                                     |
+
+##### Security
+
+| Security Schema | Scopes |
+| --------------- | ------ |
+| BearerAuth      |        |
+
+### /api/account/balances
+
+#### GET
+
+##### Summary:
+
+Get token balances
+
+##### Description:
+
+Get all token balances for the authenticated team
+
+##### Parameters
+
+| Name          | Located in | Description                                                    | Required | Schema |
+| ------------- | ---------- | -------------------------------------------------------------- | -------- | ------ |
+| Authorization | header     | Bearer token for authentication (format "Bearer YOUR_API_KEY") | Yes      | string |
+
+##### Responses
+
+| Code | Description                                      |
+| ---- | ------------------------------------------------ |
+| 200  | Team token balances                              |
+| 401  | Unauthorized - Missing or invalid authentication |
+| 500  | Server error                                     |
+
+##### Security
+
+| Security Schema | Scopes |
+| --------------- | ------ |
+| BearerAuth      |        |
+
+### /api/account/portfolio
+
+#### GET
+
+##### Summary:
+
+Get portfolio information
+
+##### Description:
+
+Get portfolio valuation and token details for the authenticated team
+
+##### Parameters
+
+| Name          | Located in | Description                                                    | Required | Schema |
+| ------------- | ---------- | -------------------------------------------------------------- | -------- | ------ |
+| Authorization | header     | Bearer token for authentication (format "Bearer YOUR_API_KEY") | Yes      | string |
+
+##### Responses
+
+| Code | Description                                      |
+| ---- | ------------------------------------------------ |
+| 200  | Team portfolio information                       |
+| 401  | Unauthorized - Missing or invalid authentication |
+| 500  | Server error                                     |
+
+##### Security
+
+| Security Schema | Scopes |
+| --------------- | ------ |
+| BearerAuth      |        |
+
+### /api/account/trades
+
+#### GET
+
+##### Summary:
+
+Get trade history
+
+##### Description:
+
+Get trade history for the authenticated team
+
+##### Parameters
+
+| Name          | Located in | Description                                                    | Required | Schema |
+| ------------- | ---------- | -------------------------------------------------------------- | -------- | ------ |
+| Authorization | header     | Bearer token for authentication (format "Bearer YOUR_API_KEY") | Yes      | string |
+
+##### Responses
+
+| Code | Description                                      |
+| ---- | ------------------------------------------------ |
+| 200  | Team trade history                               |
+| 401  | Unauthorized - Missing or invalid authentication |
+| 500  | Server error                                     |
+
+##### Security
+
+| Security Schema | Scopes |
+| --------------- | ------ |
+| BearerAuth      |        |
+
+### /api/admin/setup
+
+#### POST
+
+##### Summary:
+
+Set up initial admin account
+
+##### Description:
+
+Creates the first admin account. This endpoint is only available when no admin exists in the system.
+
+##### Responses
+
+| Code | Description                                               |
+| ---- | --------------------------------------------------------- |
+| 201  | Admin account created successfully                        |
+| 400  | Missing required parameters or password too short         |
+| 403  | Admin setup not allowed - an admin account already exists |
+| 500  | Server error                                              |
+
+### /api/admin/teams/register
+
+#### POST
+
+##### Summary:
+
+Register a new team
+
+##### Description:
+
+Admin-only endpoint to register a new team. Admins create team accounts and distribute the generated API keys to team members. Teams cannot register themselves.
+
+##### Responses
+
+| Code | Description                                           |
+| ---- | ----------------------------------------------------- |
+| 201  | Team registered successfully                          |
+| 400  | Missing required parameters or invalid wallet address |
+| 409  | Team with this email or wallet address already exists |
+| 500  | Server error                                          |
+
+##### Security
+
+| Security Schema | Scopes |
+| --------------- | ------ |
+| BearerAuth      |        |
+
+### /api/admin/teams
+
+#### GET
+
+##### Summary:
+
+List all teams
+
+##### Description:
+
+Get a list of all non-admin teams
+
+##### Responses
+
+| Code | Description                                  |
+| ---- | -------------------------------------------- |
+| 200  | List of teams                                |
+| 401  | Unauthorized - Admin authentication required |
+| 500  | Server error                                 |
+
+##### Security
+
+| Security Schema | Scopes |
+| --------------- | ------ |
+| BearerAuth      |        |
+
+### /api/admin/teams/{teamId}/key
+
+#### GET
+
+##### Summary:
+
+Get a team's API key
+
+##### Description:
+
+Retrieves the original API key for a team. Use this when teams lose or misplace their API key.
+
+##### Parameters
+
+| Name   | Located in | Description    | Required | Schema |
+| ------ | ---------- | -------------- | -------- | ------ |
+| teamId | path       | ID of the team | Yes      | string |
+
+##### Responses
+
+| Code | Description                                  |
+| ---- | -------------------------------------------- |
+| 200  | API key retrieved successfully               |
+| 401  | Unauthorized - Admin authentication required |
+| 403  | Cannot retrieve API key for admin accounts   |
+| 404  | Team not found                               |
+| 500  | Server error                                 |
+
+##### Security
+
+| Security Schema | Scopes |
+| --------------- | ------ |
+| BearerAuth      |        |
+
+### /api/admin/teams/{teamId}
+
+#### DELETE
+
+##### Summary:
+
+Delete a team
+
+##### Description:
+
+Permanently delete a team and all associated data
+
+##### Parameters
+
+| Name   | Located in | Description              | Required | Schema |
+| ------ | ---------- | ------------------------ | -------- | ------ |
+| teamId | path       | ID of the team to delete | Yes      | string |
+
+##### Responses
+
+| Code | Description                                  |
+| ---- | -------------------------------------------- |
+| 200  | Team deleted successfully                    |
+| 400  | Team ID is required                          |
+| 401  | Unauthorized - Admin authentication required |
+| 403  | Cannot delete admin accounts                 |
+| 404  | Team not found                               |
+| 500  | Server error                                 |
+
+##### Security
+
+| Security Schema | Scopes |
+| --------------- | ------ |
+| BearerAuth      |        |
+
+### /api/admin/competition/create
+
+#### POST
+
+##### Summary:
+
+Create a competition
+
+##### Description:
+
+Create a new competition without starting it. It will be in PENDING status and can be started later.
+
+##### Responses
+
+| Code | Description                                  |
+| ---- | -------------------------------------------- |
+| 201  | Competition created successfully             |
+| 400  | Missing required parameters                  |
+| 401  | Unauthorized - Admin authentication required |
+| 500  | Server error                                 |
+
+##### Security
+
+| Security Schema | Scopes |
+| --------------- | ------ |
+| BearerAuth      |        |
+
+### /api/admin/competition/start
+
+#### POST
+
+##### Summary:
+
+Start a competition
+
+##### Description:
+
+Start a new or existing competition with specified teams. If competitionId is provided, it will start an existing competition. Otherwise, it will create and start a new one.
+
+##### Responses
+
+| Code | Description                                    |
+| ---- | ---------------------------------------------- |
+| 200  | Competition started successfully               |
+| 400  | Missing required parameters                    |
+| 401  | Unauthorized - Admin authentication required   |
+| 404  | Competition not found when using competitionId |
+| 500  | Server error                                   |
+
+##### Security
+
+| Security Schema | Scopes |
+| --------------- | ------ |
+| BearerAuth      |        |
+
+### /api/admin/competition/end
+
+#### POST
+
+##### Summary:
+
+End a competition
+
+##### Description:
+
+End an active competition and finalize the results
+
+##### Responses
+
+| Code | Description                                  |
+| ---- | -------------------------------------------- |
+| 200  | Competition ended successfully               |
+| 400  | Missing competitionId parameter              |
+| 401  | Unauthorized - Admin authentication required |
+| 404  | Competition not found                        |
+| 500  | Server error                                 |
+
+##### Security
+
+| Security Schema | Scopes |
+| --------------- | ------ |
+| BearerAuth      |        |
+
+### /api/admin/competition/{competitionId}/snapshots
+
+#### GET
+
+##### Summary:
+
+Get competition snapshots
+
+##### Description:
+
+Get portfolio snapshots for a competition, optionally filtered by team
+
+##### Parameters
+
+| Name          | Located in | Description                          | Required | Schema |
+| ------------- | ---------- | ------------------------------------ | -------- | ------ |
+| competitionId | path       | ID of the competition                | Yes      | string |
+| teamId        | query      | Optional team ID to filter snapshots | No       | string |
+
+##### Responses
+
+| Code | Description                                      |
+| ---- | ------------------------------------------------ |
+| 200  | Competition snapshots                            |
+| 400  | Missing competitionId or team not in competition |
+| 401  | Unauthorized - Admin authentication required     |
+| 404  | Competition or team not found                    |
+| 500  | Server error                                     |
+
+##### Security
+
+| Security Schema | Scopes |
+| --------------- | ------ |
+| BearerAuth      |        |
+
+### /api/admin/reports/performance
+
+#### GET
+
+##### Summary:
+
+Get performance reports
+
+##### Description:
+
+Get performance reports and leaderboard for a competition
+
+##### Parameters
+
+| Name          | Located in | Description           | Required | Schema |
+| ------------- | ---------- | --------------------- | -------- | ------ |
+| competitionId | query      | ID of the competition | Yes      | string |
+
+##### Responses
+
+| Code | Description                                  |
+| ---- | -------------------------------------------- |
+| 200  | Performance reports                          |
+| 400  | Missing competitionId parameter              |
+| 401  | Unauthorized - Admin authentication required |
+| 404  | Competition not found                        |
+| 500  | Server error                                 |
+
+##### Security
+
+| Security Schema | Scopes |
+| --------------- | ------ |
+| BearerAuth      |        |
+
+### /api/admin/teams/{teamId}/deactivate
+
+#### POST
+
+##### Summary:
+
+Deactivate a team
+
+##### Description:
+
+Deactivate a team from the competition. The team will no longer be able to perform any actions.
+
+##### Parameters
+
+| Name   | Located in | Description                  | Required | Schema |
+| ------ | ---------- | ---------------------------- | -------- | ------ |
+| teamId | path       | ID of the team to deactivate | Yes      | string |
+
+##### Responses
+
+| Code | Description                                  |
+| ---- | -------------------------------------------- |
+| 200  | Team deactivated successfully                |
+| 400  | Missing required parameters                  |
+| 401  | Unauthorized - Admin authentication required |
+| 403  | Cannot deactivate admin accounts             |
+| 404  | Team not found                               |
+| 500  | Server error                                 |
+
+##### Security
+
+| Security Schema | Scopes |
+| --------------- | ------ |
+| BearerAuth      |        |
+
+### /api/admin/teams/{teamId}/reactivate
+
+#### POST
+
+##### Summary:
+
+Reactivate a team
+
+##### Description:
+
+Reactivate a previously deactivated team, allowing them to participate in the competition again.
+
+##### Parameters
+
+| Name   | Located in | Description                  | Required | Schema |
+| ------ | ---------- | ---------------------------- | -------- | ------ |
+| teamId | path       | ID of the team to reactivate | Yes      | string |
+
+##### Responses
+
+| Code | Description                                  |
+| ---- | -------------------------------------------- |
+| 200  | Team reactivated successfully                |
+| 400  | Team is already active                       |
+| 401  | Unauthorized - Admin authentication required |
+| 404  | Team not found                               |
+| 500  | Server error                                 |
+
+##### Security
+
+| Security Schema | Scopes |
+| --------------- | ------ |
+| BearerAuth      |        |
+
+### /api/competition/leaderboard
+
+#### GET
+
+##### Summary:
+
+Get competition leaderboard
+
+##### Description:
+
+Get the leaderboard for the active competition or a specific competition. Access may be restricted to administrators only based on environment configuration.
+
+##### Parameters
+
+| Name          | Located in | Description                                                               | Required | Schema |
+| ------------- | ---------- | ------------------------------------------------------------------------- | -------- | ------ |
+| Authorization | header     | Bearer token for authentication (format "Bearer YOUR_API_KEY")            | Yes      | string |
+| competitionId | query      | Optional competition ID (if not provided, the active competition is used) | No       | string |
+
+##### Responses
+
+| Code | Description                                                                                           |
+| ---- | ----------------------------------------------------------------------------------------------------- |
+| 200  | Competition leaderboard                                                                               |
+| 400  | Bad request - No active competition and no competitionId provided                                     |
+| 401  | Unauthorized - Missing or invalid authentication                                                      |
+| 403  | Forbidden - Access denied due to permission restrictions or team not participating in the competition |
+| 404  | Competition not found                                                                                 |
+| 500  | Server error                                                                                          |
+
+##### Security
+
+| Security Schema | Scopes |
+| --------------- | ------ |
+| BearerAuth      |        |
+
+### /api/competition/status
+
+#### GET
+
+##### Summary:
+
+Get competition status
+
+##### Description:
+
+Get the status of the active competition
+
+##### Parameters
+
+| Name          | Located in | Description                                                    | Required | Schema |
+| ------------- | ---------- | -------------------------------------------------------------- | -------- | ------ |
+| Authorization | header     | Bearer token for authentication (format "Bearer YOUR_API_KEY") | Yes      | string |
+
+##### Responses
+
+| Code | Description                                      |
+| ---- | ------------------------------------------------ |
+| 200  | Competition status                               |
+| 401  | Unauthorized - Missing or invalid authentication |
+| 500  | Server error                                     |
+
+##### Security
+
+| Security Schema | Scopes |
+| --------------- | ------ |
+| BearerAuth      |        |
+
+### /api/competition/rules
+
+#### GET
+
+##### Summary:
+
+Get competition rules
+
+##### Description:
+
+Get the rules, rate limits, and other configuration details for the competition
+
+##### Parameters
+
+| Name          | Located in | Description                                                    | Required | Schema |
+| ------------- | ---------- | -------------------------------------------------------------- | -------- | ------ |
+| Authorization | header     | Bearer token for authentication (format "Bearer YOUR_API_KEY") | Yes      | string |
+
+##### Responses
+
+| Code | Description                                           |
+| ---- | ----------------------------------------------------- |
+| 200  | Competition rules retrieved successfully              |
+| 400  | Bad request - No active competition                   |
+| 401  | Unauthorized - Missing or invalid authentication      |
+| 403  | Forbidden - Team not participating in the competition |
+| 500  | Server error                                          |
+
+##### Security
+
+| Security Schema | Scopes |
+| --------------- | ------ |
+| BearerAuth      |        |
+
+### /api/health
+
+#### GET
+
+##### Summary:
+
+Basic health check
+
+##### Description:
+
+Check if the API is running
+
+##### Responses
+
+| Code | Description    |
+| ---- | -------------- |
+| 200  | API is healthy |
+| 500  | Server error   |
+
+### /api/health/detailed
+
+#### GET
+
+##### Summary:
+
+Detailed health check
+
+##### Description:
+
+Check if the API and all its services are running properly
+
+##### Responses
+
+| Code | Description            |
+| ---- | ---------------------- |
+| 200  | Detailed health status |
+| 500  | Server error           |
+
+### /api/price
+
+#### GET
+
+##### Summary:
+
+Get price for a token
+
+##### Description:
+
+Get the current price of a specified token
+
+##### Parameters
+
+| Name          | Located in | Description                                                    | Required | Schema |
+| ------------- | ---------- | -------------------------------------------------------------- | -------- | ------ |
+| Authorization | header     | Bearer token for authentication (format "Bearer YOUR_API_KEY") | Yes      | string |
+| token         | query      | Token address                                                  | Yes      | string |
+| chain         | query      | Blockchain type of the token                                   | No       | string |
+| specificChain | query      | Specific chain for EVM tokens                                  | No       | string |
+
+##### Responses
+
+| Code | Description                                      |
+| ---- | ------------------------------------------------ |
+| 200  | Token price information                          |
+| 400  | Invalid request parameters                       |
+| 401  | Unauthorized - Missing or invalid authentication |
+| 500  | Server error                                     |
+
+##### Security
+
+| Security Schema | Scopes |
+| --------------- | ------ |
+| BearerAuth      |        |
+
+### /api/price/token-info
+
+#### GET
+
+##### Summary:
+
+Get detailed token information
+
+##### Description:
+
+Get detailed token information including price and specific chain
+
+##### Parameters
+
+| Name          | Located in | Description                                                    | Required | Schema |
+| ------------- | ---------- | -------------------------------------------------------------- | -------- | ------ |
+| Authorization | header     | Bearer token for authentication (format "Bearer YOUR_API_KEY") | Yes      | string |
+| token         | query      | Token address                                                  | Yes      | string |
+| chain         | query      | Blockchain type of the token                                   | No       | string |
+| specificChain | query      | Specific chain for EVM tokens                                  | No       | string |
+
+##### Responses
+
+| Code | Description                                      |
+| ---- | ------------------------------------------------ |
+| 200  | Token information                                |
+| 400  | Invalid request parameters                       |
+| 401  | Unauthorized - Missing or invalid authentication |
+| 500  | Server error                                     |
+
+##### Security
+
+| Security Schema | Scopes |
+| --------------- | ------ |
+| BearerAuth      |        |
+
+### /api/public/teams/register
+
+#### POST
+
+##### Summary:
+
+Register a new team
+
+##### Description:
+
+Public endpoint to register a new team. Teams can self-register with this endpoint without requiring admin authentication.
+
+##### Responses
+
+| Code | Description                                           |
+| ---- | ----------------------------------------------------- |
+| 201  | Team registered successfully                          |
+| 400  | Missing required parameters or invalid wallet address |
+| 409  | Team with this email or wallet address already exists |
+| 500  | Server error                                          |
+
+### /api/trade/execute
+
+#### POST
+
+##### Summary:
+
+Execute a trade
+
+##### Description:
+
+Execute a trade between two tokens
+
+##### Parameters
+
+| Name          | Located in | Description                                                    | Required | Schema |
+| ------------- | ---------- | -------------------------------------------------------------- | -------- | ------ |
+| Authorization | header     | Bearer token for authentication (format "Bearer YOUR_API_KEY") | Yes      | string |
+
+##### Responses
+
+| Code | Description                                                   |
+| ---- | ------------------------------------------------------------- |
+| 200  | Trade executed successfully                                   |
+| 400  | Invalid input parameters                                      |
+| 401  | Unauthorized - Missing or invalid authentication              |
+| 403  | Forbidden - Competition not in progress or other restrictions |
+| 500  | Server error                                                  |
+
+##### Security
+
+| Security Schema | Scopes |
+| --------------- | ------ |
+| BearerAuth      |        |
+
+### /api/trade/quote
+
+#### GET
+
+##### Summary:
+
+Get a quote for a trade
+
+##### Description:
+
+Get a quote for a potential trade between two tokens
+
+##### Parameters
+
+| Name              | Located in | Description                                                    | Required | Schema |
+| ----------------- | ---------- | -------------------------------------------------------------- | -------- | ------ |
+| Authorization     | header     | Bearer token for authentication (format "Bearer YOUR_API_KEY") | Yes      | string |
+| fromToken         | query      | Token address to sell                                          | Yes      | string |
+| toToken           | query      | Token address to buy                                           | Yes      | string |
+| amount            | query      | Amount of fromToken to get quote for                           | Yes      | string |
+| fromChain         | query      | Optional blockchain type for fromToken                         | No       | string |
+| fromSpecificChain | query      | Optional specific chain for fromToken                          | No       | string |
+| toChain           | query      | Optional blockchain type for toToken                           | No       | string |
+| toSpecificChain   | query      | Optional specific chain for toToken                            | No       | string |
+
+##### Responses
+
+| Code | Description                                      |
+| ---- | ------------------------------------------------ |
+| 200  | Quote generated successfully                     |
+| 400  | Invalid input parameters                         |
+| 401  | Unauthorized - Missing or invalid authentication |
+| 500  | Server error                                     |
+
+##### Security
+
+| Security Schema | Scopes |
+| --------------- | ------ |
+| BearerAuth      |        |
+
+### Models
+
+#### Error
+
+| Name      | Type     | Description                          | Required |
+| --------- | -------- | ------------------------------------ | -------- |
+| error     | string   | Error message                        | No       |
+| status    | integer  | HTTP status code                     | No       |
+| timestamp | dateTime | Timestamp of when the error occurred | No       |
+
+#### Trade
+
+| Name              | Type     | Description                                  | Required |
+| ----------------- | -------- | -------------------------------------------- | -------- |
+| id                | string   | Unique trade ID                              | No       |
+| teamId            | string   | Team ID that executed the trade              | No       |
+| competitionId     | string   | ID of the competition this trade is part of  | No       |
+| fromToken         | string   | Token address that was sold                  | No       |
+| toToken           | string   | Token address that was bought                | No       |
+| fromAmount        | number   | Amount of fromToken that was sold            | No       |
+| toAmount          | number   | Amount of toToken that was received          | No       |
+| price             | number   | Price at which the trade was executed        | No       |
+| success           | boolean  | Whether the trade was successfully completed | No       |
+| error             | string   | Error message if the trade failed            | No       |
+| timestamp         | dateTime | Timestamp of when the trade was executed     | No       |
+| fromChain         | string   | Blockchain type of the source token          | No       |
+| toChain           | string   | Blockchain type of the destination token     | No       |
+| fromSpecificChain | string   | Specific chain for the source token          | No       |
+| toSpecificChain   | string   | Specific chain for the destination token     | No       |
+
+#### TokenBalance
+
+| Name          | Type   | Description                   | Required |
+| ------------- | ------ | ----------------------------- | -------- |
+| token         | string | Token address                 | No       |
+| amount        | number | Token balance amount          | No       |
+| chain         | string | Chain the token belongs to    | No       |
+| specificChain | string | Specific chain for EVM tokens | No       |

--- a/apps/api/openapi/openapi.json
+++ b/apps/api/openapi/openapi.json
@@ -1,0 +1,3265 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Trading Simulator API",
+    "version": "1.0.0",
+    "description": "API for the Trading Simulator - a platform for simulated cryptocurrency trading competitions\n      \n## Authentication Guide\n\nThis API uses Bearer token authentication. All protected endpoints require the following header:\n\n- **Authorization**: Bearer your-api-key\n\nWhere \"your-api-key\" is the API key provided during team registration.\n\n### Authentication Examples\n\n**cURL Example:**\n\n```bash\ncurl -X GET \"https://api.example.com/api/account/balances\" \\\n  -H \"Authorization: Bearer abc123def456_ghi789jkl012\" \\\n  -H \"Content-Type: application/json\"\n```\n\n**JavaScript Example:**\n\n```javascript\nconst fetchData = async () => {\n  const apiKey = 'abc123def456_ghi789jkl012';\n  const response = await fetch('https://api.example.com/api/account/balances', {\n    headers: {\n      'Authorization': `Bearer ${apiKey}`,\n      'Content-Type': 'application/json'\n    }\n  });\n  \n  return await response.json();\n};\n```\n\nFor convenience, we provide an API client that handles authentication automatically. See `docs/examples/api-client.ts`.\n      ",
+    "contact": {
+      "name": "API Support",
+      "email": "support@example.com"
+    },
+    "license": {
+      "name": "ISC License",
+      "url": "https://opensource.org/licenses/ISC"
+    }
+  },
+  "servers": [
+    {
+      "url": "http://localhost:3000",
+      "description": "Local development server"
+    },
+    {
+      "url": "https://api.example.com",
+      "description": "Production server"
+    }
+  ],
+  "components": {
+    "securitySchemes": {
+      "BearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "description": "API key provided in the Authorization header using Bearer token authentication"
+      }
+    },
+    "schemas": {
+      "Error": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "type": "string",
+            "description": "Error message"
+          },
+          "status": {
+            "type": "integer",
+            "description": "HTTP status code"
+          },
+          "timestamp": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp of when the error occurred"
+          }
+        }
+      },
+      "Trade": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Unique trade ID"
+          },
+          "teamId": {
+            "type": "string",
+            "description": "Team ID that executed the trade"
+          },
+          "competitionId": {
+            "type": "string",
+            "description": "ID of the competition this trade is part of"
+          },
+          "fromToken": {
+            "type": "string",
+            "description": "Token address that was sold"
+          },
+          "toToken": {
+            "type": "string",
+            "description": "Token address that was bought"
+          },
+          "fromAmount": {
+            "type": "number",
+            "description": "Amount of fromToken that was sold"
+          },
+          "toAmount": {
+            "type": "number",
+            "description": "Amount of toToken that was received"
+          },
+          "price": {
+            "type": "number",
+            "description": "Price at which the trade was executed"
+          },
+          "success": {
+            "type": "boolean",
+            "description": "Whether the trade was successfully completed"
+          },
+          "error": {
+            "type": "string",
+            "description": "Error message if the trade failed"
+          },
+          "timestamp": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp of when the trade was executed"
+          },
+          "fromChain": {
+            "type": "string",
+            "description": "Blockchain type of the source token"
+          },
+          "toChain": {
+            "type": "string",
+            "description": "Blockchain type of the destination token"
+          },
+          "fromSpecificChain": {
+            "type": "string",
+            "description": "Specific chain for the source token"
+          },
+          "toSpecificChain": {
+            "type": "string",
+            "description": "Specific chain for the destination token"
+          }
+        }
+      },
+      "TokenBalance": {
+        "type": "object",
+        "properties": {
+          "token": {
+            "type": "string",
+            "description": "Token address"
+          },
+          "amount": {
+            "type": "number",
+            "description": "Token balance amount"
+          },
+          "chain": {
+            "type": "string",
+            "description": "Chain the token belongs to"
+          },
+          "specificChain": {
+            "type": "string",
+            "description": "Specific chain for EVM tokens"
+          }
+        }
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Auth",
+      "description": "Authentication endpoints"
+    },
+    {
+      "name": "Account",
+      "description": "Account management endpoints"
+    },
+    {
+      "name": "Trade",
+      "description": "Trading endpoints"
+    },
+    {
+      "name": "Price",
+      "description": "Price information endpoints"
+    },
+    {
+      "name": "Competition",
+      "description": "Competition endpoints"
+    },
+    {
+      "name": "Admin",
+      "description": "Admin endpoints"
+    },
+    {
+      "name": "Health",
+      "description": "Health check endpoints"
+    }
+  ],
+  "paths": {
+    "/api/account/profile": {
+      "get": {
+        "tags": [
+          "Account"
+        ],
+        "summary": "Get team profile",
+        "description": "Get profile information for the authenticated team",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Authorization",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Bearer token for authentication (format \"Bearer YOUR_API_KEY\")",
+            "example": "Bearer abc123def456_ghi789jkl012"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Team profile",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "description": "Operation success status"
+                    },
+                    "team": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "description": "Team ID"
+                        },
+                        "name": {
+                          "type": "string",
+                          "description": "Team name"
+                        },
+                        "email": {
+                          "type": "string",
+                          "description": "Team email"
+                        },
+                        "contactPerson": {
+                          "type": "string",
+                          "description": "Contact person name"
+                        },
+                        "metadata": {
+                          "type": "object",
+                          "description": "Optional agent metadata",
+                          "nullable": true,
+                          "properties": {
+                            "ref": {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string",
+                                  "description": "Agent name"
+                                },
+                                "version": {
+                                  "type": "string",
+                                  "description": "Agent version"
+                                },
+                                "url": {
+                                  "type": "string",
+                                  "description": "Link to agent documentation or repository"
+                                }
+                              }
+                            },
+                            "description": {
+                              "type": "string",
+                              "description": "Brief description of the agent"
+                            },
+                            "social": {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string",
+                                  "description": "Agent social name"
+                                },
+                                "email": {
+                                  "type": "string",
+                                  "description": "Contact email for the agent"
+                                },
+                                "twitter": {
+                                  "type": "string",
+                                  "description": "Twitter handle"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "createdAt": {
+                          "type": "string",
+                          "format": "date-time",
+                          "description": "Team creation timestamp"
+                        },
+                        "updatedAt": {
+                          "type": "string",
+                          "format": "date-time",
+                          "description": "Team last update timestamp"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - Missing or invalid authentication"
+          },
+          "404": {
+            "description": "Team not found"
+          },
+          "500": {
+            "description": "Server error"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Account"
+        ],
+        "summary": "Update team profile",
+        "description": "Update profile information for the authenticated team",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Authorization",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Bearer token for authentication (format \"Bearer YOUR_API_KEY\")",
+            "example": "Bearer abc123def456_ghi789jkl012"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "contactPerson": {
+                    "type": "string",
+                    "description": "New contact person name"
+                  },
+                  "metadata": {
+                    "type": "object",
+                    "description": "Optional agent metadata",
+                    "properties": {
+                      "ref": {
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "type": "string",
+                            "description": "Agent name"
+                          },
+                          "version": {
+                            "type": "string",
+                            "description": "Agent version"
+                          },
+                          "url": {
+                            "type": "string",
+                            "description": "Link to agent documentation or repository"
+                          }
+                        }
+                      },
+                      "description": {
+                        "type": "string",
+                        "description": "Brief description of the agent"
+                      },
+                      "social": {
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "type": "string",
+                            "description": "Agent social name"
+                          },
+                          "email": {
+                            "type": "string",
+                            "description": "Contact email for the agent"
+                          },
+                          "twitter": {
+                            "type": "string",
+                            "description": "Twitter handle"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated team profile",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "description": "Operation success status"
+                    },
+                    "team": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "description": "Team ID"
+                        },
+                        "name": {
+                          "type": "string",
+                          "description": "Team name"
+                        },
+                        "email": {
+                          "type": "string",
+                          "description": "Team email"
+                        },
+                        "contactPerson": {
+                          "type": "string",
+                          "description": "Updated contact person name"
+                        },
+                        "metadata": {
+                          "type": "object",
+                          "description": "Optional agent metadata",
+                          "nullable": true,
+                          "properties": {
+                            "ref": {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string",
+                                  "description": "Agent name"
+                                },
+                                "version": {
+                                  "type": "string",
+                                  "description": "Agent version"
+                                },
+                                "url": {
+                                  "type": "string",
+                                  "description": "Link to agent documentation or repository"
+                                }
+                              }
+                            },
+                            "description": {
+                              "type": "string",
+                              "description": "Brief description of the agent"
+                            },
+                            "social": {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string",
+                                  "description": "Agent social name"
+                                },
+                                "email": {
+                                  "type": "string",
+                                  "description": "Contact email for the agent"
+                                },
+                                "twitter": {
+                                  "type": "string",
+                                  "description": "Twitter handle"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "createdAt": {
+                          "type": "string",
+                          "format": "date-time",
+                          "description": "Team creation timestamp"
+                        },
+                        "updatedAt": {
+                          "type": "string",
+                          "format": "date-time",
+                          "description": "Team update timestamp"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - Missing or invalid authentication"
+          },
+          "404": {
+            "description": "Team not found"
+          },
+          "500": {
+            "description": "Server error"
+          }
+        }
+      }
+    },
+    "/api/account/reset-api-key": {
+      "post": {
+        "tags": [
+          "Account"
+        ],
+        "summary": "Reset team API key",
+        "description": "Reset the API key for the authenticated team. This will invalidate the current API key and generate a new one.",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Authorization",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Bearer token for authentication (format \"Bearer YOUR_API_KEY\")",
+            "example": "Bearer abc123def456_ghi789jkl012"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "API key reset successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "description": "Operation success status"
+                    },
+                    "apiKey": {
+                      "type": "string",
+                      "description": "New API key to use for future requests",
+                      "example": "new123key456_xyz789abc"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - Missing or invalid authentication"
+          },
+          "404": {
+            "description": "Team not found"
+          },
+          "500": {
+            "description": "Server error"
+          }
+        }
+      }
+    },
+    "/api/account/balances": {
+      "get": {
+        "tags": [
+          "Account"
+        ],
+        "summary": "Get token balances",
+        "description": "Get all token balances for the authenticated team",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Authorization",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Bearer token for authentication (format \"Bearer YOUR_API_KEY\")",
+            "example": "Bearer abc123def456_ghi789jkl012"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Team token balances",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "description": "Operation success status"
+                    },
+                    "teamId": {
+                      "type": "string",
+                      "description": "Team ID"
+                    },
+                    "balances": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "token": {
+                            "type": "string",
+                            "description": "Token address"
+                          },
+                          "amount": {
+                            "type": "number",
+                            "description": "Token balance amount"
+                          },
+                          "chain": {
+                            "type": "string",
+                            "enum": [
+                              "evm",
+                              "svm"
+                            ],
+                            "description": "Blockchain type of the token"
+                          },
+                          "specificChain": {
+                            "type": "string",
+                            "nullable": true,
+                            "description": "Specific chain for EVM tokens"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - Missing or invalid authentication"
+          },
+          "500": {
+            "description": "Server error"
+          }
+        }
+      }
+    },
+    "/api/account/portfolio": {
+      "get": {
+        "tags": [
+          "Account"
+        ],
+        "summary": "Get portfolio information",
+        "description": "Get portfolio valuation and token details for the authenticated team",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Authorization",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Bearer token for authentication (format \"Bearer YOUR_API_KEY\")",
+            "example": "Bearer abc123def456_ghi789jkl012"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Team portfolio information",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "description": "Operation success status"
+                    },
+                    "teamId": {
+                      "type": "string",
+                      "description": "Team ID"
+                    },
+                    "totalValue": {
+                      "type": "number",
+                      "description": "Total portfolio value in USD"
+                    },
+                    "tokens": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "token": {
+                            "type": "string",
+                            "description": "Token address"
+                          },
+                          "amount": {
+                            "type": "number",
+                            "description": "Token balance amount"
+                          },
+                          "price": {
+                            "type": "number",
+                            "description": "Current token price in USD"
+                          },
+                          "value": {
+                            "type": "number",
+                            "description": "Total value of token holdings in USD"
+                          },
+                          "chain": {
+                            "type": "string",
+                            "enum": [
+                              "evm",
+                              "svm"
+                            ],
+                            "description": "Blockchain type of the token"
+                          },
+                          "specificChain": {
+                            "type": "string",
+                            "nullable": true,
+                            "description": "Specific chain for EVM tokens"
+                          }
+                        }
+                      }
+                    },
+                    "snapshotTime": {
+                      "type": "string",
+                      "format": "date-time",
+                      "description": "Time of the snapshot (if source is 'snapshot')"
+                    },
+                    "source": {
+                      "type": "string",
+                      "enum": [
+                        "snapshot",
+                        "live-calculation"
+                      ],
+                      "description": "Source of the portfolio data"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - Missing or invalid authentication"
+          },
+          "500": {
+            "description": "Server error"
+          }
+        }
+      }
+    },
+    "/api/account/trades": {
+      "get": {
+        "tags": [
+          "Account"
+        ],
+        "summary": "Get trade history",
+        "description": "Get trade history for the authenticated team",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Authorization",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Bearer token for authentication (format \"Bearer YOUR_API_KEY\")",
+            "example": "Bearer abc123def456_ghi789jkl012"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Team trade history",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "description": "Operation success status"
+                    },
+                    "teamId": {
+                      "type": "string",
+                      "description": "Team ID"
+                    },
+                    "trades": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "description": "Unique trade ID"
+                          },
+                          "teamId": {
+                            "type": "string",
+                            "description": "Team ID that executed the trade"
+                          },
+                          "competitionId": {
+                            "type": "string",
+                            "description": "ID of the competition this trade is part of"
+                          },
+                          "fromToken": {
+                            "type": "string",
+                            "description": "Token address that was sold"
+                          },
+                          "toToken": {
+                            "type": "string",
+                            "description": "Token address that was bought"
+                          },
+                          "fromAmount": {
+                            "type": "number",
+                            "description": "Amount of fromToken that was sold"
+                          },
+                          "toAmount": {
+                            "type": "number",
+                            "description": "Amount of toToken that was received"
+                          },
+                          "price": {
+                            "type": "number",
+                            "description": "Price at which the trade was executed"
+                          },
+                          "success": {
+                            "type": "boolean",
+                            "description": "Whether the trade was successfully completed"
+                          },
+                          "error": {
+                            "type": "string",
+                            "description": "Error message if the trade failed"
+                          },
+                          "reason": {
+                            "type": "string",
+                            "description": "Reason provided for executing the trade"
+                          },
+                          "timestamp": {
+                            "type": "string",
+                            "format": "date-time",
+                            "description": "Timestamp of when the trade was executed"
+                          },
+                          "fromChain": {
+                            "type": "string",
+                            "description": "Blockchain type of the source token"
+                          },
+                          "toChain": {
+                            "type": "string",
+                            "description": "Blockchain type of the destination token"
+                          },
+                          "fromSpecificChain": {
+                            "type": "string",
+                            "description": "Specific chain for the source token"
+                          },
+                          "toSpecificChain": {
+                            "type": "string",
+                            "description": "Specific chain for the destination token"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - Missing or invalid authentication"
+          },
+          "500": {
+            "description": "Server error"
+          }
+        }
+      }
+    },
+    "/api/admin/setup": {
+      "post": {
+        "tags": [
+          "Admin"
+        ],
+        "summary": "Set up initial admin account",
+        "description": "Creates the first admin account. This endpoint is only available when no admin exists in the system.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "username",
+                  "password",
+                  "email"
+                ],
+                "properties": {
+                  "username": {
+                    "type": "string",
+                    "description": "Admin username",
+                    "example": "admin"
+                  },
+                  "password": {
+                    "type": "string",
+                    "description": "Admin password (minimum 8 characters)",
+                    "format": "password",
+                    "example": "password123"
+                  },
+                  "email": {
+                    "type": "string",
+                    "format": "email",
+                    "description": "Admin email address",
+                    "example": "admin@example.com"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Admin account created successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "description": "Operation success status"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "Success message"
+                    },
+                    "admin": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "description": "Admin ID"
+                        },
+                        "username": {
+                          "type": "string",
+                          "description": "Admin username"
+                        },
+                        "email": {
+                          "type": "string",
+                          "description": "Admin email"
+                        },
+                        "createdAt": {
+                          "type": "string",
+                          "format": "date-time",
+                          "description": "Account creation timestamp"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing required parameters or password too short"
+          },
+          "403": {
+            "description": "Admin setup not allowed - an admin account already exists"
+          },
+          "500": {
+            "description": "Server error"
+          }
+        }
+      }
+    },
+    "/api/admin/teams/register": {
+      "post": {
+        "tags": [
+          "Admin"
+        ],
+        "summary": "Register a new team",
+        "description": "Admin-only endpoint to register a new team. Admins create team accounts and distribute the generated API keys to team members. Teams cannot register themselves.",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "teamName",
+                  "email",
+                  "contactPerson",
+                  "walletAddress"
+                ],
+                "properties": {
+                  "teamName": {
+                    "type": "string",
+                    "description": "Name of the team",
+                    "example": "Team Alpha"
+                  },
+                  "email": {
+                    "type": "string",
+                    "format": "email",
+                    "description": "Team email address",
+                    "example": "team@example.com"
+                  },
+                  "contactPerson": {
+                    "type": "string",
+                    "description": "Name of the contact person",
+                    "example": "John Doe"
+                  },
+                  "walletAddress": {
+                    "type": "string",
+                    "description": "Ethereum wallet address (must start with 0x)",
+                    "example": 1.0392900530713021e+47
+                  },
+                  "metadata": {
+                    "type": "object",
+                    "description": "Optional metadata about the team's agent",
+                    "example": {
+                      "ref": {
+                        "name": "ksobot",
+                        "version": "1.0.0",
+                        "url": "github.com/example/ksobot"
+                      },
+                      "description": "Trading bot description",
+                      "social": {
+                        "name": "KSO",
+                        "email": "kso@example.com",
+                        "twitter": "hey_kso"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Team registered successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "description": "Operation success status"
+                    },
+                    "team": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "description": "Team ID"
+                        },
+                        "name": {
+                          "type": "string",
+                          "description": "Team name"
+                        },
+                        "email": {
+                          "type": "string",
+                          "description": "Team email"
+                        },
+                        "contactPerson": {
+                          "type": "string",
+                          "description": "Contact person name"
+                        },
+                        "walletAddress": {
+                          "type": "string",
+                          "description": "Ethereum wallet address"
+                        },
+                        "apiKey": {
+                          "type": "string",
+                          "description": "API key for the team to use with Bearer authentication. Admin should securely provide this to the team.",
+                          "example": "abc123def456_ghi789jkl012"
+                        },
+                        "metadata": {
+                          "type": "object",
+                          "description": "Optional agent metadata if provided"
+                        },
+                        "createdAt": {
+                          "type": "string",
+                          "format": "date-time",
+                          "description": "Account creation timestamp"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing required parameters or invalid wallet address"
+          },
+          "409": {
+            "description": "Team with this email or wallet address already exists"
+          },
+          "500": {
+            "description": "Server error"
+          }
+        }
+      }
+    },
+    "/api/admin/teams": {
+      "get": {
+        "tags": [
+          "Admin"
+        ],
+        "summary": "List all teams",
+        "description": "Get a list of all non-admin teams",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of teams",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "description": "Operation success status"
+                    },
+                    "teams": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "description": "Team ID"
+                          },
+                          "name": {
+                            "type": "string",
+                            "description": "Team name"
+                          },
+                          "email": {
+                            "type": "string",
+                            "description": "Team email"
+                          },
+                          "contactPerson": {
+                            "type": "string",
+                            "description": "Contact person name"
+                          },
+                          "createdAt": {
+                            "type": "string",
+                            "format": "date-time",
+                            "description": "Account creation timestamp"
+                          },
+                          "updatedAt": {
+                            "type": "string",
+                            "format": "date-time",
+                            "description": "Account update timestamp"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - Admin authentication required"
+          },
+          "500": {
+            "description": "Server error"
+          }
+        }
+      }
+    },
+    "/api/admin/teams/{teamId}/key": {
+      "get": {
+        "tags": [
+          "Admin"
+        ],
+        "summary": "Get a team's API key",
+        "description": "Retrieves the original API key for a team. Use this when teams lose or misplace their API key.",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "teamId",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "ID of the team"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "API key retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "description": "Operation success status"
+                    },
+                    "team": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "description": "Team ID"
+                        },
+                        "name": {
+                          "type": "string",
+                          "description": "Team name"
+                        },
+                        "apiKey": {
+                          "type": "string",
+                          "description": "The team's API key"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - Admin authentication required"
+          },
+          "403": {
+            "description": "Cannot retrieve API key for admin accounts"
+          },
+          "404": {
+            "description": "Team not found"
+          },
+          "500": {
+            "description": "Server error"
+          }
+        }
+      }
+    },
+    "/api/admin/teams/{teamId}": {
+      "delete": {
+        "tags": [
+          "Admin"
+        ],
+        "summary": "Delete a team",
+        "description": "Permanently delete a team and all associated data",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "teamId",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "ID of the team to delete"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Team deleted successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "description": "Operation success status"
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "Success message"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Team ID is required"
+          },
+          "401": {
+            "description": "Unauthorized - Admin authentication required"
+          },
+          "403": {
+            "description": "Cannot delete admin accounts"
+          },
+          "404": {
+            "description": "Team not found"
+          },
+          "500": {
+            "description": "Server error"
+          }
+        }
+      }
+    },
+    "/api/admin/competition/create": {
+      "post": {
+        "tags": [
+          "Admin"
+        ],
+        "summary": "Create a competition",
+        "description": "Create a new competition without starting it. It will be in PENDING status and can be started later.",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "name"
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "Competition name",
+                    "example": "Spring 2023 Trading Competition"
+                  },
+                  "description": {
+                    "type": "string",
+                    "description": "Competition description",
+                    "example": "A trading competition for the spring semester"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Competition created successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "description": "Operation success status"
+                    },
+                    "competition": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "description": "Competition ID"
+                        },
+                        "name": {
+                          "type": "string",
+                          "description": "Competition name"
+                        },
+                        "description": {
+                          "type": "string",
+                          "description": "Competition description"
+                        },
+                        "status": {
+                          "type": "string",
+                          "enum": [
+                            "PENDING",
+                            "ACTIVE",
+                            "COMPLETED"
+                          ],
+                          "description": "Competition status"
+                        },
+                        "createdAt": {
+                          "type": "string",
+                          "format": "date-time",
+                          "description": "Competition creation date"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing required parameters"
+          },
+          "401": {
+            "description": "Unauthorized - Admin authentication required"
+          },
+          "500": {
+            "description": "Server error"
+          }
+        }
+      }
+    },
+    "/api/admin/competition/start": {
+      "post": {
+        "tags": [
+          "Admin"
+        ],
+        "summary": "Start a competition",
+        "description": "Start a new or existing competition with specified teams. If competitionId is provided, it will start an existing competition. Otherwise, it will create and start a new one.",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "teamIds"
+                ],
+                "properties": {
+                  "competitionId": {
+                    "type": "string",
+                    "description": "ID of an existing competition to start. If not provided, a new competition will be created."
+                  },
+                  "name": {
+                    "type": "string",
+                    "description": "Competition name (required when creating a new competition)",
+                    "example": "Spring 2023 Trading Competition"
+                  },
+                  "description": {
+                    "type": "string",
+                    "description": "Competition description (used when creating a new competition)",
+                    "example": "A trading competition for the spring semester"
+                  },
+                  "teamIds": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "Array of team IDs to include in the competition"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Competition started successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "description": "Operation success status"
+                    },
+                    "competition": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "description": "Competition ID"
+                        },
+                        "name": {
+                          "type": "string",
+                          "description": "Competition name"
+                        },
+                        "description": {
+                          "type": "string",
+                          "description": "Competition description"
+                        },
+                        "startDate": {
+                          "type": "string",
+                          "format": "date-time",
+                          "description": "Competition start date"
+                        },
+                        "endDate": {
+                          "type": "string",
+                          "format": "date-time",
+                          "nullable": true,
+                          "description": "Competition end date (null if not ended)"
+                        },
+                        "status": {
+                          "type": "string",
+                          "enum": [
+                            "PENDING",
+                            "ACTIVE",
+                            "COMPLETED"
+                          ],
+                          "description": "Competition status"
+                        },
+                        "teamIds": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "description": "Team IDs participating in the competition"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing required parameters"
+          },
+          "401": {
+            "description": "Unauthorized - Admin authentication required"
+          },
+          "404": {
+            "description": "Competition not found when using competitionId"
+          },
+          "500": {
+            "description": "Server error"
+          }
+        }
+      }
+    },
+    "/api/admin/competition/end": {
+      "post": {
+        "tags": [
+          "Admin"
+        ],
+        "summary": "End a competition",
+        "description": "End an active competition and finalize the results",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "competitionId"
+                ],
+                "properties": {
+                  "competitionId": {
+                    "type": "string",
+                    "description": "ID of the competition to end"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Competition ended successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "description": "Operation success status"
+                    },
+                    "competition": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "description": "Competition ID"
+                        },
+                        "name": {
+                          "type": "string",
+                          "description": "Competition name"
+                        },
+                        "description": {
+                          "type": "string",
+                          "description": "Competition description"
+                        },
+                        "startDate": {
+                          "type": "string",
+                          "format": "date-time",
+                          "description": "Competition start date"
+                        },
+                        "endDate": {
+                          "type": "string",
+                          "format": "date-time",
+                          "description": "Competition end date"
+                        },
+                        "status": {
+                          "type": "string",
+                          "enum": [
+                            "PENDING",
+                            "ACTIVE",
+                            "COMPLETED"
+                          ],
+                          "description": "Competition status (completed)"
+                        }
+                      }
+                    },
+                    "leaderboard": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "teamId": {
+                            "type": "string",
+                            "description": "Team ID"
+                          },
+                          "value": {
+                            "type": "number",
+                            "description": "Final portfolio value"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing competitionId parameter"
+          },
+          "401": {
+            "description": "Unauthorized - Admin authentication required"
+          },
+          "404": {
+            "description": "Competition not found"
+          },
+          "500": {
+            "description": "Server error"
+          }
+        }
+      }
+    },
+    "/api/admin/competition/{competitionId}/snapshots": {
+      "get": {
+        "tags": [
+          "Admin"
+        ],
+        "summary": "Get competition snapshots",
+        "description": "Get portfolio snapshots for a competition, optionally filtered by team",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "competitionId",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "ID of the competition"
+          },
+          {
+            "in": "query",
+            "name": "teamId",
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "description": "Optional team ID to filter snapshots"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Competition snapshots",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "description": "Operation success status"
+                    },
+                    "snapshots": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "description": "Snapshot ID"
+                          },
+                          "competitionId": {
+                            "type": "string",
+                            "description": "Competition ID"
+                          },
+                          "teamId": {
+                            "type": "string",
+                            "description": "Team ID"
+                          },
+                          "totalValue": {
+                            "type": "number",
+                            "description": "Total portfolio value at snapshot time"
+                          },
+                          "timestamp": {
+                            "type": "string",
+                            "format": "date-time",
+                            "description": "Snapshot timestamp"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing competitionId or team not in competition"
+          },
+          "401": {
+            "description": "Unauthorized - Admin authentication required"
+          },
+          "404": {
+            "description": "Competition or team not found"
+          },
+          "500": {
+            "description": "Server error"
+          }
+        }
+      }
+    },
+    "/api/admin/reports/performance": {
+      "get": {
+        "tags": [
+          "Admin"
+        ],
+        "summary": "Get performance reports",
+        "description": "Get performance reports and leaderboard for a competition",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "competitionId",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "ID of the competition"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Performance reports",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "description": "Operation success status"
+                    },
+                    "competition": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "description": "Competition ID"
+                        },
+                        "name": {
+                          "type": "string",
+                          "description": "Competition name"
+                        },
+                        "description": {
+                          "type": "string",
+                          "description": "Competition description"
+                        },
+                        "startDate": {
+                          "type": "string",
+                          "format": "date-time",
+                          "description": "Competition start date"
+                        },
+                        "endDate": {
+                          "type": "string",
+                          "format": "date-time",
+                          "nullable": true,
+                          "description": "Competition end date"
+                        },
+                        "status": {
+                          "type": "string",
+                          "enum": [
+                            "PENDING",
+                            "ACTIVE",
+                            "COMPLETED"
+                          ],
+                          "description": "Competition status"
+                        }
+                      }
+                    },
+                    "leaderboard": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "rank": {
+                            "type": "integer",
+                            "description": "Team rank on the leaderboard"
+                          },
+                          "teamId": {
+                            "type": "string",
+                            "description": "Team ID"
+                          },
+                          "teamName": {
+                            "type": "string",
+                            "description": "Team name"
+                          },
+                          "portfolioValue": {
+                            "type": "number",
+                            "description": "Portfolio value"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing competitionId parameter"
+          },
+          "401": {
+            "description": "Unauthorized - Admin authentication required"
+          },
+          "404": {
+            "description": "Competition not found"
+          },
+          "500": {
+            "description": "Server error"
+          }
+        }
+      }
+    },
+    "/api/admin/teams/{teamId}/deactivate": {
+      "post": {
+        "tags": [
+          "Admin"
+        ],
+        "summary": "Deactivate a team",
+        "description": "Deactivate a team from the competition. The team will no longer be able to perform any actions.",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "teamId",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "ID of the team to deactivate"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "reason"
+                ],
+                "properties": {
+                  "reason": {
+                    "type": "string",
+                    "description": "Reason for deactivation",
+                    "example": "Violated competition rules by using external API"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Team deactivated successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "description": "Operation success status"
+                    },
+                    "team": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "description": "Team ID"
+                        },
+                        "name": {
+                          "type": "string",
+                          "description": "Team name"
+                        },
+                        "active": {
+                          "type": "boolean",
+                          "description": "Active status (will be false)"
+                        },
+                        "deactivationReason": {
+                          "type": "string",
+                          "description": "Reason for deactivation"
+                        },
+                        "deactivationDate": {
+                          "type": "string",
+                          "format": "date-time",
+                          "description": "Date of deactivation"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing required parameters"
+          },
+          "401": {
+            "description": "Unauthorized - Admin authentication required"
+          },
+          "403": {
+            "description": "Cannot deactivate admin accounts"
+          },
+          "404": {
+            "description": "Team not found"
+          },
+          "500": {
+            "description": "Server error"
+          }
+        }
+      }
+    },
+    "/api/admin/teams/{teamId}/reactivate": {
+      "post": {
+        "tags": [
+          "Admin"
+        ],
+        "summary": "Reactivate a team",
+        "description": "Reactivate a previously deactivated team, allowing them to participate in the competition again.",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "teamId",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "ID of the team to reactivate"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Team reactivated successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "description": "Operation success status"
+                    },
+                    "team": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "description": "Team ID"
+                        },
+                        "name": {
+                          "type": "string",
+                          "description": "Team name"
+                        },
+                        "active": {
+                          "type": "boolean",
+                          "description": "Active status (will be true)"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Team is already active"
+          },
+          "401": {
+            "description": "Unauthorized - Admin authentication required"
+          },
+          "404": {
+            "description": "Team not found"
+          },
+          "500": {
+            "description": "Server error"
+          }
+        }
+      }
+    },
+    "/api/competition/leaderboard": {
+      "get": {
+        "tags": [
+          "Competition"
+        ],
+        "summary": "Get competition leaderboard",
+        "description": "Get the leaderboard for the active competition or a specific competition. Access may be restricted to administrators only based on environment configuration.",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Authorization",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Bearer token for authentication (format \"Bearer YOUR_API_KEY\")",
+            "example": "Bearer abc123def456_ghi789jkl012"
+          },
+          {
+            "in": "query",
+            "name": "competitionId",
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "description": "Optional competition ID (if not provided, the active competition is used)"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Competition leaderboard",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "description": "Operation success status"
+                    },
+                    "competition": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "description": "Competition ID"
+                        },
+                        "name": {
+                          "type": "string",
+                          "description": "Competition name"
+                        },
+                        "description": {
+                          "type": "string",
+                          "nullable": true,
+                          "description": "Competition description"
+                        },
+                        "startDate": {
+                          "type": "string",
+                          "format": "date-time",
+                          "description": "Competition start date"
+                        },
+                        "endDate": {
+                          "type": "string",
+                          "format": "date-time",
+                          "nullable": true,
+                          "description": "Competition end date"
+                        },
+                        "status": {
+                          "type": "string",
+                          "enum": [
+                            "PENDING",
+                            "ACTIVE",
+                            "COMPLETED"
+                          ],
+                          "description": "Competition status"
+                        },
+                        "createdAt": {
+                          "type": "string",
+                          "format": "date-time",
+                          "description": "When the competition was created"
+                        },
+                        "updatedAt": {
+                          "type": "string",
+                          "format": "date-time",
+                          "description": "When the competition was last updated"
+                        }
+                      }
+                    },
+                    "leaderboard": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "rank": {
+                            "type": "integer",
+                            "description": "Team rank on the leaderboard"
+                          },
+                          "teamId": {
+                            "type": "string",
+                            "description": "Team ID"
+                          },
+                          "teamName": {
+                            "type": "string",
+                            "description": "Team name"
+                          },
+                          "portfolioValue": {
+                            "type": "number",
+                            "description": "Current portfolio value in USD"
+                          },
+                          "active": {
+                            "type": "boolean",
+                            "description": "Whether the team is active"
+                          },
+                          "deactivationReason": {
+                            "type": "string",
+                            "nullable": true,
+                            "description": "Reason for deactivation if applicable"
+                          }
+                        }
+                      }
+                    },
+                    "hasInactiveTeams": {
+                      "type": "boolean",
+                      "description": "Indicates if any teams are inactive"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request - No active competition and no competitionId provided"
+          },
+          "401": {
+            "description": "Unauthorized - Missing or invalid authentication"
+          },
+          "403": {
+            "description": "Forbidden - Access denied due to permission restrictions or team not participating in the competition"
+          },
+          "404": {
+            "description": "Competition not found"
+          },
+          "500": {
+            "description": "Server error"
+          }
+        }
+      }
+    },
+    "/api/competition/status": {
+      "get": {
+        "tags": [
+          "Competition"
+        ],
+        "summary": "Get competition status",
+        "description": "Get the status of the active competition",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Authorization",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Bearer token for authentication (format \"Bearer YOUR_API_KEY\")",
+            "example": "Bearer abc123def456_ghi789jkl012"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Competition status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "description": "Operation success status"
+                    },
+                    "active": {
+                      "type": "boolean",
+                      "description": "Whether there is an active competition"
+                    },
+                    "competition": {
+                      "type": "object",
+                      "nullable": true,
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "description": "Competition ID"
+                        },
+                        "name": {
+                          "type": "string",
+                          "description": "Competition name"
+                        },
+                        "description": {
+                          "type": "string",
+                          "nullable": true,
+                          "description": "Competition description"
+                        },
+                        "startDate": {
+                          "type": "string",
+                          "format": "date-time",
+                          "description": "Competition start date"
+                        },
+                        "endDate": {
+                          "type": "string",
+                          "format": "date-time",
+                          "nullable": true,
+                          "description": "Competition end date"
+                        },
+                        "status": {
+                          "type": "string",
+                          "enum": [
+                            "PENDING",
+                            "ACTIVE",
+                            "COMPLETED"
+                          ],
+                          "description": "Competition status"
+                        },
+                        "createdAt": {
+                          "type": "string",
+                          "format": "date-time",
+                          "description": "When the competition was created"
+                        },
+                        "updatedAt": {
+                          "type": "string",
+                          "format": "date-time",
+                          "description": "When the competition was last updated"
+                        }
+                      }
+                    },
+                    "message": {
+                      "type": "string",
+                      "description": "Additional information about the competition status",
+                      "nullable": true
+                    },
+                    "participating": {
+                      "type": "boolean",
+                      "description": "Whether the authenticated team is participating in the competition",
+                      "nullable": true
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - Missing or invalid authentication"
+          },
+          "500": {
+            "description": "Server error"
+          }
+        }
+      }
+    },
+    "/api/competition/rules": {
+      "get": {
+        "tags": [
+          "Competition"
+        ],
+        "summary": "Get competition rules",
+        "description": "Get the rules, rate limits, and other configuration details for the competition",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Authorization",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Bearer token for authentication (format \"Bearer YOUR_API_KEY\")",
+            "example": "Bearer abc123def456_ghi789jkl012"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Competition rules retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "description": "Operation success status"
+                    },
+                    "rules": {
+                      "type": "object",
+                      "properties": {
+                        "tradingRules": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "description": "List of trading rules for the competition"
+                        },
+                        "rateLimits": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "description": "Rate limits for API endpoints"
+                        },
+                        "availableChains": {
+                          "type": "object",
+                          "properties": {
+                            "svm": {
+                              "type": "boolean",
+                              "description": "Whether Solana (SVM) is available"
+                            },
+                            "evm": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              },
+                              "description": "List of available EVM chains"
+                            }
+                          }
+                        },
+                        "slippageFormula": {
+                          "type": "string",
+                          "description": "Formula used for calculating slippage"
+                        },
+                        "portfolioSnapshots": {
+                          "type": "object",
+                          "properties": {
+                            "interval": {
+                              "type": "string",
+                              "description": "Interval between portfolio snapshots"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request - No active competition"
+          },
+          "401": {
+            "description": "Unauthorized - Missing or invalid authentication"
+          },
+          "403": {
+            "description": "Forbidden - Team not participating in the competition"
+          },
+          "500": {
+            "description": "Server error"
+          }
+        }
+      }
+    },
+    "/api/health": {
+      "get": {
+        "tags": [
+          "Health"
+        ],
+        "summary": "Basic health check",
+        "description": "Check if the API is running",
+        "responses": {
+          "200": {
+            "description": "API is healthy",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "description": "Health status of the API",
+                      "example": "ok"
+                    },
+                    "timestamp": {
+                      "type": "string",
+                      "format": "date-time",
+                      "description": "Current server time"
+                    },
+                    "uptime": {
+                      "type": "number",
+                      "description": "Server uptime in seconds"
+                    },
+                    "version": {
+                      "type": "string",
+                      "description": "API version"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error"
+          }
+        }
+      }
+    },
+    "/api/health/detailed": {
+      "get": {
+        "tags": [
+          "Health"
+        ],
+        "summary": "Detailed health check",
+        "description": "Check if the API and all its services are running properly",
+        "responses": {
+          "200": {
+            "description": "Detailed health status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "description": "Overall health status of the API",
+                      "example": "ok"
+                    },
+                    "timestamp": {
+                      "type": "string",
+                      "format": "date-time",
+                      "description": "Current server time"
+                    },
+                    "uptime": {
+                      "type": "number",
+                      "description": "Server uptime in seconds"
+                    },
+                    "version": {
+                      "type": "string",
+                      "description": "API version"
+                    },
+                    "services": {
+                      "type": "object",
+                      "description": "Status of individual services",
+                      "properties": {
+                        "priceTracker": {
+                          "type": "string",
+                          "description": "Status of the price tracker service",
+                          "example": "ok"
+                        },
+                        "balanceManager": {
+                          "type": "string",
+                          "description": "Status of the balance manager service",
+                          "example": "ok"
+                        },
+                        "tradeSimulator": {
+                          "type": "string",
+                          "description": "Status of the trade simulator service",
+                          "example": "ok"
+                        },
+                        "competitionManager": {
+                          "type": "string",
+                          "description": "Status of the competition manager service",
+                          "example": "ok"
+                        },
+                        "teamManager": {
+                          "type": "string",
+                          "description": "Status of the team manager service",
+                          "example": "ok"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error"
+          }
+        }
+      }
+    },
+    "/api/price": {
+      "get": {
+        "tags": [
+          "Price"
+        ],
+        "summary": "Get price for a token",
+        "description": "Get the current price of a specified token",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Authorization",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Bearer token for authentication (format \"Bearer YOUR_API_KEY\")",
+            "example": "Bearer abc123def456_ghi789jkl012"
+          },
+          {
+            "in": "query",
+            "name": "token",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Token address",
+            "example": "So11111111111111111111111111111111111111112"
+          },
+          {
+            "in": "query",
+            "name": "chain",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "evm",
+                "svm"
+              ]
+            },
+            "required": false,
+            "description": "Blockchain type of the token",
+            "example": "svm"
+          },
+          {
+            "in": "query",
+            "name": "specificChain",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "eth",
+                "polygon",
+                "bsc",
+                "arbitrum",
+                "optimism",
+                "avalanche",
+                "base",
+                "linea",
+                "zksync",
+                "scroll",
+                "mantle",
+                "svm"
+              ]
+            },
+            "required": false,
+            "description": "Specific chain for EVM tokens",
+            "example": "eth"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Token price information",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "description": "Whether the price was successfully retrieved"
+                    },
+                    "price": {
+                      "type": "number",
+                      "nullable": true,
+                      "description": "Current price of the token in USD"
+                    },
+                    "token": {
+                      "type": "string",
+                      "description": "Token address"
+                    },
+                    "chain": {
+                      "type": "string",
+                      "enum": [
+                        "EVM",
+                        "SVM"
+                      ],
+                      "description": "Blockchain type of the token"
+                    },
+                    "specificChain": {
+                      "type": "string",
+                      "nullable": true,
+                      "description": "Specific chain for EVM tokens"
+                    },
+                    "timestamp": {
+                      "type": "string",
+                      "format": "date-time",
+                      "description": "Timestamp when the price was fetched"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request parameters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - Missing or invalid authentication"
+          },
+          "500": {
+            "description": "Server error"
+          }
+        }
+      }
+    },
+    "/api/price/token-info": {
+      "get": {
+        "tags": [
+          "Price"
+        ],
+        "summary": "Get detailed token information",
+        "description": "Get detailed token information including price and specific chain",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Authorization",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Bearer token for authentication (format \"Bearer YOUR_API_KEY\")",
+            "example": "Bearer abc123def456_ghi789jkl012"
+          },
+          {
+            "in": "query",
+            "name": "token",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Token address",
+            "example": "So11111111111111111111111111111111111111112"
+          },
+          {
+            "in": "query",
+            "name": "chain",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "evm",
+                "svm"
+              ]
+            },
+            "required": false,
+            "description": "Blockchain type of the token",
+            "example": "svm"
+          },
+          {
+            "in": "query",
+            "name": "specificChain",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "eth",
+                "polygon",
+                "bsc",
+                "arbitrum",
+                "optimism",
+                "avalanche",
+                "base",
+                "linea",
+                "zksync",
+                "scroll",
+                "mantle",
+                "svm"
+              ]
+            },
+            "required": false,
+            "description": "Specific chain for EVM tokens",
+            "example": "eth"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Token information",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "description": "Whether the token information was successfully retrieved"
+                    },
+                    "price": {
+                      "type": "number",
+                      "nullable": true,
+                      "description": "Current price of the token in USD"
+                    },
+                    "token": {
+                      "type": "string",
+                      "description": "Token address"
+                    },
+                    "chain": {
+                      "type": "string",
+                      "enum": [
+                        "EVM",
+                        "SVM"
+                      ],
+                      "description": "Blockchain type of the token"
+                    },
+                    "specificChain": {
+                      "type": "string",
+                      "nullable": true,
+                      "description": "Specific chain for EVM tokens"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request parameters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - Missing or invalid authentication"
+          },
+          "500": {
+            "description": "Server error"
+          }
+        }
+      }
+    },
+    "/api/public/teams/register": {
+      "post": {
+        "tags": [
+          "Public"
+        ],
+        "summary": "Register a new team",
+        "description": "Public endpoint to register a new team. Teams can self-register with this endpoint without requiring admin authentication.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "teamName",
+                  "email",
+                  "contactPerson"
+                ],
+                "properties": {
+                  "teamName": {
+                    "type": "string",
+                    "description": "Name of the team",
+                    "example": "Team Alpha"
+                  },
+                  "email": {
+                    "type": "string",
+                    "format": "email",
+                    "description": "Team email address",
+                    "example": "team@example.com"
+                  },
+                  "contactPerson": {
+                    "type": "string",
+                    "description": "Name of the contact person",
+                    "example": "John Doe"
+                  },
+                  "walletAddress": {
+                    "type": "string",
+                    "description": "(Optional) Ethereum wallet address (must start with 0x). If not provided, one will be auto-generated.",
+                    "example": 1.0392900530713021e+47
+                  },
+                  "metadata": {
+                    "type": "object",
+                    "description": "Optional metadata about the team's agent",
+                    "example": {
+                      "ref": {
+                        "name": "ksobot",
+                        "version": "1.0.0",
+                        "url": "github.com/example/ksobot"
+                      },
+                      "description": "Trading bot description",
+                      "social": {
+                        "name": "KSO",
+                        "email": "kso@example.com",
+                        "twitter": "hey_kso"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Team registered successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "description": "Operation success status"
+                    },
+                    "team": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "description": "Team ID"
+                        },
+                        "name": {
+                          "type": "string",
+                          "description": "Team name"
+                        },
+                        "email": {
+                          "type": "string",
+                          "description": "Team email"
+                        },
+                        "contactPerson": {
+                          "type": "string",
+                          "description": "Contact person name"
+                        },
+                        "walletAddress": {
+                          "type": "string",
+                          "description": "Ethereum wallet address"
+                        },
+                        "apiKey": {
+                          "type": "string",
+                          "description": "API key for the team to use with Bearer authentication",
+                          "example": "abc123def456_ghi789jkl012"
+                        },
+                        "metadata": {
+                          "type": "object",
+                          "description": "Optional agent metadata if provided"
+                        },
+                        "createdAt": {
+                          "type": "string",
+                          "format": "date-time",
+                          "description": "Account creation timestamp"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing required parameters or invalid wallet address"
+          },
+          "409": {
+            "description": "Team with this email or wallet address already exists"
+          },
+          "500": {
+            "description": "Server error"
+          }
+        }
+      }
+    },
+    "/api/trade/execute": {
+      "post": {
+        "tags": [
+          "Trade"
+        ],
+        "summary": "Execute a trade",
+        "description": "Execute a trade between two tokens",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Authorization",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Bearer token for authentication (format \"Bearer YOUR_API_KEY\")"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "fromToken",
+                  "toToken",
+                  "amount",
+                  "reason"
+                ],
+                "properties": {
+                  "fromToken": {
+                    "type": "string",
+                    "description": "Token address to sell",
+                    "example": "So11111111111111111111111111111111111111112"
+                  },
+                  "toToken": {
+                    "type": "string",
+                    "description": "Token address to buy",
+                    "example": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+                  },
+                  "amount": {
+                    "type": "string",
+                    "description": "Amount of fromToken to trade",
+                    "example": "1.5"
+                  },
+                  "reason": {
+                    "type": "string",
+                    "description": "Reason for executing this trade",
+                    "example": "Strong upward momentum in the market combined with positive news on this token's ecosystem growth."
+                  },
+                  "slippageTolerance": {
+                    "type": "string",
+                    "description": "Optional slippage tolerance in percentage",
+                    "example": "0.5"
+                  },
+                  "fromChain": {
+                    "type": "string",
+                    "description": "Optional - Blockchain type for fromToken",
+                    "example": "svm"
+                  },
+                  "fromSpecificChain": {
+                    "type": "string",
+                    "description": "Optional - Specific chain for fromToken",
+                    "example": "mainnet"
+                  },
+                  "toChain": {
+                    "type": "string",
+                    "description": "Optional - Blockchain type for toToken",
+                    "example": "svm"
+                  },
+                  "toSpecificChain": {
+                    "type": "string",
+                    "description": "Optional - Specific chain for toToken",
+                    "example": "mainnet"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Trade executed successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "description": "Whether the trade was successfully executed"
+                    },
+                    "transaction": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "description": "Unique trade ID"
+                        },
+                        "teamId": {
+                          "type": "string",
+                          "description": "Team ID that executed the trade"
+                        },
+                        "competitionId": {
+                          "type": "string",
+                          "description": "ID of the competition this trade is part of"
+                        },
+                        "fromToken": {
+                          "type": "string",
+                          "description": "Token address that was sold"
+                        },
+                        "toToken": {
+                          "type": "string",
+                          "description": "Token address that was bought"
+                        },
+                        "fromAmount": {
+                          "type": "number",
+                          "description": "Amount of fromToken that was sold"
+                        },
+                        "toAmount": {
+                          "type": "number",
+                          "description": "Amount of toToken that was received"
+                        },
+                        "price": {
+                          "type": "number",
+                          "description": "Price at which the trade was executed"
+                        },
+                        "success": {
+                          "type": "boolean",
+                          "description": "Whether the trade was successfully completed"
+                        },
+                        "error": {
+                          "type": "string",
+                          "description": "Error message if the trade failed"
+                        },
+                        "reason": {
+                          "type": "string",
+                          "description": "Reason provided for executing the trade"
+                        },
+                        "timestamp": {
+                          "type": "string",
+                          "format": "date-time",
+                          "description": "Timestamp of when the trade was executed"
+                        },
+                        "fromChain": {
+                          "type": "string",
+                          "description": "Blockchain type of the source token"
+                        },
+                        "toChain": {
+                          "type": "string",
+                          "description": "Blockchain type of the destination token"
+                        },
+                        "fromSpecificChain": {
+                          "type": "string",
+                          "description": "Specific chain for the source token"
+                        },
+                        "toSpecificChain": {
+                          "type": "string",
+                          "description": "Specific chain for the destination token"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid input parameters"
+          },
+          "401": {
+            "description": "Unauthorized - Missing or invalid authentication"
+          },
+          "403": {
+            "description": "Forbidden - Competition not in progress or other restrictions"
+          },
+          "500": {
+            "description": "Server error"
+          }
+        }
+      }
+    },
+    "/api/trade/quote": {
+      "get": {
+        "tags": [
+          "Trade"
+        ],
+        "summary": "Get a quote for a trade",
+        "description": "Get a quote for a potential trade between two tokens",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Authorization",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Bearer token for authentication (format \"Bearer YOUR_API_KEY\")"
+          },
+          {
+            "in": "query",
+            "name": "fromToken",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Token address to sell",
+            "example": "So11111111111111111111111111111111111111112"
+          },
+          {
+            "in": "query",
+            "name": "toToken",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Token address to buy",
+            "example": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+          },
+          {
+            "in": "query",
+            "name": "amount",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Amount of fromToken to get quote for",
+            "example": 1.5
+          },
+          {
+            "in": "query",
+            "name": "fromChain",
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "description": "Optional blockchain type for fromToken",
+            "example": "svm"
+          },
+          {
+            "in": "query",
+            "name": "fromSpecificChain",
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "description": "Optional specific chain for fromToken",
+            "example": "mainnet"
+          },
+          {
+            "in": "query",
+            "name": "toChain",
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "description": "Optional blockchain type for toToken",
+            "example": "svm"
+          },
+          {
+            "in": "query",
+            "name": "toSpecificChain",
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "description": "Optional specific chain for toToken",
+            "example": "mainnet"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Quote generated successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "fromToken": {
+                      "type": "string",
+                      "description": "Token address being sold"
+                    },
+                    "toToken": {
+                      "type": "string",
+                      "description": "Token address being bought"
+                    },
+                    "fromAmount": {
+                      "type": "number",
+                      "description": "Amount of fromToken to be sold"
+                    },
+                    "toAmount": {
+                      "type": "number",
+                      "description": "Estimated amount of toToken to be received"
+                    },
+                    "exchangeRate": {
+                      "type": "number",
+                      "description": "Exchange rate between the tokens (toAmount / fromAmount)"
+                    },
+                    "slippage": {
+                      "type": "number",
+                      "description": "Applied slippage percentage for this trade size"
+                    },
+                    "prices": {
+                      "type": "object",
+                      "properties": {
+                        "fromToken": {
+                          "type": "number",
+                          "description": "Price of the source token in USD"
+                        },
+                        "toToken": {
+                          "type": "number",
+                          "description": "Price of the destination token in USD"
+                        }
+                      }
+                    },
+                    "chains": {
+                      "type": "object",
+                      "properties": {
+                        "fromChain": {
+                          "type": "string",
+                          "description": "Blockchain type of the source token"
+                        },
+                        "toChain": {
+                          "type": "string",
+                          "description": "Blockchain type of the destination token"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid input parameters"
+          },
+          "401": {
+            "description": "Unauthorized - Missing or invalid authentication"
+          },
+          "500": {
+            "description": "Server error"
+          }
+        }
+      }
+    }
+  }
+}

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -33,8 +33,8 @@
     "setup:competition": "ts-node scripts/setup-competition.ts",
     "end:competition": "ts-node scripts/end-competition.ts",
     "comp:status": "ts-node scripts/competition-status.ts",
-    "generate-openapi": "ts-node -e \"const { swaggerSpec } = require('./src/config/swagger'); require('fs').writeFileSync('./docs/openapi.json', JSON.stringify(swaggerSpec, null, 2));\"",
-    "generate-markdown": "openapi-markdown -i ./docs/openapi.json -o ./docs/API.md",
+    "generate-openapi": "ts-node -e \"const { swaggerSpec } = require('./src/config/swagger'); require('fs').writeFileSync('./openapi/openapi.json', JSON.stringify(swaggerSpec, null, 2));\"",
+    "generate-markdown": "openapi-markdown -i ./openapi/openapi.json -o ./openapi/API.md",
     "generate-docs": "npm run generate-openapi && npm run generate-markdown"
   },
   "keywords": [

--- a/apps/api/src/controllers/account.controller.ts
+++ b/apps/api/src/controllers/account.controller.ts
@@ -328,4 +328,27 @@ export class AccountController {
       next(error);
     }
   }
+
+  /**
+   * Reset the API key for the authenticated team
+   * @param req Express request
+   * @param res Express response
+   * @param next Express next function
+   */
+  static async resetApiKey(req: Request, res: Response, next: NextFunction) {
+    try {
+      const teamId = req.teamId as string;
+
+      // Use the TeamManager service to reset the API key
+      const result = await services.teamManager.resetApiKey(teamId);
+
+      // Return the new API key
+      res.status(200).json({
+        success: true,
+        apiKey: result.apiKey,
+      });
+    } catch (error) {
+      next(error);
+    }
+  }
 }

--- a/apps/api/src/middleware/admin-auth.middleware.ts
+++ b/apps/api/src/middleware/admin-auth.middleware.ts
@@ -53,7 +53,10 @@ export const adminAuthMiddleware = (teamManager: TeamManager) => {
 
       if (!teamId) {
         console.log("[AdminAuthMiddleware] Invalid API key");
-        throw new ApiError(401, "Invalid API key");
+        throw new ApiError(
+          401,
+          "Invalid API key. This key may have been reset or is no longer associated with an active account. Please ensure you're using your most recent API key.",
+        );
       }
 
       // Get the team to check admin status

--- a/apps/api/src/middleware/auth.middleware.ts
+++ b/apps/api/src/middleware/auth.middleware.ts
@@ -35,7 +35,10 @@ export const authMiddleware = (
 
       if (!teamId) {
         console.log(`[AuthMiddleware] Invalid API key`);
-        throw new ApiError(401, "Invalid API key");
+        throw new ApiError(
+          401,
+          "Invalid API key. This key may have been reset or is no longer associated with an active account. Please ensure you're using your most recent API key.",
+        );
       }
 
       console.log(

--- a/apps/api/src/routes/account.routes.ts
+++ b/apps/api/src/routes/account.routes.ts
@@ -233,6 +233,48 @@ router.put("/profile", AccountController.updateProfile);
 
 /**
  * @openapi
+ * /api/account/reset-api-key:
+ *   post:
+ *     tags:
+ *       - Account
+ *     summary: Reset team API key
+ *     description: Reset the API key for the authenticated team. This will invalidate the current API key and generate a new one.
+ *     security:
+ *       - BearerAuth: []
+ *     parameters:
+ *       - in: header
+ *         name: Authorization
+ *         schema:
+ *           type: string
+ *         required: true
+ *         description: Bearer token for authentication (format "Bearer YOUR_API_KEY")
+ *         example: "Bearer abc123def456_ghi789jkl012"
+ *     responses:
+ *       200:
+ *         description: API key reset successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                   description: Operation success status
+ *                 apiKey:
+ *                   type: string
+ *                   description: New API key to use for future requests
+ *                   example: "new123key456_xyz789abc"
+ *       401:
+ *         description: Unauthorized - Missing or invalid authentication
+ *       404:
+ *         description: Team not found
+ *       500:
+ *         description: Server error
+ */
+router.post("/reset-api-key", AccountController.resetApiKey);
+
+/**
+ * @openapi
  * /api/account/balances:
  *   get:
  *     tags:


### PR DESCRIPTION
# Summary

- Allows teams to reset their api keys, thus updating the `updatedAt` and `apiKey` fields in their corresponding entry in the `teams` table
- Updates the apiKeyCache
- Provide a new test case in team.test.ts e2e test to validate functionality

## Additional Updates

- Regenerated openapi docs given the route change to accounts
- Moved openapi references to location that would be included by git
- Add missing test case for trade reason