### PR TITLE
feat: public competition routes

### DIFF
--- a/.cursor/rules/api-specific-config.mdc
+++ b/.cursor/rules/api-specific-config.mdc
@@ -47,6 +47,9 @@ alwaysApply: false
 - Authentication flows must be thoroughly tested
 - Performance-critical changes require load testing validation
 
+### Running Tests
+- To run tests using the e2e testing suite, you can use a format such as `cd apps/api && pnpm test:e2e name-of-test.test.ts`
+
 ## API Design Patterns
 
 ### Response Format Consistency

--- a/apps/api/e2e/tests/competition.test.ts
+++ b/apps/api/e2e/tests/competition.test.ts
@@ -2591,4 +2591,141 @@ describe("Competition API", () => {
       expect(joinResponse.error).toContain("does not match agent ID in URL");
     }
   });
+
+  describe("Public Competition Access (No Authentication Required)", () => {
+    test("should allow unauthenticated access to GET /competitions", async () => {
+      // Setup: Create test competition via admin
+      const adminClient = createTestClient();
+      await adminClient.loginAsAdmin(adminApiKey);
+      await createTestCompetition(adminClient, "Public Test Competition");
+
+      // Test: Direct axios call without authentication
+      const response = await axios.get(`${getBaseUrl()}/api/competitions`);
+
+      expect(response.status).toBe(200);
+      expect(response.data.success).toBe(true);
+      expect(response.data.competitions).toBeDefined();
+      expect(Array.isArray(response.data.competitions)).toBe(true);
+    });
+
+    test("should allow unauthenticated access to GET /competitions/{id}", async () => {
+      // Setup: Create test competition via admin
+      const adminClient = createTestClient();
+      await adminClient.loginAsAdmin(adminApiKey);
+      const { competition } = await createTestCompetition(
+        adminClient,
+        "Public Test Competition Details",
+      );
+
+      // Test: Direct axios call without authentication
+      const response = await axios.get(
+        `${getBaseUrl()}/api/competitions/${competition.id}`,
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.data.success).toBe(true);
+      expect(response.data.competition).toBeDefined();
+      expect(response.data.competition.id).toBe(competition.id);
+      expect(response.data.competition.name).toBe(
+        "Public Test Competition Details",
+      );
+    });
+
+    test("should allow unauthenticated access to GET /competitions/{id}/agents", async () => {
+      // Setup: Create competition with agents via admin
+      const adminClient = createTestClient();
+      await adminClient.loginAsAdmin(adminApiKey);
+
+      const { agent } = await registerUserAndAgentAndGetClient({
+        adminApiKey,
+        agentName: "Public Test Agent",
+      });
+
+      const { competition } = await startTestCompetition(
+        adminClient,
+        "Public Competition with Agents",
+        [agent.id],
+      );
+
+      // Test: Direct axios call without authentication
+      const response = await axios.get(
+        `${getBaseUrl()}/api/competitions/${competition.id}/agents`,
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.data.success).toBe(true);
+      expect(response.data.competitionId).toBe(competition.id);
+      expect(response.data.agents).toBeDefined();
+      expect(Array.isArray(response.data.agents)).toBe(true);
+    });
+
+    test("should return 404 for non-existent competition in public endpoints", async () => {
+      const nonExistentId = "00000000-0000-0000-0000-000000000000";
+
+      // Test all three public endpoints with non-existent ID
+      await expect(
+        axios.get(`${getBaseUrl()}/api/competitions/${nonExistentId}`),
+      ).rejects.toMatchObject({
+        response: { status: 404 },
+      });
+
+      await expect(
+        axios.get(`${getBaseUrl()}/api/competitions/${nonExistentId}/agents`),
+      ).rejects.toMatchObject({
+        response: { status: 404 },
+      });
+    });
+
+    test("protected endpoints should still require authentication", async () => {
+      const protectedEndpoints = [
+        "/api/competitions/leaderboard",
+        "/api/competitions/status",
+        "/api/competitions/rules",
+        "/api/competitions/upcoming",
+      ];
+
+      // Test each protected endpoint without authentication
+      for (const endpoint of protectedEndpoints) {
+        await expect(
+          axios.get(`${getBaseUrl()}${endpoint}`),
+        ).rejects.toMatchObject({
+          response: { status: 401 },
+        });
+      }
+    });
+
+    test("join/leave competition endpoints should still require authentication", async () => {
+      // Setup: Create test competition and agent
+      const adminClient = createTestClient();
+      await adminClient.loginAsAdmin(adminApiKey);
+
+      const { agent } = await registerUserAndAgentAndGetClient({
+        adminApiKey,
+        agentName: "Protected Test Agent",
+      });
+
+      const { competition } = await createTestCompetition(
+        adminClient,
+        "Protected Test Competition",
+      );
+
+      // Test: Join endpoint without authentication
+      await expect(
+        axios.post(
+          `${getBaseUrl()}/api/competitions/${competition.id}/agents/${agent.id}`,
+        ),
+      ).rejects.toMatchObject({
+        response: { status: 401 },
+      });
+
+      // Test: Leave endpoint without authentication
+      await expect(
+        axios.delete(
+          `${getBaseUrl()}/api/competitions/${competition.id}/agents/${agent.id}`,
+        ),
+      ).rejects.toMatchObject({
+        response: { status: 401 },
+      });
+    });
+  });
 });

