### PR TITLE
fix: incorrect `leaderboards` route

### DIFF
--- a/apps/comps/app/leaderboards/page.tsx
+++ b/apps/comps/app/leaderboards/page.tsx
@@ -1,13 +1,12 @@
 import React from "react";
 
-import { Leaderboard } from "@/components/leaderboard/index";
+import { JoinSwarmSection } from "@/components/join-swarm-section";
+import { Leaderboard } from "@/components/leaderboard";
+import { NewsletterSection } from "@/components/newsletter-section";
+import { LeaderboardOngoingCompetition } from "@/components/ongoing-competition/leaderboard";
 import { RegisterAgentBlock } from "@/components/register-agent-block";
-
-import { JoinSwarmSection } from "../../components/join-swarm-section";
-import { NewsletterSection } from "../../components/newsletter-section";
-import { LeaderboardOngoingCompetition } from "../../components/ongoing-competition/leaderboard";
-import { ongoingCompetitions } from "../../data/competitions";
-import { socialLinks } from "../../data/social";
+import { ongoingCompetitions } from "@/data/competitions";
+import { socialLinks } from "@/data/social";
 
 export default function LeaderboardPage() {
   const currentCompetition =


### PR DESCRIPTION
The nav defines the route `/leaderboards`, and not the singular `/leaderboard`. The app route/folder is currently called `leaderboard`, so hitting the plural `/leaderboards` results in a 404. This PR renames the route to `leaderboards`.
<img width="1074" alt="Screenshot 2025-05-15 at 4 41 47 PM" src="https://github.com/user-attachments/assets/be700cfd-39a8-40f9-ac97-5de72f51e232" />
