### PR TITLE
feat(api): add `stats` to comps response

### DIFF
--- a/apps/api/e2e/utils/api-types.ts
+++ b/apps/api/e2e/utils/api-types.ts
@@ -304,6 +304,12 @@ export interface Competition {
   createdAt: string;
   updatedAt: string;
   agentIds?: string[];
+  stats?: {
+    totalTrades: number;
+    totalAgents: number;
+    totalVolume: number;
+    uniqueTokens: number;
+  };
 }
 
 // Leaderboard entry

--- a/apps/api/src/controllers/competition.controller.ts
+++ b/apps/api/src/controllers/competition.controller.ts
@@ -521,11 +521,25 @@ export function makeCompetitionController(services: ServiceRegistry) {
         if (!competition) {
           throw new ApiError(404, "Competition not found");
         }
+        const trades =
+          await services.tradeSimulator.getCompetitionTrades(competitionId);
+        const stats = {
+          totalTrades: trades.length,
+          totalAgents: new Set(trades.map((trade) => trade.agentId)).size,
+          totalVolume: trades.reduce(
+            (acc, trade) => acc + trade.tradeAmountUsd,
+            0,
+          ),
+          uniqueTokens: new Set([
+            ...trades.map((trade) => trade.fromToken),
+            ...trades.map((trade) => trade.toToken),
+          ]).size,
+        };
 
         // Return the competition details
         res.status(200).json({
           success: true,
-          competition: competition,
+          competition: { ...competition, stats },
         });
       } catch (error) {
         next(error);

--- a/apps/api/src/routes/competitions.routes.ts
+++ b/apps/api/src/routes/competitions.routes.ts
@@ -541,6 +541,21 @@ export function configureCompetitionsRoutes(
    *                       format: date-time
    *                       nullable: true
    *                       description: Competition end date (null for pending/active competitions)
+   *                     stats:
+   *                       type: object
+   *                       properties:
+   *                         totalTrades:
+   *                           type: number
+   *                           description: Total number of trades
+   *                         totalAgents:
+   *                           type: number
+   *                           description: Total number of agents
+   *                         totalVolume:
+   *                           type: number
+   *                           description: Total volume of trades in USD
+   *                         uniqueTokens:
+   *                           type: number
+   *                           description: Total number of unique tokens traded
    *                     createdAt:
    *                       type: string
    *                       format: date-time


### PR DESCRIPTION
adds a `stats` field for basic competition statistics, which get displayed on a dedicated competition's page. closes https://github.com/recallnet/js-recall/issues/461. note: we can create a "final" PR for the `api-sdk` changes once we code freeze.