### PR TITLE
feat: move cross-chain trading into admin route toggle

### DIFF
--- a/.github/workflows/api-ci.yml
+++ b/.github/workflows/api-ci.yml
@@ -285,9 +285,6 @@ jobs:
           PORTFOLIO_SNAPSHOT_INTERVAL_MS=10000
           PORTFOLIO_PRICE_FRESHNESS_MS=10000
 
-          # Cross-chain trading configuration
-          ALLOW_CROSS_CHAIN_TRADING=false
-
           # Optional: Disable ability for participants to view leaderboard activity
           DISABLE_PARTICIPANT_LEADERBOARD_ACCESS=false
           EOF

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -65,7 +65,6 @@ PORTFOLIO_SNAPSHOT_INTERVAL_MS=120000
 PORTFOLIO_PRICE_FRESHNESS_MS=600000
 
 # Trading Configuration
-ALLOW_CROSS_CHAIN_TRADING=false  # Set to false to disable trades between different chains
 MAX_TRADE_PERCENTAGE=25          # Maximum trade size as percentage of portfolio value (default: 25)
 
 # Optional: Price fetching using our primary provider

--- a/apps/api/.env.test
+++ b/apps/api/.env.test
@@ -55,8 +55,5 @@ INITIAL_BASE_USDC_BALANCE=5000
 PORTFOLIO_SNAPSHOT_INTERVAL_MS=10000
 PORTFOLIO_PRICE_FRESHNESS_MS=10000
 
-# Cross-chain trading configuration
-ALLOW_CROSS_CHAIN_TRADING=false
-
 # Optional: Disable ability for participants to view leaderboard activity
 DISABLE_PARTICIPANT_LEADERBOARD_ACCESS=false

--- a/apps/api/.github/workflows/ci.yml
+++ b/apps/api/.github/workflows/ci.yml
@@ -192,9 +192,6 @@ jobs:
           PORTFOLIO_SNAPSHOT_INTERVAL_MS=10000
           PORTFOLIO_PRICE_FRESHNESS_MS=10000
 
-          # Cross-chain trading configuration
-          ALLOW_CROSS_CHAIN_TRADING=false
-
           # Optional: Disable ability for participants to view leaderboard activity
           DISABLE_PARTICIPANT_LEADERBOARD_ACCESS=false
           EOF

--- a/apps/api/e2e/README.md
+++ b/apps/api/e2e/README.md
@@ -63,16 +63,6 @@ If you modify these values in the `.env.test` file, you may need to also update 
 
 > **Note**: The test suite is designed to adapt to the actual balances available. This flexible approach allows tests to pass with different balance configurations, but the values above are recommended for consistent testing behavior.
 
-### Cross-Chain Trading Tests
-
-The cross-chain trading tests depend on the `ALLOW_CROSS_CHAIN_TRADING` environment variable:
-
-```
-# Set to true to enable cross-chain trading tests
-# Set to false to skip cross-chain trading tests
-ALLOW_CROSS_CHAIN_TRADING=false
-```
-
 Tests will automatically adapt based on this setting, either executing cross-chain trades or skipping those tests.
 
 ## Running Tests

--- a/apps/api/e2e/setup.ts
+++ b/apps/api/e2e/setup.ts
@@ -93,9 +93,6 @@ export async function setup() {
         `- INITIAL_BASE_USDC_BALANCE: ${process.env.INITIAL_BASE_USDC_BALANCE} (was: ${originalBaseUsdcBalance})`,
       );
       console.log(
-        `- ALLOW_CROSS_CHAIN_TRADING: ${process.env.ALLOW_CROSS_CHAIN_TRADING}`,
-      );
-      console.log(
         `- DISABLE_PARTICIPANT_LEADERBOARD_ACCESS: ${process.env.DISABLE_PARTICIPANT_LEADERBOARD_ACCESS} (was: ${originalLeaderboardAccess})`,
       );
     }