--- a/apps/api/openapi/API.md
+++ b/apps/api/openapi/API.md
@@ -689,6 +689,39 @@ Retrieve the information for the given agent ID
 | --------------- | ------ |
 | BearerAuth      |        |
 
+### /api/agent/{agentId}/competitions
+
+#### GET
+
+##### Summary:
+
+Get agent competitions
+
+##### Description:
+
+Retrieve all competitions associated with the specified agent
+
+##### Parameters
+
+| Name    | Located in | Description           | Required | Schema |
+| ------- | ---------- | --------------------- | -------- | ------ |
+| agentId | path       | The UUID of the agent | Yes      | string |
+
+##### Responses
+
+| Code | Description                         |
+| ---- | ----------------------------------- |
+| 200  | Competitions retrieved successfully |
+| 401  | Agent not authenticated             |
+| 404  | Agent or competitions not found     |
+| 500  | Internal server error               |
+
+##### Security
+
+| Security Schema | Scopes |
+| --------------- | ------ |
+| BearerAuth      |        |
+
 ### /api/agents
 
 #### GET

--- a/apps/api/src/controllers/competition.controller.ts
+++ b/apps/api/src/controllers/competition.controller.ts
@@ -452,7 +452,9 @@ export function makeCompetitionController(services: ServiceRegistry) {
             `[CompetitionController] User ${userId} requesting competitions`,
           );
         } else {
-          throw new ApiError(401, "Authentication required");
+          console.log(
+            `[CompetitionController] Unauthenticated request for competitions (public access)`,
+          );
         }
 
         // Get all competitions, or those with a given status from the query params
@@ -516,7 +518,9 @@ export function makeCompetitionController(services: ServiceRegistry) {
             `[CompetitionController] User ${userId} requesting competition details`,
           );
         } else {
-          throw new ApiError(401, "Authentication required");
+          console.log(
+            `[CompetitionController] Unauthenticated request for competition details (public access)`,
+          );
         }
 
         // Get competition ID from path parameter
@@ -586,7 +590,9 @@ export function makeCompetitionController(services: ServiceRegistry) {
             `[CompetitionController] User ${userId} requesting competition agents`,
           );
         } else {
-          throw new ApiError(401, "Authentication required");
+          console.log(
+            `[CompetitionController] Unauthenticated request for competition agents (public access)`,
+          );
         }
 
         // Get competition ID from path parameter

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -84,7 +84,7 @@ app.use(express.urlencoded({ extended: true }));
 // Define different types of protected routes with their authentication needs
 const agentApiKeyRoutes = ["/api/agent", "/api/trade", "/api/price"];
 
