### PR TITLE
fix: ensure dev or production db exists before migration

### DIFF
--- a/apps/api/src/database/db.ts
+++ b/apps/api/src/database/db.ts
@@ -5,7 +5,7 @@ import { isPgSchema } from "drizzle-orm/pg-core";
 import { reset, seed } from "drizzle-seed";
 import fs from "fs";
 import path from "path";
-import { Pool } from "pg";
+import { Client, Pool } from "pg";
 import { fileURLToPath } from "url";
 
 import * as relations from "@recallnet/comps-db/relations";
@@ -93,6 +93,7 @@ export async function dropAll() {
 }
 
 export async function migrateDb() {
+  await ensureDatabaseExists();
   await migrate(db, {
     migrationsFolder: path.join(__dirname, "../../drizzle"),
   });
@@ -100,4 +101,58 @@ export async function migrateDb() {
 
 export async function seedDb() {
   await seed(db, schema);
+}
+
+/**
+ * Ensures the target database (from DATABASE_URL) exists. If it does not, creates it.
+ * Connects to the 'postgres' database to perform the check and creation.
+ *
+ * @throws Error if DATABASE_URL is not set or database name cannot be determined.
+ * @example
+ * await ensureDatabaseExists();
+ */
+export async function ensureDatabaseExists(): Promise<void> {
+  if (!process.env.DATABASE_URL) {
+    throw new Error("DATABASE_URL is not set");
+  }
+  const url = new URL(process.env.DATABASE_URL);
+
+  const dbName = url.pathname.slice(1);
+
+  // Connect to postgres database to create our production database
+  const client = new Client({
+    host: url.hostname || "localhost",
+    port: parseInt(url.port || "5432"),
+    user: url.username || "postgres",
+    password: url.password || "postgres",
+    database: "postgres", // Connect to default postgres database
+  });
+
+  try {
+    await client.connect();
+    console.log(`Connected to postgres to check if database ${dbName} exists`);
+
+    // Check if our production database exists
+    const result = await client.query(
+      `
+      SELECT EXISTS(
+        SELECT FROM pg_database WHERE datname = $1
+      );
+    `,
+      [dbName],
+    );
+
+    if (!result.rows[0].exists) {
+      console.log(`Database "${dbName}" does not exist, creating it...`);
+      await client.query(`CREATE DATABASE "${dbName}";`);
+      console.log(`Database "${dbName}" created successfully`);
+    } else {
+      console.log(`Database "${dbName}" already exists`);
+    }
+  } catch (error) {
+    console.error("Error ensuring production database:", error);
+    throw error;
+  } finally {
+    await client.end();
+  }
 }


### PR DESCRIPTION
# Summary

- Ensures that the database exists before attempting a migration (same pattern used by the testing suite)