### PR TITLE
feat: integrate fromTokenSymbol into trading schema and return types

### DIFF
--- a/apps/api/drizzle/0003_yielding_killraven.sql
+++ b/apps/api/drizzle/0003_yielding_killraven.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "trading_comps"."trades" ADD COLUMN "from_token_symbol" varchar(20) NOT NULL;

--- a/apps/api/drizzle/meta/0003_snapshot.json
+++ b/apps/api/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,2411 @@
+{
+  "id": "01050e1d-6641-47c1-930d-79e7cb9e881d",
+  "prevId": "afd9fbeb-d5d7-4ae1-a4c3-2fc5368b91de",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.admins": {
+      "name": "admins",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "varchar(400)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "actor_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "last_login_at": {
+          "name": "last_login_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_admins_username": {
+          "name": "idx_admins_username",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_admins_email": {
+          "name": "idx_admins_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_admins_api_key": {
+          "name": "idx_admins_api_key",
+          "columns": [
+            {
+              "expression": "api_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_admins_status": {
+          "name": "idx_admins_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "admins_username_unique": {
+          "name": "admins_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        },
+        "admins_email_unique": {
+          "name": "admins_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "admins_api_key_unique": {
+          "name": "admins_api_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "api_key"
+          ]
+        },
+        "admins_username_key": {
+          "name": "admins_username_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        },
+        "admins_email_key": {
+          "name": "admins_email_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "admins_api_key_key": {
+          "name": "admins_api_key_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "api_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wallet_address": {
+          "name": "wallet_address",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "varchar(400)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "actor_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "deactivation_reason": {
+          "name": "deactivation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deactivation_date": {
+          "name": "deactivation_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agents_owner_id": {
+          "name": "idx_agents_owner_id",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agents_status": {
+          "name": "idx_agents_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agents_wallet_address": {
+          "name": "idx_agents_wallet_address",
+          "columns": [
+            {
+              "expression": "wallet_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agents_api_key": {
+          "name": "idx_agents_api_key",
+          "columns": [
+            {
+              "expression": "api_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agents_owner_id_fkey": {
+          "name": "agents_owner_id_fkey",
+          "tableFrom": "agents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agents_wallet_address_unique": {
+          "name": "agents_wallet_address_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "wallet_address"
+          ]
+        },
+        "agents_email_unique": {
+          "name": "agents_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "agents_owner_id_name_key": {
+          "name": "agents_owner_id_name_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "owner_id",
+            "name"
+          ]
+        },
+        "agents_api_key_key": {
+          "name": "agents_api_key_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "api_key"
+          ]
+        },
+        "agents_wallet_address_key": {
+          "name": "agents_wallet_address_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "wallet_address"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.competition_agents": {
+      "name": "competition_agents",
+      "schema": "",
+      "columns": {
+        "competition_id": {
+          "name": "competition_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "competition_agents_competition_id_fkey": {
+          "name": "competition_agents_competition_id_fkey",
+          "tableFrom": "competition_agents",
+          "tableTo": "competitions",
+          "columnsFrom": [
+            "competition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "competition_agents_agent_id_fkey": {
+          "name": "competition_agents_agent_id_fkey",
+          "tableFrom": "competition_agents",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "competition_agents_pkey": {
+          "name": "competition_agents_pkey",
+          "columns": [
+            "competition_id",
+            "agent_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.competitions": {
+      "name": "competitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "competition_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'trading'"
+        },
+        "external_url": {
+          "name": "external_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "competition_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_competitions_status": {
+          "name": "idx_competitions_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "wallet_address": {
+          "name": "wallet_address",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "actor_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_users_wallet_address": {
+          "name": "idx_users_wallet_address",
+          "columns": [
+            {
+              "expression": "wallet_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_status": {
+          "name": "idx_users_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_wallet_address_unique": {
+          "name": "users_wallet_address_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "wallet_address"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "users_wallet_address_key": {
+          "name": "users_wallet_address_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "wallet_address"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "trading_comps.balances": {
+      "name": "balances",
+      "schema": "trading_comps",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_address": {
+          "name": "token_address",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "specific_chain": {
+          "name": "specific_chain",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_balances_specific_chain": {
+          "name": "idx_balances_specific_chain",
+          "columns": [
+            {
+              "expression": "specific_chain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_balances_agent_id": {
+          "name": "idx_balances_agent_id",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "balances_agent_id_fkey": {
+          "name": "balances_agent_id_fkey",
+          "tableFrom": "balances",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "balances_agent_id_token_address_key": {
+          "name": "balances_agent_id_token_address_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "agent_id",
+            "token_address"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "trading_comps.portfolio_snapshots": {
+      "name": "portfolio_snapshots",
+      "schema": "trading_comps",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "total_value": {
+          "name": "total_value",
+          "type": "numeric(30, 15)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_portfolio_snapshots_agent_competition": {
+          "name": "idx_portfolio_snapshots_agent_competition",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_portfolio_snapshots_timestamp": {
+          "name": "idx_portfolio_snapshots_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "portfolio_snapshots_agent_id_fkey": {
+          "name": "portfolio_snapshots_agent_id_fkey",
+          "tableFrom": "portfolio_snapshots",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "portfolio_snapshots_competition_id_fkey": {
+          "name": "portfolio_snapshots_competition_id_fkey",
+          "tableFrom": "portfolio_snapshots",
+          "tableTo": "competitions",
+          "columnsFrom": [
+            "competition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "trading_comps.portfolio_token_values": {
+      "name": "portfolio_token_values",
+      "schema": "trading_comps",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "portfolio_snapshot_id": {
+          "name": "portfolio_snapshot_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_address": {
+          "name": "token_address",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_usd": {
+          "name": "value_usd",
+          "type": "numeric(30, 15)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "specific_chain": {
+          "name": "specific_chain",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_portfolio_token_values_snapshot_id": {
+          "name": "idx_portfolio_token_values_snapshot_id",
+          "columns": [
+            {
+              "expression": "portfolio_snapshot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_portfolio_token_values_specific_chain": {
+          "name": "idx_portfolio_token_values_specific_chain",
+          "columns": [
+            {
+              "expression": "specific_chain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "portfolio_token_values_portfolio_snapshot_id_fkey": {
+          "name": "portfolio_token_values_portfolio_snapshot_id_fkey",
+          "tableFrom": "portfolio_token_values",
+          "tableTo": "portfolio_snapshots",
+          "schemaTo": "trading_comps",
+          "columnsFrom": [
+            "portfolio_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "trading_comps.prices": {
+      "name": "prices",
+      "schema": "trading_comps",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "chain": {
+          "name": "chain",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "specific_chain": {
+          "name": "specific_chain",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_prices_chain": {
+          "name": "idx_prices_chain",
+          "columns": [
+            {
+              "expression": "chain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_prices_specific_chain": {
+          "name": "idx_prices_specific_chain",
+          "columns": [
+            {
+              "expression": "specific_chain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_prices_timestamp": {
+          "name": "idx_prices_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_prices_token": {
+          "name": "idx_prices_token",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_prices_token_chain": {
+          "name": "idx_prices_token_chain",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_prices_token_specific_chain": {
+          "name": "idx_prices_token_specific_chain",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "specific_chain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_prices_token_timestamp": {
+          "name": "idx_prices_token_timestamp",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "trading_comps.trades": {
+      "name": "trades",
+      "schema": "trading_comps",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_token": {
+          "name": "from_token",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_token": {
+          "name": "to_token",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_amount": {
+          "name": "from_amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_amount": {
+          "name": "to_amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trade_amount_usd": {
+          "name": "trade_amount_usd",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_token_symbol": {
+          "name": "to_token_symbol",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_token_symbol": {
+          "name": "from_token_symbol",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "from_chain": {
+          "name": "from_chain",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_chain": {
+          "name": "to_chain",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_specific_chain": {
+          "name": "from_specific_chain",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_specific_chain": {
+          "name": "to_specific_chain",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_trades_competition_id": {
+          "name": "idx_trades_competition_id",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_trades_from_chain": {
+          "name": "idx_trades_from_chain",
+          "columns": [
+            {
+              "expression": "from_chain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_trades_from_specific_chain": {
+          "name": "idx_trades_from_specific_chain",
+          "columns": [
+            {
+              "expression": "from_specific_chain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_trades_agent_id": {
+          "name": "idx_trades_agent_id",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_trades_timestamp": {
+          "name": "idx_trades_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_trades_to_chain": {
+          "name": "idx_trades_to_chain",
+          "columns": [
+            {
+              "expression": "to_chain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_trades_to_specific_chain": {
+          "name": "idx_trades_to_specific_chain",
+          "columns": [
+            {
+              "expression": "to_specific_chain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trades_agent_id_fkey": {
+          "name": "trades_agent_id_fkey",
+          "tableFrom": "trades",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "trades_competition_id_fkey": {
+          "name": "trades_competition_id_fkey",
+          "tableFrom": "trades",
+          "tableTo": "competitions",
+          "columnsFrom": [
+            "competition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "trading_comps.trading_competitions": {
+      "name": "trading_competitions",
+      "schema": "trading_comps",
+      "columns": {
+        "competitionId": {
+          "name": "competitionId",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cross_chain_trading_type": {
+          "name": "cross_chain_trading_type",
+          "type": "cross_chain_trading_type",
+          "typeSchema": "trading_comps",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'disallowAll'"
+        }
+      },
+      "indexes": {
+        "idx_competitions_cross_chain_trading": {
+          "name": "idx_competitions_cross_chain_trading",
+          "columns": [
+            {
+              "expression": "cross_chain_trading_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trading_competitions_competitionId_competitions_id_fk": {
+          "name": "trading_competitions_competitionId_competitions_id_fk",
+          "tableFrom": "trading_competitions",
+          "tableTo": "competitions",
+          "columnsFrom": [
+            "competitionId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.epochs": {
+      "name": "epochs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "epochs_number_unique": {
+          "name": "epochs_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rewards": {
+      "name": "rewards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "epoch": {
+          "name": "epoch",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(30, 18)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "leaf_hash": {
+          "name": "leaf_hash",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimed": {
+          "name": "claimed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_rewards_epoch": {
+          "name": "idx_rewards_epoch",
+          "columns": [
+            {
+              "expression": "epoch",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_rewards_address": {
+          "name": "idx_rewards_address",
+          "columns": [
+            {
+              "expression": "address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rewards_epoch_epochs_id_fk": {
+          "name": "rewards_epoch_epochs_id_fk",
+          "tableFrom": "rewards",
+          "tableTo": "epochs",
+          "columnsFrom": [
+            "epoch"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rewards_roots": {
+      "name": "rewards_roots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "epoch": {
+          "name": "epoch",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root_hash": {
+          "name": "root_hash",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tx": {
+          "name": "tx",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_rewards_roots_epoch": {
+          "name": "uq_rewards_roots_epoch",
+          "columns": [
+            {
+              "expression": "epoch",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rewards_roots_epoch_epochs_id_fk": {
+          "name": "rewards_roots_epoch_epochs_id_fk",
+          "tableFrom": "rewards_roots",
+          "tableTo": "epochs",
+          "columnsFrom": [
+            "epoch"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rewards_tree": {
+      "name": "rewards_tree",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "epoch": {
+          "name": "epoch",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idx": {
+          "name": "idx",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_rewards_tree_epoch_level_idx": {
+          "name": "idx_rewards_tree_epoch_level_idx",
+          "columns": [
+            {
+              "expression": "epoch",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "level",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idx",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_rewards_tree_level_hash": {
+          "name": "idx_rewards_tree_level_hash",
+          "columns": [
+            {
+              "expression": "level",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_rewards_tree_level_idx": {
+          "name": "idx_rewards_tree_level_idx",
+          "columns": [
+            {
+              "expression": "level",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idx",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rewards_tree_epoch_epochs_id_fk": {
+          "name": "rewards_tree_epoch_epochs_id_fk",
+          "tableFrom": "rewards_tree",
+          "tableTo": "epochs",
+          "columnsFrom": [
+            "epoch"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stakes": {
+      "name": "stakes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(30, 18)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "withdrawal_at": {
+          "name": "withdrawal_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "withdrawn_at": {
+          "name": "withdrawn_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "epoch_created": {
+          "name": "epoch_created",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_stakes_address": {
+          "name": "idx_stakes_address",
+          "columns": [
+            {
+              "expression": "address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stakes_user_id_users_id_fk": {
+          "name": "stakes_user_id_users_id_fk",
+          "tableFrom": "stakes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "stakes_epoch_created_epochs_id_fk": {
+          "name": "stakes_epoch_created_epochs_id_fk",
+          "tableFrom": "stakes",
+          "tableTo": "epochs",
+          "columnsFrom": [
+            "epoch_created"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vote_assignments": {
+      "name": "vote_assignments",
+      "schema": "",
+      "columns": {
+        "stake_id": {
+          "name": "stake_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "epoch": {
+          "name": "epoch",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(30, 18)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_vote_assignments_user_epoch": {
+          "name": "idx_vote_assignments_user_epoch",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "epoch",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_vote_assignments_epoch": {
+          "name": "idx_vote_assignments_epoch",
+          "columns": [
+            {
+              "expression": "epoch",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vote_assignments_stake_id_stakes_id_fk": {
+          "name": "vote_assignments_stake_id_stakes_id_fk",
+          "tableFrom": "vote_assignments",
+          "tableTo": "stakes",
+          "columnsFrom": [
+            "stake_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vote_assignments_user_id_users_id_fk": {
+          "name": "vote_assignments_user_id_users_id_fk",
+          "tableFrom": "vote_assignments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vote_assignments_epoch_epochs_id_fk": {
+          "name": "vote_assignments_epoch_epochs_id_fk",
+          "tableFrom": "vote_assignments",
+          "tableTo": "epochs",
+          "columnsFrom": [
+            "epoch"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "vote_assignments_pkey": {
+          "name": "vote_assignments_pkey",
+          "columns": [
+            "stake_id",
+            "user_id",
+            "epoch"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.votes_available": {
+      "name": "votes_available",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "epoch": {
+          "name": "epoch",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(30, 18)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "votes_available_user_id_users_id_fk": {
+          "name": "votes_available_user_id_users_id_fk",
+          "tableFrom": "votes_available",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "votes_available_epoch_epochs_id_fk": {
+          "name": "votes_available_epoch_epochs_id_fk",
+          "tableFrom": "votes_available",
+          "tableTo": "epochs",
+          "columnsFrom": [
+            "epoch"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "votes_available_pkey": {
+          "name": "votes_available_pkey",
+          "columns": [
+            "user_id",
+            "epoch"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.votes_performed": {
+      "name": "votes_performed",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "epoch": {
+          "name": "epoch",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(30, 18)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_votes_performed_agent_epoch": {
+          "name": "idx_votes_performed_agent_epoch",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "epoch",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_votes_performed_epoch": {
+          "name": "idx_votes_performed_epoch",
+          "columns": [
+            {
+              "expression": "epoch",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "votes_performed_user_id_users_id_fk": {
+          "name": "votes_performed_user_id_users_id_fk",
+          "tableFrom": "votes_performed",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "votes_performed_agent_id_agents_id_fk": {
+          "name": "votes_performed_agent_id_agents_id_fk",
+          "tableFrom": "votes_performed",
+          "tableTo": "agents",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "votes_performed_epoch_epochs_id_fk": {
+          "name": "votes_performed_epoch_epochs_id_fk",
+          "tableFrom": "votes_performed",
+          "tableTo": "epochs",
+          "columnsFrom": [
+            "epoch"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "votes_performed_pkey": {
+          "name": "votes_performed_pkey",
+          "columns": [
+            "user_id",
+            "agent_id",
+            "epoch"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.actor_status": {
+      "name": "actor_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "inactive",
+        "suspended",
+        "deleted"
+      ]
+    },
+    "public.competition_status": {
+      "name": "competition_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "active",
+        "ended"
+      ]
+    },
+    "public.competition_type": {
+      "name": "competition_type",
+      "schema": "public",
+      "values": [
+        "trading"
+      ]
+    },
+    "trading_comps.cross_chain_trading_type": {
+      "name": "cross_chain_trading_type",
+      "schema": "trading_comps",
+      "values": [
+        "disallowAll",
+        "disallowXParent",
+        "allow"
+      ]
+    }
+  },
+  "schemas": {
+    "trading_comps": "trading_comps"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1748454089351,
       "tag": "0002_polite_obadiah_stane",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1748875766494,
+      "tag": "0003_yielding_killraven",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/e2e/tests/trading.test.ts
+++ b/apps/api/e2e/tests/trading.test.ts
@@ -131,6 +131,20 @@ describe("Trading API", () => {
     expect((buyTradeResponse as TradeResponse).transaction).toBeDefined();
     expect((buyTradeResponse as TradeResponse).transaction.id).toBeDefined();
 
+    // Verify token symbols are included
+    expect(
+      (buyTradeResponse as TradeResponse).transaction.fromTokenSymbol,
+    ).toBeDefined();
+    expect(
+      (buyTradeResponse as TradeResponse).transaction.toTokenSymbol,
+    ).toBeDefined();
+    console.log(
+      `Buy trade fromTokenSymbol: "${(buyTradeResponse as TradeResponse).transaction.fromTokenSymbol}"`,
+    );
+    console.log(
+      `Buy trade toTokenSymbol: "${(buyTradeResponse as TradeResponse).transaction.toTokenSymbol}"`,
+    );
+
     // Verify chain field is included in transaction response
     if ((buyTradeResponse as TradeResponse).transaction.fromChain) {
       expect((buyTradeResponse as TradeResponse).transaction.fromChain).toBe(
@@ -936,7 +950,7 @@ describe("Trading API", () => {
     expect(buyTradeResponse.success).toBe(true);
     expect((buyTradeResponse as TradeResponse).transaction).toBeDefined();
 
-    // Verify chain fields in the transaction
+    // Verify chain field is included in the transaction
     expect((buyTradeResponse as TradeResponse).transaction.fromChain).toBe(
       BlockchainType.SVM,
     );
@@ -1584,6 +1598,7 @@ describe("Trading API", () => {
       toAmount: smallValue,
       price: smallValue, // make sure exchange rate value can be very small
       toTokenSymbol: "NA",
+      fromTokenSymbol: "USDC",
       success: true,
       agentId: agent.id,
       tradeAmountUsd: smallValue,
@@ -1814,6 +1829,14 @@ describe("Trading API", () => {
       console.log(
         `Trade execution toTokenSymbol: "${transaction.toTokenSymbol}"`,
       );
+
+      // Verify fromTokenSymbol is included
+      expect(transaction.fromTokenSymbol).toBeDefined();
+      expect(typeof transaction.fromTokenSymbol).toBe("string");
+      expect(transaction.fromTokenSymbol.length).toBeGreaterThan(0);
+      console.log(
+        `Trade execution fromTokenSymbol: "${transaction.fromTokenSymbol}"`,
+      );
     }
 
     // Wait for trade to be processed
@@ -1866,6 +1889,13 @@ describe("Trading API", () => {
         console.log(
           `Trade history toTokenSymbol: "${lastTrade.toTokenSymbol}"`,
         );
+
+        expect(lastTrade.fromTokenSymbol).toBeDefined();
+        expect(typeof lastTrade.fromTokenSymbol).toBe("string");
+        expect(lastTrade.fromTokenSymbol.length).toBeGreaterThan(0);
+        console.log(
+          `Trade history fromTokenSymbol: "${lastTrade.fromTokenSymbol}"`,
+        );
       }
     }
 
@@ -1906,6 +1936,11 @@ describe("Trading API", () => {
         (t) => t.token === solTokenAddress,
       );
 
+      // Find USDC token in portfolio (the fromToken from our trade)
+      const usdcTokenInPortfolio = portfolio.tokens.find(
+        (t) => t.token === usdcTokenAddress,
+      );
+
       if (solTokenInPortfolio) {
         // Verify the toTokenSymbol from quote matches what's in the portfolio
         expect(quote.symbols.toTokenSymbol).toBe(solTokenInPortfolio.symbol);
@@ -1914,7 +1949,21 @@ describe("Trading API", () => {
         expect(tradeTransaction.toTokenSymbol).toBe(solTokenInPortfolio.symbol);
 
         console.log(
-          `Symbol consistency verified: "${quote.symbols.toTokenSymbol}" across all responses`,
+          `toTokenSymbol consistency verified: "${quote.symbols.toTokenSymbol}" across all responses`,
+        );
+      }
+
+      if (usdcTokenInPortfolio) {
+        // Verify the fromTokenSymbol from quote matches what's in the portfolio
+        expect(quote.symbols.fromTokenSymbol).toBe(usdcTokenInPortfolio.symbol);
+
+        // Verify the fromTokenSymbol from trade execution matches what's in the portfolio
+        expect(tradeTransaction.fromTokenSymbol).toBe(
+          usdcTokenInPortfolio.symbol,
+        );
+
+        console.log(
+          `fromTokenSymbol consistency verified: "${quote.symbols.fromTokenSymbol}" across all responses`,
         );
       }
     }
@@ -1994,6 +2043,20 @@ describe("Trading API", () => {
     expect(buyTradeResponse.success).toBe(true);
     expect((buyTradeResponse as TradeResponse).transaction).toBeDefined();
     expect((buyTradeResponse as TradeResponse).transaction.id).toBeDefined();
+
+    // Verify token symbols are included
+    expect(
+      (buyTradeResponse as TradeResponse).transaction.fromTokenSymbol,
+    ).toBeDefined();
+    expect(
+      (buyTradeResponse as TradeResponse).transaction.toTokenSymbol,
+    ).toBeDefined();
+    console.log(
+      `Buy trade fromTokenSymbol: "${(buyTradeResponse as TradeResponse).transaction.fromTokenSymbol}"`,
+    );
+    console.log(
+      `Buy trade toTokenSymbol: "${(buyTradeResponse as TradeResponse).transaction.toTokenSymbol}"`,
+    );
 
     // Verify chain field is included in transaction response
     if ((buyTradeResponse as TradeResponse).transaction.fromChain) {

--- a/apps/api/e2e/utils/api-types.ts
+++ b/apps/api/e2e/utils/api-types.ts
@@ -250,6 +250,7 @@ export interface TradeTransaction {
   fromSpecificChain: string | null;
   toSpecificChain: string | null;
   toTokenSymbol: string;
+  fromTokenSymbol: string;
 }
 
 // Trade history response

--- a/apps/api/openapi/openapi.json
+++ b/apps/api/openapi/openapi.json
@@ -2469,6 +2469,11 @@
                             "description": "Symbol of the destination token",
                             "example": "USDC"
                           },
+                          "fromTokenSymbol": {
+                            "type": "string",
+                            "description": "Symbol of the source token",
+                            "example": "SOL"
+                          },
                           "success": {
                             "type": "boolean",
                             "description": "Whether the trade was successfully completed"
@@ -2996,6 +3001,13 @@
                             ],
                             "description": "Competition status (always PENDING)"
                           },
+                          "type": {
+                            "type": "string",
+                            "enum": [
+                              "trading"
+                            ],
+                            "description": "Competition type"
+                          },
                           "crossChainTradingType": {
                             "type": "string",
                             "enum": [
@@ -3112,6 +3124,13 @@
                             "ended"
                           ],
                           "description": "Competition status"
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "trading"
+                          ],
+                          "description": "Competition type"
                         },
                         "createdAt": {
                           "type": "string",
@@ -3289,6 +3308,13 @@
                             "ended"
                           ],
                           "description": "Competition status"
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "trading"
+                          ],
+                          "description": "Competition type"
                         },
                         "crossChainTradingType": {
                           "type": "string",
@@ -3486,6 +3512,13 @@
                             ],
                             "description": "Competition status (always pending)"
                           },
+                          "type": {
+                            "type": "string",
+                            "enum": [
+                              "trading"
+                            ],
+                            "description": "Competition type"
+                          },
                           "crossChainTradingType": {
                             "type": "string",
                             "enum": [
@@ -3591,6 +3624,13 @@
                             "completed"
                           ],
                           "description": "Competition status"
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "trading"
+                          ],
+                          "description": "Competition type"
                         },
                         "crossChainTradingType": {
                           "type": "string",
@@ -4523,6 +4563,10 @@
                         "toTokenSymbol": {
                           "type": "string",
                           "description": "Symbol of the destination token"
+                        },
+                        "fromTokenSymbol": {
+                          "type": "string",
+                          "description": "Symbol of the source token"
                         }
                       }
                     }

--- a/apps/api/src/database/schema/trading/defs.ts
+++ b/apps/api/src/database/schema/trading/defs.ts
@@ -109,6 +109,7 @@ export const trades = tradingComps.table(
       mode: "number",
     }).notNull(),
     toTokenSymbol: varchar("to_token_symbol", { length: 20 }).notNull(),
+    fromTokenSymbol: varchar("from_token_symbol", { length: 20 }).notNull(),
     success: boolean().notNull(),
     error: text(),
     reason: text().notNull(),

--- a/apps/api/src/routes/agent.routes.ts
+++ b/apps/api/src/routes/agent.routes.ts
@@ -363,6 +363,10 @@ export function configureAgentRoutes(agentController: AgentController): Router {
    *                         type: string
    *                         description: Symbol of the destination token
    *                         example: "USDC"
+   *                       fromTokenSymbol:
+   *                         type: string
+   *                         description: Symbol of the source token
+   *                         example: "SOL"
    *                       success:
    *                         type: boolean
    *                         description: Whether the trade was successfully completed

--- a/apps/api/src/routes/trade.routes.ts
+++ b/apps/api/src/routes/trade.routes.ts
@@ -140,6 +140,9 @@ export function configureTradeRoutes(
    *                     toTokenSymbol:
    *                       type: string
    *                       description: Symbol of the destination token
+   *                     fromTokenSymbol:
+   *                       type: string
+   *                       description: Symbol of the source token
    *       400:
    *         description: Invalid input parameters
    *       401:

--- a/apps/api/src/services/trade-simulator.service.ts
+++ b/apps/api/src/services/trade-simulator.service.ts
@@ -332,6 +332,7 @@ export class TradeSimulator {
         toAmount,
         price: toAmount / fromAmount, // Exchange rate
         toTokenSymbol: toPrice.symbol,
+        fromTokenSymbol: fromPrice.symbol,
         tradeAmountUsd: fromValueUSD, // Store the USD value of the trade
         success: true,
         agentId,

--- a/packages/api-sdk/.speakeasy/gen.lock
+++ b/packages/api-sdk/.speakeasy/gen.lock
@@ -1,17 +1,17 @@
 lockVersion: 2.0.0
 id: e923f7a3-3252-4ef0-9997-307b6bd8549a
 management:
-  docChecksum: f1af7514191f1dfd30e1d5a66c8046fd
+  docChecksum: 29fde560b0c2951e46fea9a53977aec3
   docVersion: 1.0.0
-  speakeasyVersion: 1.554.1
-  generationVersion: 2.616.1
-  releaseVersion: 0.1.5
-  configChecksum: 2fa758fcd333e49d5c885b66938ac112
+  speakeasyVersion: 1.555.0
+  generationVersion: 2.618.0
+  releaseVersion: 0.1.6
+  configChecksum: ceceb979da5e8092b73c527676adc1bd
 features:
   typescript:
     additionalDependencies: 0.1.0
     constsAndDefaults: 0.1.11
-    core: 3.21.9
+    core: 3.21.10
     defaultEnabledRetries: 0.1.0
     devContainers: 2.90.0
     enumUnions: 0.1.0
@@ -101,12 +101,14 @@ generatedFiles:
   - docs/models/operations/getapicompetitionscompetitionidrequest.md
   - docs/models/operations/getapicompetitionscompetitionidresponse.md
   - docs/models/operations/getapicompetitionscompetitionidstatus.md
+  - docs/models/operations/getapicompetitionscompetitionidtype.md
   - docs/models/operations/getapicompetitionscrosschaintradingtype.md
   - docs/models/operations/getapicompetitionsleaderboardcompetition.md
   - docs/models/operations/getapicompetitionsleaderboardleaderboard.md
   - docs/models/operations/getapicompetitionsleaderboardrequest.md
   - docs/models/operations/getapicompetitionsleaderboardresponse.md
   - docs/models/operations/getapicompetitionsleaderboardstatus.md
+  - docs/models/operations/getapicompetitionsleaderboardtype.md
   - docs/models/operations/getapicompetitionsrequest.md
   - docs/models/operations/getapicompetitionsresponse.md
   - docs/models/operations/getapicompetitionsrulesresponse.md
@@ -115,10 +117,13 @@ generatedFiles:
   - docs/models/operations/getapicompetitionsstatuscrosschaintradingtype.md
   - docs/models/operations/getapicompetitionsstatusresponse.md
   - docs/models/operations/getapicompetitionsstatusstatus.md
+  - docs/models/operations/getapicompetitionsstatustype.md
+  - docs/models/operations/getapicompetitionstype.md
   - docs/models/operations/getapicompetitionsupcomingcompetition.md
   - docs/models/operations/getapicompetitionsupcomingcrosschaintradingtype.md
   - docs/models/operations/getapicompetitionsupcomingresponse.md
   - docs/models/operations/getapicompetitionsupcomingstatus.md
+  - docs/models/operations/getapicompetitionsupcomingtype.md
   - docs/models/operations/getapihealthdetailedresponse.md
   - docs/models/operations/getapihealthresponse.md
   - docs/models/operations/getapipricechainresponse.md

--- a/packages/api-sdk/.speakeasy/gen.yaml
+++ b/packages/api-sdk/.speakeasy/gen.yaml
@@ -20,7 +20,7 @@ generation:
     oAuth2ClientCredentialsEnabled: false
     oAuth2PasswordEnabled: false
 typescript:
-  version: 0.1.5
+  version: 0.1.6
   additionalDependencies:
     dependencies: {}
     devDependencies: {}

--- a/packages/api-sdk/.speakeasy/workflow.lock
+++ b/packages/api-sdk/.speakeasy/workflow.lock
@@ -1,4 +1,4 @@
-speakeasyVersion: 1.554.1
+speakeasyVersion: 1.555.0
 sources:
     Trading Simulator API:
         sourceNamespace: trading-simulator-api

--- a/packages/api-sdk/jsr.json
+++ b/packages/api-sdk/jsr.json
@@ -2,7 +2,7 @@
 
 {
   "name": "@recallnet/api-sdk",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "exports": {
     ".": "./src/index.ts",    
     "./models/errors": "./src/models/errors/index.ts",    

--- a/packages/api-sdk/package-lock.json
+++ b/packages/api-sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@recallnet/api-sdk",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@recallnet/api-sdk",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "bin": {
         "mcp": "bin/mcp-server.js"
       },

--- a/packages/api-sdk/package.json
+++ b/packages/api-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@recallnet/api-sdk",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "author": "Recall Contributors",
   "private": true,
   "type": "module",

--- a/packages/api-sdk/src/index.ts
+++ b/packages/api-sdk/src/index.ts
@@ -4,4 +4,6 @@
 
 export * from "./lib/config.js";
 export * as files from "./lib/files.js";
+export { HTTPClient } from "./lib/http.js";
+export type { Fetcher, HTTPClientOptions } from "./lib/http.js";
 export * from "./sdk/sdk.js";

--- a/packages/api-sdk/src/lib/config.ts
+++ b/packages/api-sdk/src/lib/config.ts
@@ -68,7 +68,7 @@ export function serverURLFromOptions(options: SDKOptions): URL | null {
 export const SDK_METADATA = {
   language: "typescript",
   openapiDocVersion: "1.0.0",
-  sdkVersion: "0.1.5",
-  genVersion: "2.616.1",
-  userAgent: "speakeasy-sdk/typescript 0.1.5 2.616.1 1.0.0 @recallnet/api-sdk",
+  sdkVersion: "0.1.6",
+  genVersion: "2.618.0",
+  userAgent: "speakeasy-sdk/typescript 0.1.6 2.618.0 1.0.0 @recallnet/api-sdk",
 } as const;

--- a/packages/api-sdk/src/mcp-server/mcp-server.ts
+++ b/packages/api-sdk/src/mcp-server/mcp-server.ts
@@ -19,7 +19,7 @@ const routes = buildRouteMap({
 export const app = buildApplication(routes, {
   name: "mcp",
   versionInfo: {
-    currentVersion: "0.1.5",
+    currentVersion: "0.1.6",
   },
 });
 

--- a/packages/api-sdk/src/mcp-server/server.ts
+++ b/packages/api-sdk/src/mcp-server/server.ts
@@ -64,7 +64,7 @@ export function createMCPServer(deps: {
 }) {
   const server = new McpServer({
     name: "ApiSDK",
-    version: "0.1.5",
+    version: "0.1.6",
   });
 
   const client = new ApiSDKCore({

--- a/packages/api-sdk/src/models/operations/getapiagenttrades.ts
+++ b/packages/api-sdk/src/models/operations/getapiagenttrades.ts
@@ -40,6 +40,10 @@ export type Trade = {
    */
   toTokenSymbol?: string | undefined;
   /**
+   * Symbol of the source token
+   */
+  fromTokenSymbol?: string | undefined;
+  /**
    * Whether the trade was successfully completed
    */
   success?: boolean | undefined;
@@ -95,6 +99,7 @@ export const Trade$inboundSchema: z.ZodType<Trade, z.ZodTypeDef, unknown> =
     price: z.number().optional(),
     tradeAmountUsd: z.number().optional(),
     toTokenSymbol: z.string().optional(),
+    fromTokenSymbol: z.string().optional(),
     success: z.boolean().optional(),
     error: z.nullable(z.string()).optional(),
     reason: z.string().optional(),
@@ -121,6 +126,7 @@ export type Trade$Outbound = {
   price?: number | undefined;
   tradeAmountUsd?: number | undefined;
   toTokenSymbol?: string | undefined;
+  fromTokenSymbol?: string | undefined;
   success?: boolean | undefined;
   error?: string | null | undefined;
   reason?: string | undefined;
@@ -147,6 +153,7 @@ export const Trade$outboundSchema: z.ZodType<
   price: z.number().optional(),
   tradeAmountUsd: z.number().optional(),
   toTokenSymbol: z.string().optional(),
+  fromTokenSymbol: z.string().optional(),
   success: z.boolean().optional(),
   error: z.nullable(z.string()).optional(),
   reason: z.string().optional(),

--- a/packages/api-sdk/src/models/operations/getapicompetitions.ts
+++ b/packages/api-sdk/src/models/operations/getapicompetitions.ts
@@ -41,6 +41,17 @@ export type GetApiCompetitionsStatus = ClosedEnum<
 >;
 
 /**
+ * Competition type
+ */
+export const GetApiCompetitionsType = {
+  Trading: "trading",
+} as const;
+/**
+ * Competition type
+ */
+export type GetApiCompetitionsType = ClosedEnum<typeof GetApiCompetitionsType>;
+
+/**
  * The type of cross-chain trading allowed in this competition
  */
 export const GetApiCompetitionsCrossChainTradingType = {
@@ -80,6 +91,10 @@ export type GetApiCompetitionsCompetition = {
    * Competition status (always PENDING)
    */
   status?: GetApiCompetitionsStatus | undefined;
+  /**
+   * Competition type
+   */
+  type?: GetApiCompetitionsType | undefined;
   /**
    * The type of cross-chain trading allowed in this competition
    */
@@ -190,6 +205,27 @@ export namespace GetApiCompetitionsStatus$ {
 }
 
 /** @internal */
+export const GetApiCompetitionsType$inboundSchema: z.ZodNativeEnum<
+  typeof GetApiCompetitionsType
+> = z.nativeEnum(GetApiCompetitionsType);
+
+/** @internal */
+export const GetApiCompetitionsType$outboundSchema: z.ZodNativeEnum<
+  typeof GetApiCompetitionsType
+> = GetApiCompetitionsType$inboundSchema;
+
+/**
+ * @internal
+ * @deprecated This namespace will be removed in future versions. Use schemas and types that are exported directly from this module.
+ */
+export namespace GetApiCompetitionsType$ {
+  /** @deprecated use `GetApiCompetitionsType$inboundSchema` instead. */
+  export const inboundSchema = GetApiCompetitionsType$inboundSchema;
+  /** @deprecated use `GetApiCompetitionsType$outboundSchema` instead. */
+  export const outboundSchema = GetApiCompetitionsType$outboundSchema;
+}
+
+/** @internal */
 export const GetApiCompetitionsCrossChainTradingType$inboundSchema: z.ZodNativeEnum<
   typeof GetApiCompetitionsCrossChainTradingType
 > = z.nativeEnum(GetApiCompetitionsCrossChainTradingType);
@@ -224,6 +260,7 @@ export const GetApiCompetitionsCompetition$inboundSchema: z.ZodType<
   externalUrl: z.nullable(z.string()).optional(),
   imageUrl: z.nullable(z.string()).optional(),
   status: GetApiCompetitionsStatus$inboundSchema.optional(),
+  type: GetApiCompetitionsType$inboundSchema.optional(),
   crossChainTradingType:
     GetApiCompetitionsCrossChainTradingType$inboundSchema.optional(),
   createdAt: z
@@ -246,6 +283,7 @@ export type GetApiCompetitionsCompetition$Outbound = {
   externalUrl?: string | null | undefined;
   imageUrl?: string | null | undefined;
   status?: string | undefined;
+  type?: string | undefined;
   crossChainTradingType?: string | undefined;
   createdAt?: string | undefined;
   updatedAt?: string | undefined;
@@ -263,6 +301,7 @@ export const GetApiCompetitionsCompetition$outboundSchema: z.ZodType<
   externalUrl: z.nullable(z.string()).optional(),
   imageUrl: z.nullable(z.string()).optional(),
   status: GetApiCompetitionsStatus$outboundSchema.optional(),
+  type: GetApiCompetitionsType$outboundSchema.optional(),
   crossChainTradingType:
     GetApiCompetitionsCrossChainTradingType$outboundSchema.optional(),
   createdAt: z

--- a/packages/api-sdk/src/models/operations/getapicompetitionscompetitionid.ts
+++ b/packages/api-sdk/src/models/operations/getapicompetitionscompetitionid.ts
@@ -31,6 +31,19 @@ export type GetApiCompetitionsCompetitionIdStatus = ClosedEnum<
 >;
 
 /**
+ * Competition type
+ */
+export const GetApiCompetitionsCompetitionIdType = {
+  Trading: "trading",
+} as const;
+/**
+ * Competition type
+ */
+export type GetApiCompetitionsCompetitionIdType = ClosedEnum<
+  typeof GetApiCompetitionsCompetitionIdType
+>;
+
+/**
  * The type of cross-chain trading allowed in this competition
  */
 export const GetApiCompetitionsCompetitionIdCrossChainTradingType = {
@@ -70,6 +83,10 @@ export type GetApiCompetitionsCompetitionIdCompetition = {
    * Competition status
    */
   status?: GetApiCompetitionsCompetitionIdStatus | undefined;
+  /**
+   * Competition type
+   */
+  type?: GetApiCompetitionsCompetitionIdType | undefined;
   /**
    * The type of cross-chain trading allowed in this competition
    */
@@ -188,6 +205,29 @@ export namespace GetApiCompetitionsCompetitionIdStatus$ {
 }
 
 /** @internal */
+export const GetApiCompetitionsCompetitionIdType$inboundSchema: z.ZodNativeEnum<
+  typeof GetApiCompetitionsCompetitionIdType
+> = z.nativeEnum(GetApiCompetitionsCompetitionIdType);
+
+/** @internal */
+export const GetApiCompetitionsCompetitionIdType$outboundSchema: z.ZodNativeEnum<
+  typeof GetApiCompetitionsCompetitionIdType
+> = GetApiCompetitionsCompetitionIdType$inboundSchema;
+
+/**
+ * @internal
+ * @deprecated This namespace will be removed in future versions. Use schemas and types that are exported directly from this module.
+ */
+export namespace GetApiCompetitionsCompetitionIdType$ {
+  /** @deprecated use `GetApiCompetitionsCompetitionIdType$inboundSchema` instead. */
+  export const inboundSchema =
+    GetApiCompetitionsCompetitionIdType$inboundSchema;
+  /** @deprecated use `GetApiCompetitionsCompetitionIdType$outboundSchema` instead. */
+  export const outboundSchema =
+    GetApiCompetitionsCompetitionIdType$outboundSchema;
+}
+
+/** @internal */
 export const GetApiCompetitionsCompetitionIdCrossChainTradingType$inboundSchema: z.ZodNativeEnum<
   typeof GetApiCompetitionsCompetitionIdCrossChainTradingType
 > = z.nativeEnum(GetApiCompetitionsCompetitionIdCrossChainTradingType);
@@ -222,6 +262,7 @@ export const GetApiCompetitionsCompetitionIdCompetition$inboundSchema: z.ZodType
   externalUrl: z.nullable(z.string()).optional(),
   imageUrl: z.nullable(z.string()).optional(),
   status: GetApiCompetitionsCompetitionIdStatus$inboundSchema.optional(),
+  type: GetApiCompetitionsCompetitionIdType$inboundSchema.optional(),
   crossChainTradingType:
     GetApiCompetitionsCompetitionIdCrossChainTradingType$inboundSchema.optional(),
   startDate: z
@@ -260,6 +301,7 @@ export type GetApiCompetitionsCompetitionIdCompetition$Outbound = {
   externalUrl?: string | null | undefined;
   imageUrl?: string | null | undefined;
   status?: string | undefined;
+  type?: string | undefined;
   crossChainTradingType?: string | undefined;
   startDate?: string | null | undefined;
   endDate?: string | null | undefined;
@@ -279,6 +321,7 @@ export const GetApiCompetitionsCompetitionIdCompetition$outboundSchema: z.ZodTyp
   externalUrl: z.nullable(z.string()).optional(),
   imageUrl: z.nullable(z.string()).optional(),
   status: GetApiCompetitionsCompetitionIdStatus$outboundSchema.optional(),
+  type: GetApiCompetitionsCompetitionIdType$outboundSchema.optional(),
   crossChainTradingType:
     GetApiCompetitionsCompetitionIdCrossChainTradingType$outboundSchema.optional(),
   startDate: z.nullable(z.date().transform((v) => v.toISOString())).optional(),

--- a/packages/api-sdk/src/models/operations/getapicompetitionsleaderboard.ts
+++ b/packages/api-sdk/src/models/operations/getapicompetitionsleaderboard.ts
@@ -30,6 +30,19 @@ export type GetApiCompetitionsLeaderboardStatus = ClosedEnum<
   typeof GetApiCompetitionsLeaderboardStatus
 >;
 
+/**
+ * Competition type
+ */
+export const GetApiCompetitionsLeaderboardType = {
+  Trading: "trading",
+} as const;
+/**
+ * Competition type
+ */
+export type GetApiCompetitionsLeaderboardType = ClosedEnum<
+  typeof GetApiCompetitionsLeaderboardType
+>;
+
 export type GetApiCompetitionsLeaderboardCompetition = {
   /**
    * Competition ID
@@ -63,6 +76,10 @@ export type GetApiCompetitionsLeaderboardCompetition = {
    * Competition status
    */
   status?: GetApiCompetitionsLeaderboardStatus | undefined;
+  /**
+   * Competition type
+   */
+  type?: GetApiCompetitionsLeaderboardType | undefined;
   /**
    * When the competition was created
    */
@@ -229,6 +246,28 @@ export namespace GetApiCompetitionsLeaderboardStatus$ {
 }
 
 /** @internal */
+export const GetApiCompetitionsLeaderboardType$inboundSchema: z.ZodNativeEnum<
+  typeof GetApiCompetitionsLeaderboardType
+> = z.nativeEnum(GetApiCompetitionsLeaderboardType);
+
+/** @internal */
+export const GetApiCompetitionsLeaderboardType$outboundSchema: z.ZodNativeEnum<
+  typeof GetApiCompetitionsLeaderboardType
+> = GetApiCompetitionsLeaderboardType$inboundSchema;
+
+/**
+ * @internal
+ * @deprecated This namespace will be removed in future versions. Use schemas and types that are exported directly from this module.
+ */
+export namespace GetApiCompetitionsLeaderboardType$ {
+  /** @deprecated use `GetApiCompetitionsLeaderboardType$inboundSchema` instead. */
+  export const inboundSchema = GetApiCompetitionsLeaderboardType$inboundSchema;
+  /** @deprecated use `GetApiCompetitionsLeaderboardType$outboundSchema` instead. */
+  export const outboundSchema =
+    GetApiCompetitionsLeaderboardType$outboundSchema;
+}
+
+/** @internal */
 export const GetApiCompetitionsLeaderboardCompetition$inboundSchema: z.ZodType<
   GetApiCompetitionsLeaderboardCompetition,
   z.ZodTypeDef,
@@ -253,6 +292,7 @@ export const GetApiCompetitionsLeaderboardCompetition$inboundSchema: z.ZodType<
     )
     .optional(),
   status: GetApiCompetitionsLeaderboardStatus$inboundSchema.optional(),
+  type: GetApiCompetitionsLeaderboardType$inboundSchema.optional(),
   createdAt: z
     .string()
     .datetime({ offset: true })
@@ -275,6 +315,7 @@ export type GetApiCompetitionsLeaderboardCompetition$Outbound = {
   startDate?: string | undefined;
   endDate?: string | null | undefined;
   status?: string | undefined;
+  type?: string | undefined;
   createdAt?: string | undefined;
   updatedAt?: string | undefined;
 };
@@ -296,6 +337,7 @@ export const GetApiCompetitionsLeaderboardCompetition$outboundSchema: z.ZodType<
     .optional(),
   endDate: z.nullable(z.date().transform((v) => v.toISOString())).optional(),
   status: GetApiCompetitionsLeaderboardStatus$outboundSchema.optional(),
+  type: GetApiCompetitionsLeaderboardType$outboundSchema.optional(),
   createdAt: z
     .date()
     .transform((v) => v.toISOString())

--- a/packages/api-sdk/src/models/operations/getapicompetitionsstatus.ts
+++ b/packages/api-sdk/src/models/operations/getapicompetitionsstatus.ts
@@ -24,6 +24,19 @@ export type GetApiCompetitionsStatusStatus = ClosedEnum<
 >;
 
 /**
+ * Competition type
+ */
+export const GetApiCompetitionsStatusType = {
+  Trading: "trading",
+} as const;
+/**
+ * Competition type
+ */
+export type GetApiCompetitionsStatusType = ClosedEnum<
+  typeof GetApiCompetitionsStatusType
+>;
+
+/**
  * The type of cross-chain trading allowed in this competition
  */
 export const GetApiCompetitionsStatusCrossChainTradingType = {
@@ -71,6 +84,10 @@ export type GetApiCompetitionsStatusCompetition = {
    * Competition status
    */
   status?: GetApiCompetitionsStatusStatus | undefined;
+  /**
+   * Competition type
+   */
+  type?: GetApiCompetitionsStatusType | undefined;
   /**
    * The type of cross-chain trading allowed in this competition
    */
@@ -132,6 +149,27 @@ export namespace GetApiCompetitionsStatusStatus$ {
 }
 
 /** @internal */
+export const GetApiCompetitionsStatusType$inboundSchema: z.ZodNativeEnum<
+  typeof GetApiCompetitionsStatusType
+> = z.nativeEnum(GetApiCompetitionsStatusType);
+
+/** @internal */
+export const GetApiCompetitionsStatusType$outboundSchema: z.ZodNativeEnum<
+  typeof GetApiCompetitionsStatusType
+> = GetApiCompetitionsStatusType$inboundSchema;
+
+/**
+ * @internal
+ * @deprecated This namespace will be removed in future versions. Use schemas and types that are exported directly from this module.
+ */
+export namespace GetApiCompetitionsStatusType$ {
+  /** @deprecated use `GetApiCompetitionsStatusType$inboundSchema` instead. */
+  export const inboundSchema = GetApiCompetitionsStatusType$inboundSchema;
+  /** @deprecated use `GetApiCompetitionsStatusType$outboundSchema` instead. */
+  export const outboundSchema = GetApiCompetitionsStatusType$outboundSchema;
+}
+
+/** @internal */
 export const GetApiCompetitionsStatusCrossChainTradingType$inboundSchema: z.ZodNativeEnum<
   typeof GetApiCompetitionsStatusCrossChainTradingType
 > = z.nativeEnum(GetApiCompetitionsStatusCrossChainTradingType);
@@ -179,6 +217,7 @@ export const GetApiCompetitionsStatusCompetition$inboundSchema: z.ZodType<
     )
     .optional(),
   status: GetApiCompetitionsStatusStatus$inboundSchema.optional(),
+  type: GetApiCompetitionsStatusType$inboundSchema.optional(),
   crossChainTradingType:
     GetApiCompetitionsStatusCrossChainTradingType$inboundSchema.optional(),
   createdAt: z
@@ -203,6 +242,7 @@ export type GetApiCompetitionsStatusCompetition$Outbound = {
   startDate?: string | undefined;
   endDate?: string | null | undefined;
   status?: string | undefined;
+  type?: string | undefined;
   crossChainTradingType?: string | undefined;
   createdAt?: string | undefined;
   updatedAt?: string | undefined;
@@ -225,6 +265,7 @@ export const GetApiCompetitionsStatusCompetition$outboundSchema: z.ZodType<
     .optional(),
   endDate: z.nullable(z.date().transform((v) => v.toISOString())).optional(),
   status: GetApiCompetitionsStatusStatus$outboundSchema.optional(),
+  type: GetApiCompetitionsStatusType$outboundSchema.optional(),
   crossChainTradingType:
     GetApiCompetitionsStatusCrossChainTradingType$outboundSchema.optional(),
   createdAt: z

--- a/packages/api-sdk/src/models/operations/getapicompetitionsupcoming.ts
+++ b/packages/api-sdk/src/models/operations/getapicompetitionsupcoming.ts
@@ -22,6 +22,19 @@ export type GetApiCompetitionsUpcomingStatus = ClosedEnum<
 >;
 
 /**
+ * Competition type
+ */
+export const GetApiCompetitionsUpcomingType = {
+  Trading: "trading",
+} as const;
+/**
+ * Competition type
+ */
+export type GetApiCompetitionsUpcomingType = ClosedEnum<
+  typeof GetApiCompetitionsUpcomingType
+>;
+
+/**
  * The type of cross-chain trading allowed in this competition
  */
 export const GetApiCompetitionsUpcomingCrossChainTradingType = {
@@ -61,6 +74,10 @@ export type GetApiCompetitionsUpcomingCompetition = {
    * Competition status (always pending)
    */
   status?: GetApiCompetitionsUpcomingStatus | undefined;
+  /**
+   * Competition type
+   */
+  type?: GetApiCompetitionsUpcomingType | undefined;
   /**
    * The type of cross-chain trading allowed in this competition
    */
@@ -110,6 +127,27 @@ export namespace GetApiCompetitionsUpcomingStatus$ {
 }
 
 /** @internal */
+export const GetApiCompetitionsUpcomingType$inboundSchema: z.ZodNativeEnum<
+  typeof GetApiCompetitionsUpcomingType
+> = z.nativeEnum(GetApiCompetitionsUpcomingType);
+
+/** @internal */
+export const GetApiCompetitionsUpcomingType$outboundSchema: z.ZodNativeEnum<
+  typeof GetApiCompetitionsUpcomingType
+> = GetApiCompetitionsUpcomingType$inboundSchema;
+
+/**
+ * @internal
+ * @deprecated This namespace will be removed in future versions. Use schemas and types that are exported directly from this module.
+ */
+export namespace GetApiCompetitionsUpcomingType$ {
+  /** @deprecated use `GetApiCompetitionsUpcomingType$inboundSchema` instead. */
+  export const inboundSchema = GetApiCompetitionsUpcomingType$inboundSchema;
+  /** @deprecated use `GetApiCompetitionsUpcomingType$outboundSchema` instead. */
+  export const outboundSchema = GetApiCompetitionsUpcomingType$outboundSchema;
+}
+
+/** @internal */
 export const GetApiCompetitionsUpcomingCrossChainTradingType$inboundSchema: z.ZodNativeEnum<
   typeof GetApiCompetitionsUpcomingCrossChainTradingType
 > = z.nativeEnum(GetApiCompetitionsUpcomingCrossChainTradingType);
@@ -144,6 +182,7 @@ export const GetApiCompetitionsUpcomingCompetition$inboundSchema: z.ZodType<
   externalUrl: z.nullable(z.string()).optional(),
   imageUrl: z.nullable(z.string()).optional(),
   status: GetApiCompetitionsUpcomingStatus$inboundSchema.optional(),
+  type: GetApiCompetitionsUpcomingType$inboundSchema.optional(),
   crossChainTradingType:
     GetApiCompetitionsUpcomingCrossChainTradingType$inboundSchema.optional(),
   createdAt: z
@@ -166,6 +205,7 @@ export type GetApiCompetitionsUpcomingCompetition$Outbound = {
   externalUrl?: string | null | undefined;
   imageUrl?: string | null | undefined;
   status?: string | undefined;
+  type?: string | undefined;
   crossChainTradingType?: string | undefined;
   createdAt?: string | undefined;
   updatedAt?: string | undefined;
@@ -183,6 +223,7 @@ export const GetApiCompetitionsUpcomingCompetition$outboundSchema: z.ZodType<
   externalUrl: z.nullable(z.string()).optional(),
   imageUrl: z.nullable(z.string()).optional(),
   status: GetApiCompetitionsUpcomingStatus$outboundSchema.optional(),
+  type: GetApiCompetitionsUpcomingType$outboundSchema.optional(),
   crossChainTradingType:
     GetApiCompetitionsUpcomingCrossChainTradingType$outboundSchema.optional(),
   createdAt: z

--- a/packages/api-sdk/src/models/operations/postapitradeexecute.ts
+++ b/packages/api-sdk/src/models/operations/postapitradeexecute.ts
@@ -119,6 +119,10 @@ export type Transaction = {
    * Symbol of the destination token
    */
   toTokenSymbol?: string | undefined;
+  /**
+   * Symbol of the source token
+   */
+  fromTokenSymbol?: string | undefined;
 };
 
 /**
@@ -238,6 +242,7 @@ export const Transaction$inboundSchema: z.ZodType<
   fromSpecificChain: z.string().optional(),
   toSpecificChain: z.string().optional(),
   toTokenSymbol: z.string().optional(),
+  fromTokenSymbol: z.string().optional(),
 });
 
 /** @internal */
@@ -260,6 +265,7 @@ export type Transaction$Outbound = {
   fromSpecificChain?: string | undefined;
   toSpecificChain?: string | undefined;
   toTokenSymbol?: string | undefined;
+  fromTokenSymbol?: string | undefined;
 };
 
 /** @internal */
@@ -289,6 +295,7 @@ export const Transaction$outboundSchema: z.ZodType<
   fromSpecificChain: z.string().optional(),
   toSpecificChain: z.string().optional(),
   toTokenSymbol: z.string().optional(),
+  fromTokenSymbol: z.string().optional(),
 });
 
 /**


### PR DESCRIPTION
# Add `fromTokenSymbol` to trading behavior

**What Changed:**
- Added `fromTokenSymbol` field to trades table to complement existing `toTokenSymbol`
- Updated trade execution to capture and store source token symbols
- Enhanced API responses to include both source and destination token symbols
- Updated OpenAPI documentation for trade execution and history endpoints  
- Added comprehensive E2E test coverage for the new field