-const userSessionRoutes = ["/api/user", "/api/competitions"];
+const userSessionRoutes = ["/api/user"];
 
 // Apply agent API key authentication to agent routes
 app.use(
@@ -129,7 +129,16 @@ const leaderboardController = makeLeaderboardController(services);
 const adminRoutes = configureAdminRoutes(adminController, adminMiddleware);
 const adminSetupRoutes = configureAdminSetupRoutes(adminController);
 const authRoutes = configureAuthRoutes(authController, siweSessionMiddleware);
-const competitionsRoutes = configureCompetitionsRoutes(competitionController);
+const competitionsRoutes = configureCompetitionsRoutes(
+  competitionController,
+  siweSessionMiddleware,
+  authMiddleware(
+    services.agentManager,
+    services.userManager,
+    services.adminManager,
+    services.competitionManager,
+  ),
+);
 const docsRoutes = configureDocsRoutes(docsController);
 const healthRoutes = configureHealthRoutes(healthController);
 const priceRoutes = configurePriceRoutes(priceController);

--- a/apps/api/src/routes/competitions.routes.ts
+++ b/apps/api/src/routes/competitions.routes.ts
@@ -4,13 +4,9 @@ import { CompetitionController } from "@/controllers/competition.controller.js";
 
 export function configureCompetitionsRoutes(
   controller: CompetitionController,
-  ...middlewares: RequestHandler[]
+  ...authMiddlewares: RequestHandler[]
 ) {
   const router = Router();
-
-  if (middlewares.length) {
-    router.use(...middlewares);
-  }
 
   /**
    * @openapi
@@ -262,7 +258,7 @@ export function configureCompetitionsRoutes(
    *       500:
    *         description: Server error
    */
-  router.get("/leaderboard", controller.getLeaderboard);
+  router.get("/leaderboard", ...authMiddlewares, controller.getLeaderboard);
 
   /**
    * @openapi
@@ -352,7 +348,7 @@ export function configureCompetitionsRoutes(
    *       500:
    *         description: Server error
    */
-  router.get("/status", controller.getStatus);
+  router.get("/status", ...authMiddlewares, controller.getStatus);
 
   /**
    * @openapi
@@ -417,7 +413,7 @@ export function configureCompetitionsRoutes(
    *       500:
    *         description: Server error
    */
-  router.get("/rules", controller.getRules);
+  router.get("/rules", ...authMiddlewares, controller.getRules);
 
   /**
    * @openapi
@@ -488,7 +484,11 @@ export function configureCompetitionsRoutes(
    *       500:
    *         description: Server error
    */
-  router.get("/upcoming", controller.getUpcomingCompetitions);
+  router.get(
+    "/upcoming",
+    ...authMiddlewares,
+    controller.getUpcomingCompetitions,
+  );
 
   /**
    * @openapi
@@ -787,7 +787,11 @@ export function configureCompetitionsRoutes(
    *       500:
    *         description: Server error
    */
-  router.post("/:competitionId/agents/:agentId", controller.joinCompetition);
+  router.post(
+    "/:competitionId/agents/:agentId",
+    ...authMiddlewares,
+    controller.joinCompetition,
+  );
 
   /**
    * @openapi
@@ -843,7 +847,11 @@ export function configureCompetitionsRoutes(
    *       500:
    *         description: Server error
    */
-  router.delete("/:competitionId/agents/:agentId", controller.leaveCompetition);
+  router.delete(
+    "/:competitionId/agents/:agentId",
+    ...authMiddlewares,
+    controller.leaveCompetition,
+  );
 
   return router;
 }


### PR DESCRIPTION
# Summary

- Allows unauthenticated users to view basic competition information by making 3 specific endpoints public while keeping all other competition routes protected.

## Changes

- Modified apps/api/src/routes/competitions.routes.ts:
- Removed global auth middleware application from competitions router
- Applied auth middleware selectively only to protected routes

## Made public (no auth required):

- GET /api/competitions - List competitions
- GET /api/competitions/{competitionId} - Competition details
- GET /api/competitions/{competitionId}/agents - Competition participants

## Kept protected (auth required):

- /leaderboard, /status, /rules, /upcoming
- All POST/DELETE operations

## Impact
- Users can now browse competition information before signing up, while sensitive operations remain protected. Zero breaking changes to existing authenticated functionality.

Resolves: #504