### PR TITLE
feat: add ability to get upcoming (pending) competitions

### DIFF
--- a/apps/api/e2e/utils/api-client.ts
+++ b/apps/api/e2e/utils/api-client.ts
@@ -28,6 +28,7 @@ import {
   TradeExecutionParams,
   TradeHistoryResponse,
   TradeResponse,
+  UpcomingCompetitionsResponse,
 } from "./api-types";
 import { getBaseUrl } from "./server";
 
@@ -492,6 +493,22 @@ export class ApiClient {
       return response.data as CompetitionRulesResponse;
     } catch (error) {
       return this.handleApiError(error, "get competition rules");
+    }
+  }
+
+  /**
+   * Get upcoming competitions (status=PENDING)
+   */
+  async getUpcomingCompetitions(): Promise<
+    UpcomingCompetitionsResponse | ErrorResponse
+  > {
+    try {
+      const response = await this.axiosInstance.get(
+        "/api/competition/upcoming",
+      );
+      return response.data as UpcomingCompetitionsResponse;
+    } catch (error) {
+      return this.handleApiError(error, "get upcoming competitions");
     }
   }
 

--- a/apps/api/e2e/utils/api-types.ts
+++ b/apps/api/e2e/utils/api-types.ts
@@ -307,6 +307,12 @@ export interface StartCompetitionResponse extends ApiResponse {
   initializedTeams: string[];
 }
 
+// Upcoming competitions response
+export interface UpcomingCompetitionsResponse extends ApiResponse {
+  success: true;
+  competitions: Competition[];
+}
+
 // Competition rules response
 export interface CompetitionRulesResponse extends ApiResponse {
   success: true;

--- a/apps/api/openapi/API.md
+++ b/apps/api/openapi/API.md
@@ -705,6 +705,38 @@ Get the rules, rate limits, and other configuration details for the competition
 | --------------- | ------ |
 | BearerAuth      |        |
 
+### /api/competition/upcoming
+
+#### GET
+
+##### Summary:
+
+Get upcoming competitions
+
+##### Description:
+
+Get all competitions that have not started yet (status=PENDING)
+
+##### Parameters
+
+| Name          | Located in | Description                                                    | Required | Schema |
+| ------------- | ---------- | -------------------------------------------------------------- | -------- | ------ |
+| Authorization | header     | Bearer token for authentication (format "Bearer YOUR_API_KEY") | Yes      | string |
+
+##### Responses
+
+| Code | Description                                      |
+| ---- | ------------------------------------------------ |
+| 200  | Upcoming competitions retrieved successfully     |
+| 401  | Unauthorized - Missing or invalid authentication |
+| 500  | Server error                                     |
+
+##### Security
+
+| Security Schema | Scopes |
+| --------------- | ------ |
+| BearerAuth      |        |
+
 ### /api/health
 
 #### GET

--- a/apps/api/openapi/openapi.json
+++ b/apps/api/openapi/openapi.json
@@ -2419,6 +2419,98 @@
         }
       }
     },
