### PR TITLE
Fix error message typos

### DIFF
--- a/packages/sdk/src/entities/account.ts
+++ b/packages/sdk/src/entities/account.ts
@@ -85,7 +85,7 @@ export class AccountManager {
       overrideSupplySourceAddress ??
       deployedSupplySourceAddress;
     if (!override) {
-      throw new Error(`No contract address found for chain ID ${chainId}}`);
+      throw new Error(`No contract address found for chain ID ${chainId}`);
     }
     return getContract({
       abi: recallErc20Abi,
@@ -208,7 +208,7 @@ export class AccountManager {
       overrideGatewayAddress ??
       deployedGatewayManagerFacetAddress;
     if (!override) {
-      throw new Error(`No contract address found for chain ID ${chainId}}`);
+      throw new Error(`No contract address found for chain ID ${chainId}`);
     }
     await this.approve(override, amount);
     const result = await this.getGatewayManager().fundWithToken(
@@ -246,7 +246,7 @@ export class AccountManager {
       overrideGatewayAddress ??
       deployedGatewayManagerFacetAddress;
     if (!override) {
-      throw new Error(`No contract address found for chain ID ${chainId}}`);
+      throw new Error(`No contract address found for chain ID ${chainId}`);
     }
     const result = await this.getGatewayManager().release(
       this.client.publicClient,

--- a/packages/sdk/src/entities/blob.ts
+++ b/packages/sdk/src/entities/blob.ts
@@ -107,7 +107,7 @@ export class BlobManager {
       iBlobsFacadeAddress as Record<number, Address>
     )[chainId];
     if (!deployedBlobManagerAddress) {
-      throw new Error(`No contract address found for chain ID ${chainId}}`);
+      throw new Error(`No contract address found for chain ID ${chainId}`);
     }
     this.contract = getContract({
       abi: iBlobsFacadeAbi,

--- a/packages/sdk/src/entities/bucket.ts
+++ b/packages/sdk/src/entities/bucket.ts
@@ -214,7 +214,7 @@ export class BucketManager {
       iMachineFacadeAddress as Record<number, Address>
     )[chainId];
     if (!deployedBucketManagerAddress) {
-      throw new Error(`No contract address found for chain ID ${chainId}}`);
+      throw new Error(`No contract address found for chain ID ${chainId}`);
     }
     this.factoryContract = getContract({
       abi: iMachineFacadeAbi,

--- a/packages/sdk/src/entities/credit.ts
+++ b/packages/sdk/src/entities/credit.ts
@@ -124,7 +124,7 @@ export class CreditManager {
       iCreditFacadeAddress as Record<number, Address>
     )[chainId];
     if (!deployedCreditManagerAddress) {
-      throw new Error(`No contract address found for chain ID ${chainId}}`);
+      throw new Error(`No contract address found for chain ID ${chainId}`);
     }
     this.contract = getContract({
       abi: iCreditFacadeAbi,


### PR DESCRIPTION
## Summary
- fix wrong template strings across sdk entities

## Testing
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm)*

------
https://chatgpt.com/codex/tasks/task_b_683f7f86efdc8332af73f93d1557c296