--- a/apps/api/e2e/tests/competition.test.ts
+++ b/apps/api/e2e/tests/competition.test.ts
@@ -320,7 +320,7 @@ describe("Competition API", () => {
 
     // There should be one team in the leaderboard
     expect(adminLeaderboardResponse.leaderboard.length).toBe(1);
-    expect(adminLeaderboardResponse.leaderboard[0].teamName).toBe(
+    expect(adminLeaderboardResponse.leaderboard[0]!.teamName).toBe(
       "Regular Team",
     );
 
@@ -448,6 +448,84 @@ describe("Competition API", () => {
     } catch (error) {
       // Expect error due to inactive status
       expect(error).toBeDefined();
+    }
+  });
+
+  test("creating competition with cross-chain trading parameter", async () => {
+    // Setup admin client
+    const adminClient = createTestClient();
+    await adminClient.loginAsAdmin(adminApiKey);
+
+    // Register a team
+    const { client: teamClient, team } = await registerTeamAndGetClient(
+      adminClient,
+      "Cross-Chain Test Team",
+    );
+
+    // Create and start competition with cross-chain trading enabled
+    const competitionName = `Cross-Chain Competition ${Date.now()}`;
+    const competitionResponse = await adminClient.startCompetition({
+      name: competitionName,
+      teamIds: [team.id],
+      allowCrossChainTrading: true,
+    });
+
+    expect(competitionResponse.success).toBe(true);
+
+    // Check competition status to verify it was created
+    const statusResponse = await teamClient.getCompetitionStatus();
+    expect(statusResponse.success).toBe(true);
+
+    if (statusResponse.success && statusResponse.competition) {
+      expect(statusResponse.competition.name).toBe(competitionName);
+    }
+
+    // Check competition rules to verify cross-chain trading is enabled
+    const rulesResponse = await teamClient.getRules();
+    expect(rulesResponse.success).toBe(true);
+
+    // Verify cross-chain trading setting in rules
+    if (rulesResponse.success && rulesResponse.rules) {
+      expect(rulesResponse.rules.tradingRules).toBeDefined();
+
+      // Find the cross-chain trading rule
+      const crossChainRule = rulesResponse.rules.tradingRules.find(
+        (rule: string) => rule.includes("Cross-chain trading"),
+      );
+      expect(crossChainRule).toBeDefined();
+      expect(crossChainRule).toContain("Enabled");
+    }
+
+    // Create second competition with cross-chain trading disabled
+    const secondCompetitionName = `No-Cross-Chain Competition ${Date.now()}`;
+
+    // End the first competition
+    if (competitionResponse.success && "competition" in competitionResponse) {
+      await adminClient.endCompetition(competitionResponse.competition.id);
+
+      // Start a new competition with cross-chain trading disabled
+      const secondCompetitionResponse = await adminClient.startCompetition({
+        name: secondCompetitionName,
+        teamIds: [team.id],
+        allowCrossChainTrading: false,
+      });
+
+      expect(secondCompetitionResponse.success).toBe(true);
+
+      // Check competition rules to verify cross-chain trading is disabled
+      const secondRulesResponse = await teamClient.getRules();
+      expect(secondRulesResponse.success).toBe(true);
+
+      // Verify cross-chain trading setting in rules
+      if (secondRulesResponse.success && secondRulesResponse.rules) {
+        // Find the cross-chain trading rule
+        const secondCrossChainRule =
+          secondRulesResponse.rules.tradingRules.find((rule: string) =>
+            rule.includes("Cross-chain trading"),
+          );
+        expect(secondCrossChainRule).toBeDefined();
+        expect(secondCrossChainRule).toContain("Disabled");
+      }
     }
   });
 });

--- a/apps/api/e2e/tests/trading.test.ts
+++ b/apps/api/e2e/tests/trading.test.ts
@@ -3,12 +3,14 @@ import axios from "axios";
 import config from "../../src/config";
 import { services } from "../../src/services";
 import { BlockchainType } from "../../src/types";
