### PR TITLE
feat: allow admin to serach teams based on associated data fields

### DIFF
--- a/apps/api/e2e/utils/api-client.ts
+++ b/apps/api/e2e/utils/api-client.ts
@@ -810,4 +810,42 @@ export class ApiClient {
       return this.handleApiError(error, "reset API key");
     }
   }
+
+  /**
+   * Search teams by various criteria (admin only)
+   * @param searchParams Search parameters (email, name, walletAddress, contactPerson, active, includeAdmins)
+   */
+  async searchTeams(searchParams: {
+    email?: string;
+    name?: string;
+    walletAddress?: string;
+    contactPerson?: string;
+    active?: boolean;
+    includeAdmins?: boolean;
+  }): Promise<AdminTeamsListResponse | ErrorResponse> {
+    try {
+      // Convert search parameters to query string
+      const queryParams = new URLSearchParams();
+
+      if (searchParams.email) queryParams.append("email", searchParams.email);
+      if (searchParams.name) queryParams.append("name", searchParams.name);
+      if (searchParams.walletAddress)
+        queryParams.append("walletAddress", searchParams.walletAddress);
+      if (searchParams.contactPerson)
+        queryParams.append("contactPerson", searchParams.contactPerson);
+      if (searchParams.active !== undefined)
+        queryParams.append("active", searchParams.active.toString());
+      if (searchParams.includeAdmins !== undefined)
+        queryParams.append(
+          "includeAdmins",
+          searchParams.includeAdmins.toString(),
+        );
+
+      const url = `/api/admin/teams/search?${queryParams.toString()}`;
+
+      return this.request<AdminTeamsListResponse>("get", url);
+    } catch (error) {
+      return this.handleApiError(error, "search teams");
+    }
+  }
 }

--- a/apps/api/src/controllers/admin.controller.ts
+++ b/apps/api/src/controllers/admin.controller.ts
@@ -14,7 +14,11 @@ import {
 } from "@/database/repositories/team-repository.js";
 import { ApiError } from "@/middleware/errorHandler.js";
 import { ServiceRegistry } from "@/services/index.js";
