### PR TITLE
feat(comps): leaderboard & minor fixups

### DIFF
--- a/apps/comps/app/competitions/page.tsx
+++ b/apps/comps/app/competitions/page.tsx
@@ -30,7 +30,7 @@ export default function CompetitionsPage() {
 
   const endedCompetitions =
     competitionsData?.competitions?.filter(
-      (comp) => comp.status === CompetitionStatus.Completed,
+      (comp) => comp.status === CompetitionStatus.Ended,
     ) || [];
 
   // Fetch spotlight agents using the API hook

--- a/apps/comps/app/create-agent/page.tsx
+++ b/apps/comps/app/create-agent/page.tsx
@@ -6,7 +6,7 @@ import { AgentCreated } from "@/components/agent-created";
 import { AuthGuard } from "@/components/auth-guard";
 import { BreadcrumbNav } from "@/components/breadcrumb-nav";
 import { CreateAgent, FormData } from "@/components/create-agent";
-import { useAgent } from "@/hooks/useAgent";
+import { useUserAgent } from "@/hooks/useAgent";
 import { useCreateAgent } from "@/hooks/useCreateAgent";
 
 export default function CreateAgentPage() {
@@ -18,7 +18,7 @@ export default function CreateAgentPage() {
     data: agent,
     isLoading: isAgentLoading,
     isError: isAgentError,
-  } = useAgent(createdAgentId || undefined);
+  } = useUserAgent(createdAgentId || undefined);
 
   const handleSubmit = async (data: FormData) => {
     try {

--- a/apps/comps/app/layout.tsx
+++ b/apps/comps/app/layout.tsx
@@ -21,7 +21,9 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" suppressHydrationWarning className="overflow-x-hidden">
-      <body className={`${fontSans.variable} ${fontMono.variable} antialiased`}>
+      <body
+        className={`${fontSans.variable} ${fontMono.variable} bg-black antialiased`}
+      >
         <Analytics />
         <Providers>
           <Navbar>

--- a/apps/comps/components/agent-profile/index.tsx
+++ b/apps/comps/components/agent-profile/index.tsx
@@ -191,10 +191,10 @@ export default function AgentProfile({ id }: { id: string }) {
               Upcoming
             </TabsTrigger>
             <TabsTrigger
-              value="complete"
+              value="ended"
               className={cn(
                 "rounded border border-gray-500 p-2 text-black",
-                selected === "complete"
+                selected === "ended"
                   ? "bg-gray-500 text-white"
                   : "text-gray-500",
               )}
@@ -224,7 +224,7 @@ export default function AgentProfile({ id }: { id: string }) {
           <TabsContent value="complete">
             <CompetitionTable
               competitions={agentCompetitionsData?.competitions.filter(
-                (c) => c.status === CompetitionStatus.Completed,
+                (c) => c.status === CompetitionStatus.Ended,
               )}
             />
           </TabsContent>

--- a/apps/comps/components/bignumber/index.tsx
+++ b/apps/comps/components/bignumber/index.tsx
@@ -14,32 +14,69 @@ export const BigNumberDisplay: React.FC<BigNumberDisplayProps> = ({
   compact = true,
 }) => {
   try {
-    const bigIntValue = typeof value === "bigint" ? value : BigInt(value);
-    const scale = 10n ** BigInt(decimals);
-    const integerPart = bigIntValue / scale;
-    const remainder = bigIntValue % scale;
+    let numberToFormat: number;
 
-    // Create a decimal by manually building it
-    const remainderStr = remainder
-      .toString()
-      .padStart(decimals, "0")
-      .slice(0, displayDecimals);
-    const floatStr = `${integerPart.toString()}.${remainderStr}`;
-    const numberValue = parseFloat(floatStr);
+    if (typeof value === "string" && value.includes(".")) {
+      // Case 1: Value is a string already representing a decimal number (e.g., "4321.1234")
+      // 'value' is assumed to be in base units.
+      // 'displayDecimals' will control the output format.
+      numberToFormat = parseFloat(value);
+      if (isNaN(numberToFormat)) {
+        console.error("Error parsing decimal string input:", value);
+        return <span>Error</span>;
+      }
+    } else {
+      // Case 2: Value is a bigint or a string representing a whole integer (smallest units)
+      let tempBigIntValue: bigint;
+      if (typeof value === "bigint") {
+        tempBigIntValue = value;
+      } else {
+        // value is a string
+        // Ensure the string is a valid integer representation before BigInt conversion
+        if (!/^-?\d+$/.test(value)) {
+          // Allows negative integers
+          console.error("Invalid integer string for BigInt conversion:", value);
+          return <span>Error</span>;
+        }
+        tempBigIntValue = BigInt(value);
+      }
+
+      const scale = 10n ** BigInt(decimals);
+      const integerPart = tempBigIntValue / scale;
+      const remainder = tempBigIntValue % scale;
+
+      let numStr = integerPart.toString();
+      if (displayDecimals > 0) {
+        const positiveRemainder = remainder < 0n ? -remainder : remainder;
+        const currentMaxLength = Number(decimals); // Explicitly define maxLength
+        const currentFillString = "0"; // Explicitly define fillString
+        const remainderStr = positiveRemainder
+          .toString()
+          .padStart(currentMaxLength, currentFillString)
+          .slice(0, displayDecimals);
+        numStr += `.${remainderStr}`;
+      }
+
+      numberToFormat = parseFloat(numStr);
+      if (isNaN(numberToFormat)) {
+        console.error("Error constructing number from BigInt parts:", numStr);
+        return <span>Error</span>;
+      }
+    }
 
     const formatterOptions: Intl.NumberFormatOptions = {};
-
     if (compact) {
       formatterOptions.notation = "compact";
       formatterOptions.compactDisplay = "short";
     }
 
-    if (displayDecimals !== undefined) {
+    if (displayDecimals >= 0) {
+      // Allow displayDecimals = 0 for no fractional part
       formatterOptions.maximumFractionDigits = displayDecimals;
     }
 
     const formatter = new Intl.NumberFormat("en", formatterOptions);
-    const formattedValue = formatter.format(numberValue);
+    const formattedValue = formatter.format(numberToFormat);
 
     return <span>{formattedValue}</span>;
   } catch (error) {

--- a/apps/comps/components/leaderboard-table.tsx
+++ b/apps/comps/components/leaderboard-table.tsx
@@ -29,7 +29,7 @@ const emptyAgent: (i: number) => LeaderboardAgent = (i: number) => ({
   status: "",
   rank: i,
   score: 0,
-  totalVotes: 0,
+  voteCount: 0,
   numCompetitions: 0,
 });
 
@@ -175,7 +175,7 @@ export function LeaderboardTable({
               <TableCell className="flex items-center justify-end pr-10 text-gray-500 sm:pr-0">
                 {loaded ? (
                   // TODO: this is not part of the API response, yet, but it will be guaranteed to be present via the `useLeaderboards` hook
-                  <>{agent.totalVotes || 0}</>
+                  <>{agent.voteCount || 0}</>
                 ) : (
                   <Skeleton className="h-2 w-10 rounded-full" />
                 )}

--- a/apps/comps/components/leaderboard-table.tsx
+++ b/apps/comps/components/leaderboard-table.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ArrowUp, AwardIcon, ExternalLink, Trophy } from "lucide-react";
+import { AwardIcon, ExternalLink, Trophy } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
 

--- a/apps/comps/components/leaderboard-table.tsx
+++ b/apps/comps/components/leaderboard-table.tsx
@@ -2,6 +2,7 @@
 
 import { ArrowUp, AwardIcon, ExternalLink, Trophy } from "lucide-react";
 import Image from "next/image";
+import Link from "next/link";
 
 import { Button } from "@recallnet/ui2/components/button";
 import { Skeleton } from "@recallnet/ui2/components/skeleton";
@@ -16,9 +17,9 @@ import {
 } from "@recallnet/ui2/components/table";
 import { cn } from "@recallnet/ui2/lib/utils";
 
-import { Agent } from "@/types/agent";
+import { LeaderboardAgent } from "@/types/agent";
 
-const emptyAgent: (i: number) => Agent = (i: number) => ({
+const emptyAgent: (i: number) => LeaderboardAgent = (i: number) => ({
   id: i.toString(),
   name: `some-name-${i}`,
   walletAddress: "",
@@ -26,6 +27,10 @@ const emptyAgent: (i: number) => Agent = (i: number) => ({
   imageUrl: "",
   description: "some long agent description",
   status: "",
+  rank: i,
+  score: 0,
+  totalVotes: 0,
+  numCompetitions: 0,
 });
 
 export function LeaderboardTable({
@@ -33,7 +38,7 @@ export function LeaderboardTable({
   onExtend,
   loaded,
 }: {
-  agents: Agent[];
+  agents: LeaderboardAgent[];
   onExtend: () => void;
   loaded?: boolean;
 }) {
@@ -74,10 +79,11 @@ export function LeaderboardTable({
             >
               <TableCell className="xs:flex-row flex flex-col items-center gap-2 py-6">
                 <div className="flex gap-2">
-                  <ArrowUp size={20} className="text-green-500" />
-                  <span>3</span>
+                  {/* TODO: enable once we have official rankings & net change in rank */}
+                  {/* <ArrowUp size={20} className="text-green-500" />
+                  <span>3</span> */}
                 </div>
-                {i == 0 ? (
+                {i === 0 ? (
                   <div
                     className={cn(
                       "flex w-20 items-center justify-center gap-1 rounded p-2",
@@ -88,23 +94,35 @@ export function LeaderboardTable({
                     <Trophy size={17} />
                     <span>1st</span>
                   </div>
-                ) : i < 3 ? (
+                ) : i === 1 ? (
                   <div
                     className={cn(
                       "flex w-20 items-center justify-center gap-1 rounded p-2",
-                      ["bg-gray-700", "bg-[#1A0E05]"][i - 1],
-                      i == 1 ? "text-gray-300" : "text-[#C76E29]",
+                      "bg-gray-700",
+                      "text-gray-300",
                     )}
                   >
                     <AwardIcon size={17} />
-                    <span>{i == 1 ? "2nd" : "3rd"}</span>
+                    <span>2nd</span>
+                  </div>
+                ) : i === 2 ? (
+                  <div
+                    className={cn(
+                      "flex w-20 items-center justify-center gap-1 rounded p-2",
+                      "bg-[#1A0E05]",
+                      "text-[#C76E29]",
+                    )}
+                  >
+                    <AwardIcon size={17} />
+                    <span>3rd</span>
                   </div>
                 ) : (
                   <div className="mx-6 flex items-center justify-center rounded bg-gray-800 px-2 py-3">
-                    {i}
+                    {i + 1}
                   </div>
                 )}
-                <span className="text-gray-500">{"23,533"}</span>
+                {/* TODO: hide this until official "scores" are implemented; the API does return the data, but it's not elo-based */}
+                {/* <span className="text-gray-500">{agent.score}</span> */}
               </TableCell>
 
               <TableCell className="flex items-center justify-center">
@@ -130,9 +148,11 @@ export function LeaderboardTable({
                         <div className="font-medium leading-none text-white">
                           {agent.name}
                         </div>
-                        <p className="truncate whitespace-nowrap text-xs text-gray-400">
-                          {agent.description}
-                        </p>
+                        {agent.description && (
+                          <p className="truncate whitespace-nowrap text-xs text-gray-400">
+                            {agent.description}
+                          </p>
+                        )}
                       </>
                     ) : (
                       <>
@@ -146,7 +166,7 @@ export function LeaderboardTable({
 
               <TableCell className="flex items-center justify-end pr-10 text-gray-500">
                 {loaded ? (
-                  <>{0}</>
+                  <>{agent.numCompetitions}</>
                 ) : (
                   <Skeleton className="h-2 w-10 rounded-full" />
                 )}
@@ -154,14 +174,17 @@ export function LeaderboardTable({
 
               <TableCell className="flex items-center justify-end pr-10 text-gray-500 sm:pr-0">
                 {loaded ? (
-                  "22,550"
+                  // TODO: this is not part of the API response, yet, but it will be guaranteed to be present via the `useLeaderboards` hook
+                  <>{agent.totalVotes || 0}</>
                 ) : (
                   <Skeleton className="h-2 w-10 rounded-full" />
                 )}
               </TableCell>
 
               <TableCell className="pr-15 flex items-center justify-end text-gray-500">
-                <ExternalLink />
+                <Link href={`/agents/${agent.id}`}>
+                  <ExternalLink />
+                </Link>
               </TableCell>
             </TableRow>
           ))}

--- a/apps/comps/components/ongoing-competition.tsx
+++ b/apps/comps/components/ongoing-competition.tsx
@@ -33,7 +33,7 @@ export const OngoingCompetition: React.FC<OngoingCompetitionProps> = ({
   return (
     <div className="bg-card p-8">
       <div className="mb-30 flex items-start justify-between">
-        <StringList strings={["ONGOING", ...competition.type]} />
+        <StringList strings={["ONGOING", competition.type]} />
         <IconButton
           Icon={Share1Icon}
           aria-label="Share"

--- a/apps/comps/components/upcoming-competition.tsx
+++ b/apps/comps/components/upcoming-competition.tsx
@@ -21,7 +21,7 @@ export const UpComingCompetition: React.FC<UpComingCompetitionProps> = ({
   return (
     <div className="bg-card p-8">
       <div className="mb-30 flex items-start justify-between">
-        <StringList strings={["UPCOMING", ...competition.type]} />
+        <StringList strings={["UPCOMING", competition.type]} />
         <IconButton
           Icon={Share1Icon}
           aria-label="Share"

--- a/apps/comps/hooks/useAgent.ts
+++ b/apps/comps/hooks/useAgent.ts
@@ -6,7 +6,26 @@ import { Agent } from "@/types";
 const apiClient = new ApiClient();
 
 /**
- * Hook to fetch a single agent by ID
+ * Hook to fetch a single agent by ID owned by the authenticated user
+ * @param id Agent ID
+ * @returns Query result with agent data
+ */
+export const useUserAgent = (id?: string) =>
+  useQuery({
+    queryKey: ["agent", id],
+    queryFn: async (): Promise<Agent> => {
+      if (!id) throw new Error("Agent ID is required");
+      const response = await apiClient.getUserAgent(id);
+
+      if (!response.success) throw new Error("Error when querying agent");
+
+      return response.agent;
+    },
+    enabled: !!id,
+  });
+
+/**
+ * Hook to fetch a single agent by ID (unauthenticated)
  * @param id Agent ID
  * @returns Query result with agent data
  */

--- a/apps/comps/hooks/useLeaderboards.ts
+++ b/apps/comps/hooks/useLeaderboards.ts
@@ -14,7 +14,7 @@ export const useLeaderboards = (params: GetLeaderboardParams = {}) =>
   useQuery({
     queryKey: ["leaderboards", params],
     queryFn: async (): Promise<LeaderboardResponse> => {
-      return apiClient.getLeaderboards(params);
+      return apiClient.getGlobalLeaderboard(params);
     },
     placeholderData: (prev) => prev,
   });

--- a/apps/comps/lib/api-client.ts
+++ b/apps/comps/lib/api-client.ts
@@ -190,6 +190,17 @@ export class ApiClient {
   }
 
   /**
+   * Get agent by ID owned by the authenticated user
+   * @param id - Agent ID
+   * @returns Agent details
+   */
+  async getUserAgent(id: string): Promise<{ success: boolean; agent: Agent }> {
+    return this.request<{ success: boolean; agent: Agent }>(
+      `/user/agents/${id}`,
+    );
+  }
+
+  /**
    * Get list of agents
    * @param params - Query parameters
    * @returns Agents response
@@ -200,14 +211,12 @@ export class ApiClient {
   }
 
   /**
-   * Get agent by ID
+   * Get agent by ID (unauthenticated)
    * @param id - Agent ID
    * @returns Agent details
    */
   async getAgent(id: string): Promise<{ success: boolean; agent: Agent }> {
-    return this.request<{ success: boolean; agent: Agent }>(
-      `/user/agents/${id}`,
-    );
+    return this.request<{ success: boolean; agent: Agent }>(`/agents/${id}`);
   }
 
   /**

--- a/apps/comps/lib/api-client.ts
+++ b/apps/comps/lib/api-client.ts
@@ -241,15 +241,15 @@ export class ApiClient {
   // Leaderboards endpoints
 
   /**
-   * Get leaderboards
+   * Get global leaderboard
    * @param params - Query parameters
    * @returns Leaderboards response
    */
-  async getLeaderboards(
+  async getGlobalLeaderboard(
     params: GetLeaderboardParams = {},
   ): Promise<LeaderboardResponse> {
     const queryParams = this.formatQueryParams(params);
-    return this.request<LeaderboardResponse>(`/leaderboards${queryParams}`);
+    return this.request<LeaderboardResponse>(`/leaderboard${queryParams}`);
   }
 
   // Profile endpoints

--- a/apps/comps/types/agent.ts
+++ b/apps/comps/types/agent.ts
@@ -34,7 +34,7 @@ export interface LeaderboardAgent extends Agent {
   // metadata: AgentCompetitionMetadata;
   rank: number;
   score: number;
-  totalVotes: number;
+  voteCount: number;
   numCompetitions: number;
 }
 
@@ -94,6 +94,7 @@ export interface AgentCompetition {
   pnlPercent: number;
   change24h: number;
   change24hPercent: number;
+  voteCount: number;
 }
 
 export interface CreateAgentRequest {

--- a/apps/comps/types/agent.ts
+++ b/apps/comps/types/agent.ts
@@ -17,14 +17,25 @@ export interface Trophy {
 export interface Agent {
   id: string;
   name: string;
-  walletAddress: string;
+  walletAddress?: string;
   ownerId?: string;
   imageUrl: string;
-  description: string;
+  description?: string;
   status: string;
   metadata?: AgentCompetitionMetadata;
   deactivationReason?: string;
   deactivationDate?: string;
+}
+
+export interface LeaderboardAgent extends Agent {
+  // TODO: the actual response is a subset of the `Agent` type
+  // id: string;
+  // name: string;
+  // metadata: AgentCompetitionMetadata;
+  rank: number;
+  score: number;
+  totalVotes: number;
+  numCompetitions: number;
 }
 
 export interface AgentsMetadata {
@@ -53,12 +64,13 @@ export interface LeaderboardStats {
   activeAgents: number;
   totalTrades: number;
   totalVolume: number;
+  totalCompetitions: number;
 }
 
 export interface LeaderboardResponse {
-  metadata: AgentsMetadata;
   stats: LeaderboardStats;
-  agents: Agent[];
+  agents: LeaderboardAgent[];
+  pagination: PaginationResponse;
 }
 
 export interface AgentCompetitionResponse {

--- a/apps/comps/types/enums.ts
+++ b/apps/comps/types/enums.ts
@@ -1,7 +1,7 @@
 export enum CompetitionStatus {
   Pending = "pending",
   Active = "active",
-  Completed = "completed",
+  Ended = "ended",
 }
 
 export enum CrossChainTradingType {


### PR DESCRIPTION
- the default bg color was different than `bg-black`, so you could see a slight border-like rendering on pages. e.g., the area surrounding the landing page's video.
- the `/leaderboard` API was changed to singular, and now that it's live, the leaderboards component can properly use the data. 
   - the top positions (1st, 2nd, 3rd) were displayed correctly, but numbers thereafter started at "3"...this has been fixed to properly increment values.
   - some of the datapoints are also hidden, including the "change in rank" arrow and the "score". 
   - note: the score exists in the API response, but we should ignore it for now since it's a somewhat arbitrary things until real ranks arrive.
- fixed the BigNumber component. it was causing issues for the leaderboard's `totalVolume` field when decimals were present
- updated some API client types and methods:
   - `CompetitionStatus.Ended` has replaced `...Completed`
   - the routes for getting an agent's profile used the user-scoped `/user/agents/:id` endpoint, so this has been replaced with the generic `/agents/:id` endpoint to prevent auth issues where necessary.