+import { ApiClient } from "../utils/api-client";
 import {
   BalancesResponse,
   ErrorResponse,
   PortfolioResponse,
   PriceResponse,
   SpecificChain,
+  StartCompetitionResponse,
   TokenBalance,
   TradeHistoryResponse,
   TradeResponse,
@@ -61,7 +63,11 @@ describe("Trading API", () => {
 
     // Start a competition with our team
     const competitionName = `Trading Test ${Date.now()}`;
-    await startTestCompetition(adminClient, competitionName, [team.id]);
+    (await adminClient.startCompetition({
+      name: competitionName,
+      teamIds: [team.id],
+      allowCrossChainTrading: true,
+    })) as StartCompetitionResponse;
 
     // Wait for balances to be properly initialized
     await wait(500);
@@ -720,24 +726,6 @@ describe("Trading API", () => {
   });
 
   test("team can trade with Ethereum tokens", async () => {
-    // Skip if Noves provider isn't configured (required for EVM tokens)
-    if (!config.api.noves?.enabled) {
-      console.log(
-        "Skipping Ethereum token test: Noves provider not configured",
-      );
-      return;
-    }
-
-    // Check if cross-chain trading is allowed
-    const allowCrossChainTrading =
-      process.env.ALLOW_CROSS_CHAIN_TRADING === "true";
-    if (!allowCrossChainTrading) {
-      console.log(
-        "Skipping Ethereum token test: Cross-chain trading is disabled",
-      );
-      return;
-    }
-
     // Setup admin client
     const adminClient = createTestClient();
     await adminClient.loginAsAdmin(adminApiKey);
@@ -750,7 +738,11 @@ describe("Trading API", () => {
 
     // Start a competition with our team
     const competitionName = `Ethereum Token Test ${Date.now()}`;
-    await startTestCompetition(adminClient, competitionName, [team.id]);
+    (await adminClient.startCompetition({
+      name: competitionName,
+      teamIds: [team.id],
+      allowCrossChainTrading: true,
+    })) as StartCompetitionResponse;
 
     // Wait for balances to be properly initialized
     await wait(500);
@@ -798,7 +790,7 @@ describe("Trading API", () => {
     const initialEthBalance = parseFloat(
       (initialBalanceResponse as BalancesResponse).balances
         .find((b) => b.token === ethTokenAddress)
-        ?.toString() || "0",
+        ?.amount.toString() || "0",
     );
     console.log(`Initial ETH balance: ${initialEthBalance}`);
 
@@ -816,14 +808,14 @@ describe("Trading API", () => {
       const tradeAmount = Math.min(100, svmUsdcBalance * 0.1);
 
       // Execute a buy trade (buying ETH with USDC)
-      const buyTradeResponse = await teamClient.executeTrade({
+      const buyTradeResponse = (await teamClient.executeTrade({
         fromToken: svmUsdcAddress,
         toToken: ethTokenAddress,
         amount: tradeAmount.toString(),
         fromChain: BlockchainType.SVM,
         toChain: BlockchainType.EVM,
         reason,
-      });
+      })) as TradeResponse;
 
       console.log(
         `Buy ETH trade response: ${JSON.stringify(buyTradeResponse)}`,
@@ -838,7 +830,7 @@ describe("Trading API", () => {
       // ETH balance should have increased
       const updatedEthBalance = parseFloat(
         (updatedBalanceResponse as BalancesResponse).balances
-          .find((b: TokenBalance) => b.token === ethTokenAddress)
+          .find((b) => b.token === ethTokenAddress)
           ?.amount.toString() || "0",
       );
       console.log(`Updated ETH balance: ${updatedEthBalance}`);
@@ -999,18 +991,10 @@ describe("Trading API", () => {
         `Cross-chain trade response: ${JSON.stringify(crossChainTradeResponse)}`,
       );
 
-      // If ALLOW_CROSS_CHAIN_TRADING is false, this should fail
-      const allowCrossChainTrading =
-        process.env.ALLOW_CROSS_CHAIN_TRADING === "true";
-      if (!allowCrossChainTrading) {
-        expect(crossChainTradeResponse.success).toBe(false);
-        expect((crossChainTradeResponse as ErrorResponse).error).toContain(
-          "Cross-chain trading is disabled",
-        );
-      } else {
-        // If cross-chain trading is allowed, this should succeed
-        expect(crossChainTradeResponse.success).toBe(true);
-      }
+      expect(crossChainTradeResponse.success).toBe(false);
+      expect((crossChainTradeResponse as ErrorResponse).error).toContain(
+        "Cross-chain trading is disabled",
+      );
     } catch (error) {
       console.error("Error testing cross-chain trading:", error);
     }
@@ -1141,5 +1125,283 @@ describe("Trading API", () => {
 
     // Verify the trade succeeded when reason is provided
     expect(validTradeResponse.success).toBe(true);
+  });
+
+  test("cross-chain trading respects competition settings", async () => {
+    // Setup admin client
+    const adminClient = createTestClient();
+    await adminClient.loginAsAdmin(adminApiKey);
+
+    // Register team and get client
+    const { client: teamClient, team } = await registerTeamAndGetClient(
+      adminClient,
+      "Cross-Chain Settings Team",
+    );
+
+    // Get token addresses for testing
+    const svmUsdcAddress = config.specificChainTokens.svm.usdc;
+    const ethTokenAddress = config.specificChainTokens.eth.eth;
+
+    if (!ethTokenAddress) {
+      console.log("Skipping test: Ethereum ETH token address not configured");
+      return;
+    }
+
+    // Start a competition with cross-chain trading DISABLED
+    const competitionName = `Cross-Chain Settings Test ${Date.now()}`;
+    const competitionResponse = await adminClient.startCompetition({
+      name: competitionName,
+      teamIds: [team.id],
+      allowCrossChainTrading: false,
+    });
+
+    expect(competitionResponse.success).toBe(true);
+
+    // Wait for balances to be properly initialized
+    await wait(500);
+
+    // Check if competition rules reflect the disabled cross-chain trading
+    const rulesResponse = await teamClient.getRules();
+    expect(rulesResponse.success).toBe(true);
+
+    // Find cross-chain trading rule in the rules list
+    if (rulesResponse.success && rulesResponse.rules) {
+      const crossChainRule = rulesResponse.rules.tradingRules.find(
+        (rule: string) => rule.includes("Cross-chain trading"),
+      );
+      expect(crossChainRule).toBeDefined();
+      expect(crossChainRule).toContain("Disabled");
+    }
+
+    // Verify that cross-chain trading is actually disabled by attempting a cross-chain trade
+    console.log(
+      "Attempting cross-chain trade when it's disabled in competition settings",
+    );
+
+    const balanceResponse = await teamClient.getBalance();
+    const svmUsdcBalance = parseFloat(
+      (balanceResponse as BalancesResponse).balances
+        .find((b) => b.token === svmUsdcAddress)
+        ?.amount.toString() || "0",
+    );
+    const tradeAmount = Math.min(50, svmUsdcBalance * 0.1).toString();
+
+    // Attempt to execute a cross-chain trade (should fail)
+    const crossChainTradeResponse = await teamClient.executeTrade({
+      fromToken: svmUsdcAddress,
+      toToken: ethTokenAddress,
+      amount: tradeAmount,
+      fromChain: BlockchainType.SVM,
+      toChain: BlockchainType.EVM,
+      reason: "testing cross-chain trading disabled",
+    });
+
+    // Expect the trade to fail due to cross-chain trading being disabled
+    expect(crossChainTradeResponse.success).toBe(false);
+    expect((crossChainTradeResponse as ErrorResponse).error).toContain(
+      "Cross-chain trading is disabled",
+    );
+
+    // End the first competition
+    await adminClient.endCompetition(
+      (competitionResponse as StartCompetitionResponse).competition.id,
+    );
+    await wait(500);
+
+    // Start a new competition with cross-chain trading ENABLED
+    const secondCompetitionName = `Cross-Chain Enabled Test ${Date.now()}`;
+    const secondCompetitionResponse = await adminClient.startCompetition({
+      name: secondCompetitionName,
+      teamIds: [team.id],
+      allowCrossChainTrading: true,
+    });
+
+    expect(secondCompetitionResponse.success).toBe(true);
+    await wait(500);
+
+    // Check if competition rules reflect the enabled cross-chain trading
+    const secondRulesResponse = await teamClient.getRules();
+    expect(secondRulesResponse.success).toBe(true);
+
+    // Find cross-chain trading rule in the rules list
+    if (secondRulesResponse.success && secondRulesResponse.rules) {
+      const crossChainRule = secondRulesResponse.rules.tradingRules.find(
+        (rule: string) => rule.includes("Cross-chain trading"),
+      );
+      expect(crossChainRule).toBeDefined();
+      expect(crossChainRule).toContain("Enabled");
+    }
+
+    // Now try to execute a cross-chain trade (should succeed)
+    console.log(
+      "Attempting cross-chain trade when it's enabled in competition settings",
+    );
+
+    const secondTradeResponse = await teamClient.executeTrade({
+      fromToken: svmUsdcAddress,
+      toToken: ethTokenAddress,
+      amount: tradeAmount,
+      fromChain: BlockchainType.SVM,
+      toChain: BlockchainType.EVM,
+      reason: "testing cross-chain trading enabled",
+    });
+
+    // Expect the trade to succeed now that cross-chain trading is enabled
+    expect(secondTradeResponse.success).toBe(true);
+    if (!secondTradeResponse.success) {
+      console.error(
+        "Cross-chain trade failed with error:",
+        (secondTradeResponse as ErrorResponse).error,
+      );
+      console.error("Competition settings were:", secondCompetitionResponse);
+    }
+  });
+
+  test("EVM-to-EVM trades are recognized as cross-chain", async () => {
+    // Check if we have at least two EVM chains configured
+    const evmChains = Object.keys(config.specificChainTokens).filter(
+      (chain) => chain !== "svm" && chain !== "evm",
+    );
+
+    if (evmChains.length < 2) {
+      console.log(
+        "Skipping EVM-to-EVM cross-chain test: Need at least 2 EVM chains configured",
+      );
+      return;
+    }
+
+    // Select two different EVM chains for testing
+    const sourceChain = config.evmChains[0] as SpecificChain;
+    const targetChain = evmChains[1] as SpecificChain;
+
+    console.log(
+      `Testing EVM-to-EVM cross-chain trading from ${sourceChain} to ${targetChain}`,
+    );
+
+    // Get USDC addresses for both chains
+    const sourceUsdcAddress =
+      config.specificChainTokens[
+        sourceChain as keyof typeof config.specificChainTokens
+      ]?.usdc;
+    const targetUsdcAddress =
+      config.specificChainTokens[
+        targetChain as keyof typeof config.specificChainTokens
+      ]?.usdc;
+
+    if (!sourceUsdcAddress || !targetUsdcAddress) {
+      console.log(
+        `Skipping EVM-to-EVM test: USDC not configured for ${sourceChain} or ${targetChain}`,
+      );
+      return;
+    }
+
+    // Setup admin client
+    const adminClient = createTestClient();
+    await adminClient.loginAsAdmin(adminApiKey);
+
+    // Register team and get client
+    const { client: teamClient, team } = await registerTeamAndGetClient(
+      adminClient,
+      "EVM-to-EVM Cross-Chain Team",
+    );
+
+    // Start a competition with cross-chain trading DISABLED first
+    const competitionName = `EVM-EVM Cross-Chain Test ${Date.now()}`;
+    const competitionResponse = await adminClient.startCompetition({
+      name: competitionName,
+      teamIds: [team.id],
+      allowCrossChainTrading: false,
+    });
+
+    expect(competitionResponse.success).toBe(true);
+    await wait(500);
+
+    // Verify the team has some balance on the source chain
+    const initialBalanceResponse = await teamClient.getBalance();
+    const sourceUsdcBalance = parseFloat(
+      (initialBalanceResponse.success &&
+        (initialBalanceResponse as BalancesResponse).balances
+          .find((b) => b.token === sourceUsdcAddress)
+          ?.amount.toString()) ||
+        "0",
+    );
+
+    // If we don't have any balance, we'll need to skip this test
+    if (!sourceUsdcBalance || sourceUsdcBalance <= 0) {
+      console.log(
+        `No balance available for ${sourceChain} USDC, skipping test`,
+      );
+      return;
+    }
+
+    const tradeAmount = Math.min(10, sourceUsdcBalance * 0.1).toString();
+    console.log(
+      `Trading ${tradeAmount} USDC from ${sourceChain} to ${targetChain}`,
+    );
+
+    // Attempt to execute an EVM-to-EVM cross-chain trade when disabled
+    const crossChainTradeResponse = await teamClient.executeTrade({
+      fromToken: sourceUsdcAddress,
+      toToken: targetUsdcAddress,
+      amount: tradeAmount,
+      fromChain: BlockchainType.EVM,
+      toChain: BlockchainType.EVM,
+      fromSpecificChain: sourceChain,
+      toSpecificChain: targetChain,
+      reason: "testing EVM-to-EVM cross-chain trading disabled",
+    });
+
+    // Expect the trade to fail due to cross-chain trading being disabled
+    expect(crossChainTradeResponse.success).toBe(false);
+    expect((crossChainTradeResponse as ErrorResponse).error).toContain(
+      "Cross-chain trading is disabled",
+    );
+
+    // End the first competition
+    await adminClient.endCompetition(
+      (competitionResponse as StartCompetitionResponse).competition.id,
+    );
+    await wait(500);
+
+    // Start a new competition with cross-chain trading ENABLED
+    const secondCompetitionName = `EVM-EVM Cross-Chain Enabled Test ${Date.now()}`;
+    const secondCompetitionResponse = await adminClient.startCompetition({
+      name: secondCompetitionName,
+      teamIds: [team.id],
+      allowCrossChainTrading: true,
+    });
+
+    expect(secondCompetitionResponse.success).toBe(true);
+    await wait(500);
+
+    // Now try to execute the same EVM-to-EVM cross-chain trade (should succeed)
+    const secondTradeResponse = await teamClient.executeTrade({
+      fromToken: sourceUsdcAddress,
+      toToken: targetUsdcAddress,
+      amount: tradeAmount,
+      fromChain: BlockchainType.EVM,
+      toChain: BlockchainType.EVM,
+      fromSpecificChain: sourceChain,
+      toSpecificChain: targetChain,
+      reason: "testing EVM-to-EVM cross-chain trading enabled",
+    });
+
+    // Expect the trade to succeed now that cross-chain trading is enabled
+    expect(secondTradeResponse.success).toBe(true);
+    if (!secondTradeResponse.success) {
+      console.error(
+        "EVM-to-EVM cross-chain trade failed with error:",
+        (secondTradeResponse as ErrorResponse).error,
+      );
+      console.error("Competition settings were:", secondCompetitionResponse);
+      console.error("Trade parameters:", {
+        fromToken: sourceUsdcAddress,
+        toToken: targetUsdcAddress,
+        fromChain: BlockchainType.EVM,
+        toChain: BlockchainType.EVM,
+        fromSpecificChain: sourceChain,
+        toSpecificChain: targetChain,
+      });
+    }
   });
 });

--- a/apps/api/e2e/utils/api-client.ts
+++ b/apps/api/e2e/utils/api-client.ts
@@ -223,18 +223,34 @@ export class ApiClient {
    * Start a competition
    */
   async startCompetition(
-    name: string,
-    description: string,
-    teamIds: string[],
+    params:
+      | {
+          name: string;
+          description?: string;
+          teamIds: string[];
+          allowCrossChainTrading?: boolean;
+        }
+      | string,
+    description?: string,
+    teamIds?: string[],
   ): Promise<StartCompetitionResponse | ErrorResponse> {
     try {
+      let requestData;
+
+      // Handle both object-based and individual parameter calls
+      if (typeof params === "object") {
+        requestData = params;
+      } else {
+        requestData = {
+          name: params,
+          description,
+          teamIds: teamIds || [],
+        };
+      }
+
       const response = await this.axiosInstance.post(
         "/api/admin/competition/start",
-        {
-          name,
-          description,
-          teamIds,
-        },
+        requestData,
       );
 
       return response.data;
@@ -249,6 +265,7 @@ export class ApiClient {
   async createCompetition(
     name: string,
     description?: string,
+    allowCrossChainTrading?: boolean,
   ): Promise<CreateCompetitionResponse | ErrorResponse> {
     try {
       const response = await this.axiosInstance.post(
@@ -256,6 +273,7 @@ export class ApiClient {
         {
           name,
           description,
+          allowCrossChainTrading,
         },
       );
 
@@ -271,6 +289,7 @@ export class ApiClient {
   async startExistingCompetition(
     competitionId: string,
     teamIds: string[],
+    allowCrossChainTrading?: boolean,
   ): Promise<StartCompetitionResponse | ErrorResponse> {
     try {
       const response = await this.axiosInstance.post(
@@ -278,6 +297,7 @@ export class ApiClient {
         {
           competitionId,
           teamIds,
+          allowCrossChainTrading,
         },
       );
 

--- a/apps/api/e2e/utils/api-types.ts
+++ b/apps/api/e2e/utils/api-types.ts
@@ -150,6 +150,7 @@ export interface Competition {
   startDate: string | null;
   endDate: string | null;
   status: CompetitionStatus;
+  allowCrossChainTrading: boolean;
   createdAt: string;
   updatedAt: string;
   teamIds?: string[];

--- a/apps/api/openapi/openapi.json
+++ b/apps/api/openapi/openapi.json
@@ -1331,6 +1331,12 @@
                     "type": "string",
                     "description": "Competition description",
                     "example": "A trading competition for the spring semester"
+                  },
+                  "allowCrossChainTrading": {
+                    "type": "boolean",
+                    "description": "Whether to allow cross-chain trading in this competition",
+                    "default": false,
+                    "example": false
                   }
                 }
               }
@@ -1372,6 +1378,10 @@
                             "COMPLETED"
                           ],
                           "description": "Competition status"
+                        },
+                        "allowCrossChainTrading": {
+                          "type": "boolean",
+                          "description": "Whether cross-chain trading is allowed in this competition"
                         },
                         "createdAt": {
                           "type": "string",
@@ -1439,6 +1449,12 @@
                       "type": "string"
                     },
                     "description": "Array of team IDs to include in the competition"
+                  },
+                  "allowCrossChainTrading": {
+                    "type": "boolean",
+                    "description": "Whether to allow cross-chain trading in this competition (used when creating a new competition)",
+                    "default": false,
+                    "example": false
                   }
                 }
               }
@@ -1491,6 +1507,10 @@
                             "COMPLETED"
                           ],
                           "description": "Competition status"
+                        },
+                        "allowCrossChainTrading": {
+                          "type": "boolean",
+                          "description": "Whether cross-chain trading is allowed in this competition"
                         },
                         "teamIds": {
                           "type": "array",
@@ -1597,6 +1617,10 @@
                             "COMPLETED"
                           ],
                           "description": "Competition status (completed)"
+                        },
+                        "allowCrossChainTrading": {
+                          "type": "boolean",
+                          "description": "Whether cross-chain trading is allowed in this competition"
                         }
                       }
                     },
@@ -1798,6 +1822,10 @@
                             "COMPLETED"
                           ],
                           "description": "Competition status"
+                        },
+                        "allowCrossChainTrading": {
+                          "type": "boolean",
+                          "description": "Whether cross-chain trading is allowed in this competition"
                         }
                       }
                     },

--- a/apps/api/src/config/index.ts
+++ b/apps/api/src/config/index.ts
@@ -237,7 +237,7 @@ export const features = {
   // Enable or disable cross-chain trading functionality
   // When set to false, trades can only occur between tokens on the same chain
   // Defaults to false for security, must be explicitly enabled
-  ALLOW_CROSS_CHAIN_TRADING: process.env.ALLOW_CROSS_CHAIN_TRADING === "true",
+  ALLOW_CROSS_CHAIN_TRADING: false,
 };
 
 export default config;

--- a/apps/api/src/controllers/admin.controller.ts
+++ b/apps/api/src/controllers/admin.controller.ts
@@ -280,7 +280,7 @@ export class AdminController {
     next: NextFunction,
   ) {
     try {
-      const { name, description } = req.body;
+      const { name, description, allowCrossChainTrading } = req.body;
 
       // Validate required parameters
       if (!name) {
@@ -291,6 +291,7 @@ export class AdminController {
       const competition = await services.competitionManager.createCompetition(
         name,
         description,
+        allowCrossChainTrading === true, // Convert to boolean explicitly
       );
 
       // Return the created competition
@@ -314,7 +315,13 @@ export class AdminController {
     next: NextFunction,
   ) {
     try {
-      const { competitionId, name, description, teamIds } = req.body;
+      const {
+        competitionId,
+        name,
+        description,
+        teamIds,
+        allowCrossChainTrading,
+      } = req.body;
 
       // Validate required parameters
       if (!teamIds || !Array.isArray(teamIds) || teamIds.length === 0) {
@@ -353,6 +360,7 @@ export class AdminController {
         competition = await services.competitionManager.createCompetition(
           name,
           description,
+          allowCrossChainTrading === true, // Pass the cross-chain trading parameter
         );
       }
 

--- a/apps/api/src/controllers/competition.controller.ts
+++ b/apps/api/src/controllers/competition.controller.ts
@@ -268,12 +268,13 @@ export class CompetitionController {
       // Check if user is an admin (added by auth middleware)
       const isAdmin = req.isAdmin === true;
 
+      // Get active competition
+      const activeCompetition =
+        await services.competitionManager.getActiveCompetition();
+
       // If not an admin, verify team is part of the active competition
       if (!isAdmin) {
         // Get active competition
-        const activeCompetition =
-          await services.competitionManager.getActiveCompetition();
-
         if (!activeCompetition) {
           throw new ApiError(400, "No active competition");
         }

--- a/apps/api/src/database/init.sql
+++ b/apps/api/src/database/init.sql
@@ -30,6 +30,7 @@ CREATE TABLE IF NOT EXISTS competitions (
   start_date TIMESTAMP WITH TIME ZONE,
   end_date TIMESTAMP WITH TIME ZONE,
   status VARCHAR(20) NOT NULL, -- PENDING, ACTIVE, COMPLETED
+  allow_cross_chain_trading BOOLEAN NOT NULL DEFAULT FALSE, -- Controls cross-chain trading for this competition
   created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
   updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
 );

--- a/apps/api/src/database/repositories/competition-repository.ts
+++ b/apps/api/src/database/repositories/competition-repository.ts
@@ -25,9 +25,9 @@ export class CompetitionRepository extends BaseRepository<Competition> {
     try {
       const query = `
         INSERT INTO competitions (
-          id, name, description, start_date, end_date, status, created_at, updated_at
+          id, name, description, start_date, end_date, status, allow_cross_chain_trading, created_at, updated_at
         ) VALUES (
-          $1, $2, $3, $4, $5, $6, $7, $8
+          $1, $2, $3, $4, $5, $6, $7, $8, $9
         ) RETURNING *
       `;
 
@@ -38,6 +38,7 @@ export class CompetitionRepository extends BaseRepository<Competition> {
         competition.startDate,
         competition.endDate,
         competition.status,
+        competition.allowCrossChainTrading,
         competition.createdAt,
         competition.updatedAt,
       ];
@@ -70,8 +71,9 @@ export class CompetitionRepository extends BaseRepository<Competition> {
           start_date = $3,
           end_date = $4,
           status = $5,
-          updated_at = $6
-        WHERE id = $7
+          allow_cross_chain_trading = $6,
+          updated_at = $7
+        WHERE id = $8
         RETURNING *
       `;
 
@@ -81,6 +83,7 @@ export class CompetitionRepository extends BaseRepository<Competition> {
         competition.startDate,
         competition.endDate,
         competition.status,
+        competition.allowCrossChainTrading,
         new Date(),
         competition.id,
       ];
@@ -511,6 +514,7 @@ export class CompetitionRepository extends BaseRepository<Competition> {
         ? new Date(data.endDate as string | number | Date)
         : null,
       status: data.status as CompetitionStatus,
+      allowCrossChainTrading: data.allowCrossChainTrading as boolean,
       createdAt: new Date(data.createdAt as string | number | Date),
       updatedAt: new Date(data.updatedAt as string | number | Date),
     };

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -83,6 +83,10 @@ const startServer = async () => {
     console.log("Database connection and schema verification completed");
     databaseInitialized = true;
 
+    // Load competition-specific configuration settings
+    await services.configurationService.loadCompetitionSettings();
+    console.log("Competition-specific configuration settings loaded");
+
     // Start snapshot scheduler
     services.scheduler.startSnapshotScheduler();
     console.log("Portfolio snapshot scheduler started");

--- a/apps/api/src/routes/admin.routes.ts
+++ b/apps/api/src/routes/admin.routes.ts
@@ -360,6 +360,11 @@ router.delete("/teams/:teamId", AdminController.deleteTeam);
  *                 type: string
  *                 description: Competition description
  *                 example: A trading competition for the spring semester
+ *               allowCrossChainTrading:
+ *                 type: boolean
+ *                 description: Whether to allow cross-chain trading in this competition
+ *                 default: false
+ *                 example: false
  *     responses:
  *       201:
  *         description: Competition created successfully
@@ -387,6 +392,9 @@ router.delete("/teams/:teamId", AdminController.deleteTeam);
  *                       type: string
  *                       enum: [PENDING, ACTIVE, COMPLETED]
  *                       description: Competition status
+ *                     allowCrossChainTrading:
+ *                       type: boolean
+ *                       description: Whether cross-chain trading is allowed in this competition
  *                     createdAt:
  *                       type: string
  *                       format: date-time
@@ -435,6 +443,11 @@ router.post("/competition/create", AdminController.createCompetition);
  *                 items:
  *                   type: string
  *                 description: Array of team IDs to include in the competition
+ *               allowCrossChainTrading:
+ *                 type: boolean
+ *                 description: Whether to allow cross-chain trading in this competition (used when creating a new competition)
+ *                 default: false
+ *                 example: false
  *     responses:
  *       200:
  *         description: Competition started successfully
@@ -471,6 +484,9 @@ router.post("/competition/create", AdminController.createCompetition);
  *                       type: string
  *                       enum: [PENDING, ACTIVE, COMPLETED]
  *                       description: Competition status
+ *                     allowCrossChainTrading:
+ *                       type: boolean
+ *                       description: Whether cross-chain trading is allowed in this competition
  *                     teamIds:
  *                       type: array
  *                       items:
@@ -544,6 +560,9 @@ router.post("/competition/start", AdminController.startCompetition);
  *                       type: string
  *                       enum: [PENDING, ACTIVE, COMPLETED]
  *                       description: Competition status (completed)
+ *                     allowCrossChainTrading:
+ *                       type: boolean
+ *                       description: Whether cross-chain trading is allowed in this competition
  *                 leaderboard:
  *                   type: array
  *                   items:
@@ -688,6 +707,9 @@ router.get(
  *                       type: string
  *                       enum: [PENDING, ACTIVE, COMPLETED]
  *                       description: Competition status
+ *                     allowCrossChainTrading:
+ *                       type: boolean
+ *                       description: Whether cross-chain trading is allowed in this competition
  *                 leaderboard:
  *                   type: array
  *                   items:

--- a/apps/api/src/services/competition-manager.service.ts
+++ b/apps/api/src/services/competition-manager.service.ts
@@ -69,11 +69,13 @@ export class CompetitionManager {
    * Create a new competition
    * @param name Competition name
    * @param description Optional description
+   * @param allowCrossChainTrading Whether to allow cross-chain trading in this competition (defaults to false)
    * @returns The created competition
    */
   async createCompetition(
     name: string,
     description?: string,
+    allowCrossChainTrading: boolean = false,
   ): Promise<Competition> {
     const id = uuidv4();
     const competition: Competition = {
@@ -83,13 +85,16 @@ export class CompetitionManager {
       startDate: null,
       endDate: null,
       status: CompetitionStatus.PENDING,
+      allowCrossChainTrading,
       createdAt: new Date(),
       updatedAt: new Date(),
     };
 
     await repositories.competitionRepository.create(competition);
 
-    console.log(`[CompetitionManager] Created competition: ${name} (${id})`);
+    console.log(
+      `[CompetitionManager] Created competition: ${name} (${id}), allowCrossChainTrading: ${allowCrossChainTrading}`,
+    );
     return competition;
   }
 
@@ -173,6 +178,10 @@ export class CompetitionManager {
     // Take initial portfolio snapshots
     await this.takePortfolioSnapshots(competitionId);
 
+    // Reload competition-specific configuration settings
+    await services.configurationService.loadCompetitionSettings();
+    console.log(`[CompetitionManager] Reloaded configuration settings`);
+
     return competition;
   }
 
@@ -237,6 +246,10 @@ export class CompetitionManager {
     console.log(
       `[CompetitionManager] Ended competition: ${competition.name} (${competitionId})`,
     );
+
+    // Reload configuration settings (revert to environment defaults)
+    await services.configurationService.loadCompetitionSettings();
+    console.log(`[CompetitionManager] Reloaded configuration settings`);
 
     return competition;
   }

--- a/apps/api/src/services/configuration.service.ts
+++ b/apps/api/src/services/configuration.service.ts
@@ -1,0 +1,40 @@
+import { features } from "../config";
+import { repositories } from "../database";
+
+/**
+ * Configuration Service
+ * Manages dynamic configuration settings loaded from the database
+ */
+export class ConfigurationService {
+  /**
+   * Load competition-specific settings and update global configuration
+   * This method updates the global features object with settings from the active competition
+   */
+  async loadCompetitionSettings(): Promise<void> {
+    try {
+      // Get the active competition from the database
+      const activeCompetition =
+        await repositories.competitionRepository.findActive();
+
+      if (activeCompetition) {
+        // Override the environment-based setting with competition-specific settings
+        features.ALLOW_CROSS_CHAIN_TRADING =
+          activeCompetition.allowCrossChainTrading;
+
+        console.log(
+          `[ConfigurationService] Updated cross-chain trading setting from competition ${activeCompetition.id}: ${features.ALLOW_CROSS_CHAIN_TRADING}`,
+        );
+      } else {
+        // No active competition, keep the environment variable setting
+        console.log(
+          `[ConfigurationService] No active competition, using environment setting for cross-chain trading: ${features.ALLOW_CROSS_CHAIN_TRADING}`,
+        );
+      }
+    } catch (error) {
+      console.error(
+        "[ConfigurationService] Error loading competition settings:",
+        error,
+      );
+    }
+  }
+}

--- a/apps/api/src/services/index.ts
+++ b/apps/api/src/services/index.ts
@@ -1,5 +1,6 @@
 import { BalanceManager } from "./balance-manager.service";
 import { CompetitionManager } from "./competition-manager.service";
+import { ConfigurationService } from "./configuration.service";
 import { PriceTracker } from "./price-tracker.service";
 import { SchedulerService } from "./scheduler.service";
 import { TeamManager } from "./team-manager.service";
@@ -19,6 +20,7 @@ class ServiceRegistry {
   private _competitionManager: CompetitionManager;
   private _teamManager: TeamManager;
   private _scheduler: SchedulerService;
+  private _configurationService: ConfigurationService;
 
   private constructor() {
     // Initialize services in dependency order
@@ -34,6 +36,9 @@ class ServiceRegistry {
       this._priceTracker,
     );
     this._teamManager = new TeamManager();
+
+    // Configuration service for dynamic settings
+    this._configurationService = new ConfigurationService();
 
     // Initialize and start the scheduler
     this._scheduler = new SchedulerService(this._competitionManager);
@@ -75,6 +80,10 @@ class ServiceRegistry {
   get scheduler(): SchedulerService {
     return this._scheduler;
   }
+
+  get configurationService(): ConfigurationService {
+    return this._configurationService;
+  }
 }
 
 // Create and export a singleton instance
@@ -87,4 +96,5 @@ export {
   TradeSimulator,
   CompetitionManager,
   TeamManager,
+  ConfigurationService,
 };

--- a/apps/api/src/services/trade-simulator.service.ts
+++ b/apps/api/src/services/trade-simulator.service.ts
@@ -24,8 +24,6 @@ export class TradeSimulator {
   private priceTracker: PriceTracker;
   // Cache of recent trades for performance (teamId -> trades)
   private tradeCache: Map<string, Trade[]>;
-  // Whether to allow cross-chain trading
-  private allowCrossChainTrading: boolean;
   // Maximum trade percentage of portfolio value
   private maxTradePercentage: number;
 
@@ -33,8 +31,6 @@ export class TradeSimulator {
     this.balanceManager = balanceManager;
     this.priceTracker = priceTracker;
     this.tradeCache = new Map();
-    // Use features config instead of directly accessing environment variable
-    this.allowCrossChainTrading = features.ALLOW_CROSS_CHAIN_TRADING;
     // Get the maximum trade percentage from config
     this.maxTradePercentage = config.maxTradePercentage;
   }
@@ -165,7 +161,7 @@ export class TradeSimulator {
 
       // Check for cross-chain trades if not allowed
       if (
-        !this.allowCrossChainTrading &&
+        !features.ALLOW_CROSS_CHAIN_TRADING &&
         (fromTokenChain !== toTokenChain ||
           (fromTokenSpecificChain &&
             toTokenSpecificChain &&
@@ -205,7 +201,7 @@ export class TradeSimulator {
 
       // Check for cross-chain trades if not allowed
       if (
-        !this.allowCrossChainTrading &&
+        !features.ALLOW_CROSS_CHAIN_TRADING &&
         (fromTokenChain !== toTokenChain ||
           (fromTokenSpecificChain &&
             toTokenSpecificChain &&

--- a/apps/api/src/types/index.ts
+++ b/apps/api/src/types/index.ts
@@ -195,6 +195,7 @@ export interface Competition {
   startDate: Date | null;
   endDate: Date | null;
   status: CompetitionStatus;
+  allowCrossChainTrading: boolean; // Controls whether cross-chain trading is allowed
   createdAt: Date;
   updatedAt: Date;
 }

--- a/apps/api/trade-simulator-docker/DEPLOYMENT.md
+++ b/apps/api/trade-simulator-docker/DEPLOYMENT.md
@@ -466,7 +466,6 @@ Key environment variables to configure:
 
 - **Chain Configuration**:
   - `EVM_CHAINS`: Comma-separated list of supported chains
-  - `ALLOW_CROSS_CHAIN_TRADING`: Enable/disable cross-chain trading
 
 ### .env File Mounting
 

--- a/apps/api/turbo.json
+++ b/apps/api/turbo.json
@@ -1,10 +1,11 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "extends": ["//"],
+  "extends": [
+    "//"
+  ],
   "tasks": {
     "build": {
       "env": [
-        "ALLOW_CROSS_CHAIN_TRADING",
         "ALLOW_MOCK_PRICE_HISTORY",
         "DB_CA_CERT_BASE64",
         "DB_CA_CERT_PATH",


### PR DESCRIPTION
# Summary

- Removed `ALLOW_CROSS_CHAIN_TRADING` from all previous environment locations to persistent location in database, corresponding to the competition itself (introduces a breaking change to the db design)
- Modifies existing admin routes to allow the admin to toggle this setting when creating a competition or starting one
- Provides multiple test cases to confirm functionality takes effect given variants of setting
- Introduces a new configuration service to load these settings into active memory
- uses `loadCompetitionSettings` in the competition manager service's start and end competition to ensure in-memory setting is always current with active competition (if exists), otherwise false