### PR TITLE
fix(ci): type `react` mutations | lock eslint version

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -90,7 +90,7 @@
     "copyfiles": "^2.4.1",
     "drizzle-kit": "^0.31.1",
     "drizzle-seed": "^0.3.1",
-    "eslint": "^9.27.0",
+    "eslint": "^9.19.0",
     "openapi-markdown": "^1.2.3",
     "siwe": "^3.0.0",
     "tough-cookie": "^5.1.2",

--- a/packages/conversions/package.json
+++ b/packages/conversions/package.json
@@ -45,7 +45,7 @@
     "@recallnet/typescript-config": "workspace:*",
     "@types/node": "^20.10.6",
     "dnum": "^2.9.0",
-    "eslint": "^9.15.0",
+    "eslint": "^9.19.0",
     "typescript": "^5.3.3",
     "typedoc": "^0.28.1",
     "typedoc-plugin-coverage": "^3.4.1",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -19,7 +19,7 @@
     "@next/eslint-plugin-next": "^15.1.0",
     "@typescript-eslint/eslint-plugin": "^8.15.0",
     "@typescript-eslint/parser": "^8.15.0",
-    "eslint": "^9.15.0",
+    "eslint": "^9.19.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-only-warn": "^1.1.0",
     "eslint-plugin-react": "^7.37.2",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -49,6 +49,7 @@
     "@recallnet/eslint-config": "workspace:*",
     "@recallnet/typescript-config": "workspace:*",
     "@types/react": "^19.0.0",
+    "eslint": "^9.19.0",
     "tsup": "^8.3.6",
     "typescript": "^5.7.3"
   },

--- a/packages/react/src/hooks/buckets.ts
+++ b/packages/react/src/hooks/buckets.ts
@@ -19,6 +19,30 @@ import {
 } from "@recallnet/contracts";
 import { base32ToHex, hexToBase32 } from "@recallnet/fvm/utils";
 
+// Note: the `CreateBucketResult` & `DeleteObjectResult` are fixes for random CI complaints about
+// types. See this issue for context: https://github.com/recallnet/js-recall/issues/330
+type CreateBucketResult = Omit<
+  ReturnType<typeof useWriteContract>,
+  "writeContract" | "writeContractAsync"
+> & {
+  createBucket: (options?: {
+    owner: Address;
+    metadata?: Record<string, string>;
+  }) => void;
+  createBucketAsync: (options?: {
+    owner: Address;
+    metadata?: Record<string, string>;
+  }) => Promise<`0x${string}`>;
+};
+
+type DeleteObjectResult = Omit<
+  ReturnType<typeof useWriteContract>,
+  "writeContract" | "writeContractAsync"
+> & {
+  deleteObject: (bucket: Address, key: string) => void;
+  deleteObjectAsync: (bucket: Address, key: string) => Promise<`0x${string}`>;
+};
+
 export function useListBuckets(owner?: Address) {
   const chainId = useChainId();
   const { address } = useAccount();
@@ -161,7 +185,7 @@ export function useGetObject(
   };
 }
 
-export function useCreateBucket() {
+export function useCreateBucket(): CreateBucketResult {
   const chainId = useChainId();
   const contractAddress =
     iMachineFacadeAddress[chainId as keyof typeof iMachineFacadeAddress];
@@ -302,7 +326,7 @@ export function useAddFile() {
   return { addFile, isPending, isSuccess, isError, error, data };
 }
 
-export function useDeleteObject() {
+export function useDeleteObject(): DeleteObjectResult {
   const { writeContract, writeContractAsync, ...rest } = useWriteContract();
 
   const deleteObject = useCallback(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -139,7 +139,7 @@ importers:
         specifier: ^0.3.1
         version: 0.3.1(drizzle-orm@0.43.1(@electric-sql/pglite@0.2.17)(@opentelemetry/api@1.9.0)(@types/pg@8.15.2)(better-sqlite3@11.8.1)(bun-types@1.2.13)(pg@8.16.0)(sql.js@1.13.0))
       eslint:
-        specifier: ^9.27.0
+        specifier: ^9.19.0
         version: 9.27.0(jiti@2.4.2)
       openapi-markdown:
         specifier: ^1.2.3
@@ -781,7 +781,7 @@ importers:
         specifier: ^20.10.6
         version: 20.17.48
       eslint:
-        specifier: ^9.15.0
+        specifier: ^9.19.0
         version: 9.27.0(jiti@2.4.2)
       typedoc:
         specifier: ^0.28.1
@@ -811,7 +811,7 @@ importers:
         specifier: ^8.15.0
         version: 8.32.1(eslint@9.27.0(jiti@2.4.2))(typescript@5.8.3)
       eslint:
-        specifier: ^9.15.0
+        specifier: ^9.19.0
         version: 9.27.0(jiti@2.4.2)
       eslint-config-prettier:
         specifier: ^9.1.0
@@ -1003,6 +1003,9 @@ importers:
       '@types/react':
         specifier: ^19.0.0
         version: 19.1.4
+      eslint:
+        specifier: ^9.19.0
+        version: 9.27.0(jiti@2.4.2)
       tsup:
         specifier: ^8.3.6
         version: 8.5.0(jiti@2.4.2)(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.8.0)


### PR DESCRIPTION
related to https://github.com/recallnet/js-recall/issues/330 and the issue about wagmi + type inference in `packages/react`