+    "/api/competition/upcoming": {
+      "get": {
+        "tags": [
+          "Competition"
+        ],
+        "summary": "Get upcoming competitions",
+        "description": "Get all competitions that have not started yet (status=PENDING)",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Authorization",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "Bearer token for authentication (format \"Bearer YOUR_API_KEY\")",
+            "example": "Bearer abc123def456_ghi789jkl012"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Upcoming competitions retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "description": "Operation success status"
+                    },
+                    "competitions": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "description": "Competition ID"
+                          },
+                          "name": {
+                            "type": "string",
+                            "description": "Competition name"
+                          },
+                          "description": {
+                            "type": "string",
+                            "nullable": true,
+                            "description": "Competition description"
+                          },
+                          "status": {
+                            "type": "string",
+                            "enum": [
+                              "PENDING"
+                            ],
+                            "description": "Competition status (always PENDING)"
+                          },
+                          "allowCrossChainTrading": {
+                            "type": "boolean",
+                            "description": "Whether cross-chain trading is allowed"
+                          },
+                          "createdAt": {
+                            "type": "string",
+                            "format": "date-time",
+                            "description": "When the competition was created"
+                          },
+                          "updatedAt": {
+                            "type": "string",
+                            "format": "date-time",
+                            "description": "When the competition was last updated"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - Missing or invalid authentication"
+          },
+          "500": {
+            "description": "Server error"
+          }
+        }
+      }
+    },
     "/api/health": {
       "get": {
         "tags": [

--- a/apps/api/src/controllers/competition.controller.ts
+++ b/apps/api/src/controllers/competition.controller.ts
@@ -368,4 +368,45 @@ export class CompetitionController {
       next(error);
     }
   }
+
+  /**
+   * Get all upcoming competitions (status=PENDING)
+   * @param req AuthenticatedRequest object with team authentication information
+   * @param res Express response
+   * @param next Express next function
+   */
+  static async getUpcomingCompetitions(
+    req: AuthenticatedRequest,
+    res: Response,
+    next: NextFunction,
+  ) {
+    try {
+      // Check if the team is authenticated
+      const teamId = req.teamId;
+
+      // If no team ID, they can't be authenticated
+      if (!teamId) {
+        throw new ApiError(
+          401,
+          "Authentication required to view upcoming competitions",
+        );
+      }
+
+      console.log(
+        `[CompetitionController] Team ${teamId} requesting upcoming competitions`,
+      );
+
+      // Get all upcoming competitions
+      const upcomingCompetitions =
+        await services.competitionManager.getUpcomingCompetitions();
+
+      // Return the competitions
+      res.status(200).json({
+        success: true,
+        competitions: upcomingCompetitions,
+      });
+    } catch (error) {
+      next(error);
+    }
+  }
 }

--- a/apps/api/src/database/repositories/competition-repository.ts
+++ b/apps/api/src/database/repositories/competition-repository.ts
@@ -499,6 +499,39 @@ export class CompetitionRepository extends BaseRepository<Competition> {
   }
 
   /**
+   * Find competitions by status
+   * @param status The competition status to filter by
+   * @param client Optional database client for transactions
+   */
+  async findByStatus(
+    status: CompetitionStatus,
+    client?: PoolClient,
+  ): Promise<Competition[]> {
+    try {
+      const query = `
+          SELECT * FROM competitions
+          WHERE status = $1
+          ORDER BY created_at DESC
+        `;
+
+      const result = client
+        ? await client.query(query, [status])
+        : await this.db.query(query, [status]);
+
+      return result.rows.map((row: DatabaseRow) => {
+        const camelRow = this.toCamelCase(row);
+        return this.mapToEntity(camelRow);
+      });
+    } catch (error) {
+      console.error(
+        `[CompetitionRepository] Error finding competitions with status ${status}:`,
+        error,
+      );
+      throw error;
+    }
+  }
+
+  /**
    * Map database row to Competition entity
    * @param data Row data with camelCase keys
    */

--- a/apps/api/src/routes/competition.routes.ts
+++ b/apps/api/src/routes/competition.routes.ts
@@ -268,4 +268,70 @@ router.get("/status", CompetitionController.getStatus);
  */
 router.get("/rules", CompetitionController.getRules);
 
+/**
+ * @openapi
+ * /api/competition/upcoming:
+ *   get:
+ *     tags:
+ *       - Competition
+ *     summary: Get upcoming competitions
+ *     description: Get all competitions that have not started yet (status=PENDING)
+ *     security:
+ *       - BearerAuth: []
+ *     parameters:
+ *       - in: header
+ *         name: Authorization
+ *         schema:
+ *           type: string
+ *         required: true
+ *         description: Bearer token for authentication (format "Bearer YOUR_API_KEY")
+ *         example: "Bearer abc123def456_ghi789jkl012"
+ *     responses:
+ *       200:
+ *         description: Upcoming competitions retrieved successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                   description: Operation success status
+ *                 competitions:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ *                     properties:
+ *                       id:
+ *                         type: string
+ *                         description: Competition ID
+ *                       name:
+ *                         type: string
+ *                         description: Competition name
+ *                       description:
+ *                         type: string
+ *                         nullable: true
+ *                         description: Competition description
+ *                       status:
+ *                         type: string
+ *                         enum: [PENDING]
+ *                         description: Competition status (always PENDING)
+ *                       allowCrossChainTrading:
+ *                         type: boolean
+ *                         description: Whether cross-chain trading is allowed
+ *                       createdAt:
+ *                         type: string
+ *                         format: date-time
+ *                         description: When the competition was created
+ *                       updatedAt:
+ *                         type: string
+ *                         format: date-time
+ *                         description: When the competition was last updated
+ *       401:
+ *         description: Unauthorized - Missing or invalid authentication
+ *       500:
+ *         description: Server error
+ */
+router.get("/upcoming", CompetitionController.getUpcomingCompetitions);
+
 export default router;

--- a/apps/api/src/services/competition-manager.service.ts
+++ b/apps/api/src/services/competition-manager.service.ts
@@ -551,4 +551,14 @@ export class CompetitionManager {
       return false;
     }
   }
+
+  /**
+   * Get all upcoming (pending) competitions
+   * @returns Array of competitions with PENDING status
+   */
+  async getUpcomingCompetitions(): Promise<Competition[]> {
+    return repositories.competitionRepository.findByStatus(
+      CompetitionStatus.PENDING,
+    );
+  }
 }


### PR DESCRIPTION
# Summary

- Adds a new route to apps/api/src/routes/competition.routes.ts that allows authenticated teams to fetch upcoming competitions (marked as PENDING in the db)
- Adds a new method to apps/api/src/controllers/competition.controller.ts that utilizes the competition manager service to fetch upcoming competitions, and also implements the authentication gating (same pattern as the other controllers)
- Implements a new method in apps/api/src/services/competition-manager.service.ts to use the competition repository's `findByStatus` method
- Implements `findByStatus` in apps/api/src/database/repositories/competition-repository.ts using the same pattern matching as the other repository methods to access the data layer
- Updates api-client, types, and competition.test.ts in apps/api/e2e to confirm functionality