-import { CompetitionStatus, CrossChainTradingType } from "@/types/index.js";
+import {
+  CompetitionStatus,
+  CrossChainTradingType,
+  TeamSearchParams,
+} from "@/types/index.js";
 
 export function makeAdminController(services: ServiceRegistry) {
   /**
@@ -890,6 +894,69 @@ export function makeAdminController(services: ServiceRegistry) {
             name: result.team?.name || "Unknown",
             apiKey: result.apiKey,
           },
+        });
+      } catch (error) {
+        next(error);
+      }
+    },
+
+    /**
+     * Search for teams based on various criteria
+     * @param req Express request
+     * @param res Express response
+     * @param next Express next function
+     */
+    async searchTeams(req: Request, res: Response, next: NextFunction) {
+      try {
+        const {
+          email,
+          name,
+          walletAddress,
+          contactPerson,
+          active,
+          includeAdmins,
+        } = req.query;
+
+        // Prepare search params
+        const searchParams: TeamSearchParams = {};
+
+        if (email) searchParams.email = email as string;
+        if (name) searchParams.name = name as string;
+        if (walletAddress) searchParams.walletAddress = walletAddress as string;
+        if (contactPerson) searchParams.contactPerson = contactPerson as string;
+
+        // Convert active string query param to boolean if provided
+        if (active !== undefined) {
+          searchParams.active = active === "true" || active === "1";
+        }
+
+        // Set whether to include admin accounts
+        searchParams.includeAdmins =
+          includeAdmins === "true" || includeAdmins === "1";
+
+        // Perform search
+        const teams = await services.teamManager.searchTeams(searchParams);
+
+        // Format the response to exclude sensitive data
+        const formattedTeams = teams.map((team) => ({
+          id: team.id,
+          name: team.name,
+          email: team.email,
+          contactPerson: team.contactPerson,
+          walletAddress: team.walletAddress,
+          active: team.active,
+          deactivationReason: team.deactivationReason,
+          deactivationDate: team.deactivationDate,
+          isAdmin: team.isAdmin,
+          metadata: team.metadata,
+          createdAt: team.createdAt,
+          updatedAt: team.updatedAt,
+        }));
+
+        // Return the search results
+        res.status(200).json({
+          success: true,
+          teams: formattedTeams,
         });
       } catch (error) {
         next(error);

--- a/apps/api/src/database/repositories/team-repository.ts
+++ b/apps/api/src/database/repositories/team-repository.ts
@@ -7,6 +7,7 @@ import {
 } from "@recallnet/comps-db/schema";
 
 import { db } from "@/database/db.js";
+import { TeamSearchParams } from "@/types/index.js";
 
 import { PartialExcept } from "./types.js";
 
@@ -235,6 +236,56 @@ export async function deleteTeam(teamId: string) {
     return !!result;
   } catch (error) {
     console.error("[TeamRepository] Error in delete:", error);
+    throw error;
+  }
+}
+
+/**
+ * Search for teams by various attributes
+ * @param searchParams Object containing search parameters
+ * @returns Array of teams matching the search criteria
+ */
+export async function searchTeams(searchParams: TeamSearchParams) {
+  try {
+    const conditions = [];
+
+    // Add filters for each provided parameter
+    if (searchParams.email) {
+      conditions.push(ilike(teams.email, `%${searchParams.email}%`));
+    }
+
+    if (searchParams.name) {
+      conditions.push(ilike(teams.name, `%${searchParams.name}%`));
+    }
+
+    if (searchParams.walletAddress) {
+      conditions.push(
+        ilike(teams.walletAddress, `%${searchParams.walletAddress}%`),
+      );
+    }
+
+    if (searchParams.contactPerson) {
+      conditions.push(
+        ilike(teams.contactPerson, `%${searchParams.contactPerson}%`),
+      );
+    }
+
+    if (searchParams.active !== undefined) {
+      conditions.push(eq(teams.active, searchParams.active));
+    }
+
+    // If no search parameters were provided, return all teams
+    if (conditions.length === 0) {
+      return await db.query.teams.findMany();
+    }
+
+    // Combine all conditions with AND operator
+    return await db
+      .select()
+      .from(teams)
+      .where(and(...conditions));
+  } catch (error) {
+    console.error("[TeamRepository] Error in searchTeams:", error);
     throw error;
   }
 }

--- a/apps/api/src/routes/admin.routes.ts
+++ b/apps/api/src/routes/admin.routes.ts
@@ -799,5 +799,111 @@ export function configureAdminRoutes(
    */
   router.post("/teams/:teamId/reactivate", controller.reactivateTeam);
 
+  /**
+   * @openapi
+   * /api/admin/teams/search:
+   *   get:
+   *     tags:
+   *       - Admin
+   *     summary: Search for teams
+   *     description: Search for teams based on various criteria like email, name, wallet address, etc.
+   *     security:
+   *       - BearerAuth: []
+   *     parameters:
+   *       - in: query
+   *         name: email
+   *         schema:
+   *           type: string
+   *         description: Partial match for team email
+   *       - in: query
+   *         name: name
+   *         schema:
+   *           type: string
+   *         description: Partial match for team name
+   *       - in: query
+   *         name: walletAddress
+   *         schema:
+   *           type: string
+   *         description: Partial match for wallet address
+   *       - in: query
+   *         name: contactPerson
+   *         schema:
+   *           type: string
+   *         description: Partial match for contact person name
+   *       - in: query
+   *         name: active
+   *         schema:
+   *           type: boolean
+   *         description: Filter by active status (true/false)
+   *       - in: query
+   *         name: includeAdmins
+   *         schema:
+   *           type: boolean
+   *         description: Whether to include admin accounts in results (default is false)
+   *     responses:
+   *       200:
+   *         description: List of teams matching search criteria
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   *               properties:
+   *                 success:
+   *                   type: boolean
+   *                   description: Operation success status
+   *                 teams:
+   *                   type: array
+   *                   items:
+   *                     type: object
+   *                     properties:
+   *                       id:
+   *                         type: string
+   *                         description: Team ID
+   *                       name:
+   *                         type: string
+   *                         description: Team name
+   *                       email:
+   *                         type: string
+   *                         description: Team email
+   *                       contactPerson:
+   *                         type: string
+   *                         description: Contact person name
+   *                       walletAddress:
+   *                         type: string
+   *                         description: Ethereum wallet address
+   *                       active:
+   *                         type: boolean
+   *                         description: Whether the team is active
+   *                       deactivationReason:
+   *                         type: string
+   *                         nullable: true
+   *                         description: Reason for deactivation if inactive
+   *                       deactivationDate:
+   *                         type: string
+   *                         format: date-time
+   *                         nullable: true
+   *                         description: Date of deactivation if inactive
+   *                       isAdmin:
+   *                         type: boolean
+   *                         description: Whether the team has admin privileges
+   *                       metadata:
+   *                         type: object
+   *                         nullable: true
+   *                         description: Optional agent metadata
+   *                       createdAt:
+   *                         type: string
+   *                         format: date-time
+   *                         description: Account creation timestamp
+   *                       updatedAt:
+   *                         type: string
+   *                         format: date-time
+   *                         description: Account update timestamp
+   *       401:
+   *         description: Unauthorized - Admin authentication required
+   *       500:
+   *         description: Server error
+   */
+  router.get("/teams/search", controller.searchTeams);
+
   return router;
 }

--- a/apps/api/src/services/team-manager.service.ts
+++ b/apps/api/src/services/team-manager.service.ts
@@ -13,9 +13,10 @@ import {
   findById,
   findInactiveTeams,
   reactivateTeam,
+  searchTeams,
   update,
 } from "@/database/repositories/team-repository.js";
-import { AgentMetadata, ApiAuth } from "@/types/index.js";
+import { AgentMetadata, ApiAuth, TeamSearchParams } from "@/types/index.js";
 
 /**
  * Team Manager Service
@@ -668,6 +669,37 @@ export class TeamManager {
         error,
       );
       throw error;
+    }
+  }
+
+  /**
+   * Search for teams based on various attributes
+   * @param searchParams Parameters to search by (email, name, walletAddress, contactPerson, active status)
+   * @returns Array of teams matching the search criteria
+   */
+  async searchTeams(searchParams: TeamSearchParams) {
+    try {
+      console.log(
+        `[TeamManager] Searching for teams with params:`,
+        searchParams,
+      );
+
+      // Get matching teams from repository
+      const teams = await searchTeams(searchParams);
+
+      // Filter out admin teams if needed
+      const { includeAdmins = false } = searchParams;
+      const filteredTeams = includeAdmins
+        ? teams
+        : teams.filter((team) => !team.isAdmin);
+
+      console.log(
+        `[TeamManager] Found ${filteredTeams.length} teams matching search criteria`,
+      );
+      return filteredTeams;
+    } catch (error) {
+      console.error("[TeamManager] Error searching teams:", error);
+      return [];
     }
   }
 }

--- a/apps/api/src/types/index.ts
+++ b/apps/api/src/types/index.ts
@@ -189,6 +189,18 @@ export interface Team {
 }
 
 /**
+ * Team search parameters interface
+ */
+export interface TeamSearchParams {
+  email?: string;
+  name?: string;
+  walletAddress?: string;
+  contactPerson?: string;
+  active?: boolean;
+  includeAdmins?: boolean;
+}
+
+/**
  * Competition status enum
  */
 export enum CrossChainTradingType {


### PR DESCRIPTION
# Summary

- Allows admin to search for teams based on various fields associated with that team's representation in the database
- Includes new methods added to the repository, service, controller, and route layers
- Also includes a new client method in e2e and a supporting e2e test in `admin.test.ts`