### PR TITLE
Fix build-api-sdk.sh

### DIFF
--- a/build-api-sdk.sh
+++ b/build-api-sdk.sh
@@ -1,4 +1,5 @@
-#! /usr/bin/bash
+#!/usr/bin/env bash
+
 set -eu
 
 cd apps/api


### PR DESCRIPTION
This PR enables running `./build-api-sdk.sh` without explicit `sh ...`.