### PR TITLE
fix: setup:all error when creating admin

### DIFF
--- a/apps/api/scripts/setup-everything.ts
+++ b/apps/api/scripts/setup-everything.ts
@@ -228,7 +228,6 @@ async function setupEverything() {
       // Pass the collected admin credentials as command line arguments and capture output
       const setupOutput = await runCommand("pnpm", [
         "setup:admin",
-        "--",
         adminUsername,
         adminPassword,
         adminEmail,


### PR DESCRIPTION
# Context

Fixes: https://github.com/recallnet/js-recall/issues/313
The arguments were not being passed correctly to setup:admin script