### PR TITLE
feat: api prefix routing

### DIFF
--- a/.github/workflows/api-ci.yml
+++ b/.github/workflows/api-ci.yml
@@ -257,6 +257,9 @@ jobs:
           DISABLE_PARTICIPANT_LEADERBOARD_ACCESS=false
           EOF
 
+          # Optional: API prefix
+          API_PREFIX=testing
+
       - name: Run E2E tests
         working-directory: apps/api
         run: |

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -73,3 +73,6 @@ NOVES_API_KEY=your_noves_api_key_here
 
 # Optional: Disable ability for participants to view leaderboard activity (set true to activate)
 DISABLE_PARTICIPANT_LEADERBOARD_ACCESS=false
+
+# Optional: API prefix
+API_PREFIX=development

--- a/apps/api/.env.test
+++ b/apps/api/.env.test
@@ -61,3 +61,6 @@ PORTFOLIO_PRICE_FRESHNESS_MS=10000
 # Optional: Disable ability for participants to view leaderboard activity
 DISABLE_PARTICIPANT_LEADERBOARD_ACCESS=false
 
+# Optional: API prefix
+API_PREFIX=testing
+

--- a/apps/api/e2e/utils/server.ts
+++ b/apps/api/e2e/utils/server.ts
@@ -9,7 +9,9 @@ let serverProcess: ChildProcess | null = null;
 const PORT = process.env.TEST_PORT || "3001";
 // Allow configuring the host from environment (0.0.0.0 for Docker)
 const HOST = process.env.TEST_HOST || "localhost";
-const BASE_URL = `http://${HOST}:${PORT}`;
+// Include API prefix in base URL if set
+const API_PREFIX = process.env.API_PREFIX;
+const BASE_URL = `http://${HOST}:${PORT}${API_PREFIX ? `/${API_PREFIX}` : ""}`;
 
 /**
  * Start the server for testing

--- a/apps/api/e2e/utils/test-helpers.ts
+++ b/apps/api/e2e/utils/test-helpers.ts
@@ -279,7 +279,7 @@ export function generateRandomEthAddress(): string {
 export function getApiSdk(apiKey: string): InstanceType<typeof ApiSDK> {
   return new ApiSDK({
     bearerAuth: apiKey,
-    serverIdx: 2,
+    serverURL: getBaseUrl(),
   });
 }
 

--- a/apps/api/src/config/index.ts
+++ b/apps/api/src/config/index.ts
@@ -146,6 +146,7 @@ export const config = {
     // TODO: these ports are going to be put into the openapi json spec, so they can't really be set at runtime, wtd?
     testPort: 3001,
     nodeEnv: process.env.NODE_ENV || "development",
+    apiPrefix: process.env.API_PREFIX || "",
   },
   // Frontend app configuration for interfacing with the server
   app: {

--- a/apps/api/src/config/swagger.ts
+++ b/apps/api/src/config/swagger.ts
@@ -24,7 +24,7 @@ Where "your-api-key" is the API key provided during user and agent registration.
 **cURL Example:**
 
 \`\`\`bash
-curl -X GET "https://api.example.com/api/account/balances" \\
+curl -X GET "https://api.example.com${config.server.apiPrefix ? `/${config.server.apiPrefix}` : ""}/api/account/balances" \\
   -H "Authorization: Bearer abc123def456_ghi789jkl012" \\
   -H "Content-Type: application/json"
 \`\`\`
@@ -34,7 +34,7 @@ curl -X GET "https://api.example.com/api/account/balances" \\
 \`\`\`javascript
 const fetchData = async () => {
   const apiKey = 'abc123def456_ghi789jkl012';
-  const response = await fetch('https://api.example.com/api/account/balances', {
+  const response = await fetch('https://api.example.com${config.server.apiPrefix ? `/${config.server.apiPrefix}` : ""}/api/account/balances', {
     headers: {
       'Authorization': \`Bearer \${apiKey}\`,
       'Content-Type': 'application/json'
@@ -58,15 +58,15 @@ For convenience, we provide an API client that handles authentication automatica
     },
     servers: [
       {
-        url: "https://api.competitions.recall.network",
+        url: `https://api.competitions.recall.network${config.server.apiPrefix ? `/${config.server.apiPrefix}` : ""}`,
         description: "Production server",
       },
       {
-        url: `http://localhost:${config.server.port}`,
+        url: `http://localhost:${config.server.port}${config.server.apiPrefix ? `/${config.server.apiPrefix}` : ""}`,
         description: "Local development server",
       },
       {
-        url: `http://localhost:${config.server.testPort}`,
+        url: `http://localhost:${config.server.testPort}${config.server.apiPrefix ? `/${config.server.apiPrefix}` : ""}`,
         description: "End to end testing server",
       },
     ],

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -202,7 +202,7 @@ app.get(`${apiBasePath}/api/health`, (_req, res) => {
 });
 
 // Root endpoint redirects to API documentation
-app.get("/", (_req, res) => {
+app.get(`${apiBasePath}`, (_req, res) => {
   res.redirect(`${apiBasePath}/api/docs`);
 });
 

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -183,8 +183,17 @@ apiRouter.use("/leaderboard", leaderboardRoutes);
 // Mount the API router with the prefix + /api path
 app.use(`${apiBasePath}/api`, apiRouter);
 
-// Legacy health check endpoint for backward compatibility
+// Health check endpoint
 app.get(`${apiBasePath}/health`, (_req, res) => {
+  res.status(200).json({
+    status: "ok",
+    timestamp: new Date().toISOString(),
+    version: "1.0.0",
+  });
+});
+
+// Legacy
+app.get(`${apiBasePath}/api/health`, (_req, res) => {
   res.status(200).json({
     status: "ok",
     timestamp: new Date().toISOString(),

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -45,7 +45,9 @@ const PORT = config.server.port;
 let databaseInitialized = false;
 
 // Set up API prefix configuration
-const apiBasePath = `/${config.server.apiPrefix}`;
+const apiBasePath = config.server.apiPrefix
+  ? `/${config.server.apiPrefix}`
+  : "";
 
 // Only run migrations in development, not production
 if (process.env.NODE_ENV !== "production") {

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -38,8 +38,14 @@ import { configureLeaderboardRoutes } from "./routes/leaderboard.routes.js";
 // Create Express app
 const app = express();
 
+// Create the API router
+const apiRouter = express.Router();
+
 const PORT = config.server.port;
 let databaseInitialized = false;
+
+// Set up API prefix configuration
+const apiBasePath = `/${config.server.apiPrefix}`;
 
 // Only run migrations in development, not production
 if (process.env.NODE_ENV !== "production") {
@@ -84,9 +90,13 @@ app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 
 // Define different types of protected routes with their authentication needs
-const agentApiKeyRoutes = ["/api/agent", "/api/trade", "/api/price"];
+const agentApiKeyRoutes = [
+  `${apiBasePath}/api/agent`,
+  `${apiBasePath}/api/trade`,
+  `${apiBasePath}/api/price`,
+];
 
-const userSessionRoutes = ["/api/user"];
+const userSessionRoutes = [`${apiBasePath}/api/user`];
 
 // Apply agent API key authentication to agent routes
 app.use(
@@ -156,22 +166,25 @@ const agentRoutes = configureAgentRoutes(agentController);
 const agentsRoutes = configureAgentsRoutes(agentController);
 const leaderboardRoutes = configureLeaderboardRoutes(leaderboardController);
 
-// Apply routes
-app.use("/api/auth", authRoutes);
-app.use("/api/trade", tradeRoutes);
-app.use("/api/price", priceRoutes);
-app.use("/api/competitions", competitionsRoutes);
-app.use("/api/admin/setup", adminSetupRoutes);
-app.use("/api/admin", adminRoutes);
-app.use("/api/health", healthRoutes);
-app.use("/api/docs", docsRoutes);
-app.use("/api/user", userRoutes);
-app.use("/api/agent", agentRoutes);
-app.use("/api/agents", agentsRoutes);
-app.use("/api/leaderboard", leaderboardRoutes);
+// Apply routes to the API router
+apiRouter.use("/auth", authRoutes);
+apiRouter.use("/trade", tradeRoutes);
+apiRouter.use("/price", priceRoutes);
+apiRouter.use("/competitions", competitionsRoutes);
+apiRouter.use("/admin/setup", adminSetupRoutes);
+apiRouter.use("/admin", adminRoutes);
+apiRouter.use("/health", healthRoutes);
+apiRouter.use("/docs", docsRoutes);
+apiRouter.use("/user", userRoutes);
+apiRouter.use("/agent", agentRoutes);
+apiRouter.use("/agents", agentsRoutes);
+apiRouter.use("/leaderboard", leaderboardRoutes);
+
+// Mount the API router with the prefix + /api path
+app.use(`${apiBasePath}/api`, apiRouter);
 
 // Legacy health check endpoint for backward compatibility
-app.get("/health", (_req, res) => {
+app.get(`${apiBasePath}/health`, (_req, res) => {
   res.status(200).json({
     status: "ok",
     timestamp: new Date().toISOString(),
@@ -181,7 +194,7 @@ app.get("/health", (_req, res) => {
 
 // Root endpoint redirects to API documentation
 app.get("/", (_req, res) => {
-  res.redirect("/api/docs");
+  res.redirect(`${apiBasePath}/api/docs`);
 });
 
 // Apply error handler
@@ -195,6 +208,8 @@ app.listen(PORT, "0.0.0.0", () => {
   console.log(
     `Database: ${databaseInitialized ? "Connected" : "Error - Limited functionality"}`,
   );
-  console.log(`API documentation: http://localhost:${PORT}/api/docs`);
+  console.log(
+    `API documentation: http://localhost:${PORT}${apiBasePath}/api/docs`,
+  );
   console.log(`========================================\n`);
 });

--- a/apps/api/trade-simulator-docker/docker-compose.yml
+++ b/apps/api/trade-simulator-docker/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       test:
         [
           "CMD-SHELL",
-          "wget --no-verbose --tries=1 --spider http://127.0.0.1:${PORT:-3000}/api/health || exit 1",
+          "wget --no-verbose --tries=1 --spider http://127.0.0.1:${PORT:-3000}${API_PREFIX:+/${API_PREFIX}}/api/health || exit 1",
         ]
       interval: 10s
       timeout: 5s

--- a/apps/api/trade-simulator-docker/instructions.md
+++ b/apps/api/trade-simulator-docker/instructions.md
@@ -44,8 +44,18 @@ Then run the container:
 docker run -p 3000:3000 --env-file apps/api/trade-simulator-docker/.env my-api-tag:latest
 ```
 
+## Health Checks
+
+The application provides health check endpoints that respect the `API_PREFIX` environment variable:
+
+- **No API_PREFIX**: Health checks available at `/health` and `/api/health`
+- **With API_PREFIX** (e.g., `API_PREFIX=testing-grounds`): Health checks at `/testing-grounds/health` and `/testing-grounds/api/health`
+
+The Docker Compose health check automatically adjusts to use the correct endpoint based on your `API_PREFIX` setting.
+
 ## Notes
 
 - This setup assumes PostgreSQL is running separately (not in Docker)
 - Make sure your `DATABASE_URL` points to your external PostgreSQL instance
 - The application will automatically handle database migrations on startup
+- Set `API_PREFIX` in your `.env` file if you need custom API routing (e.g., `API_PREFIX=testing-grounds`)

--- a/apps/api/turbo.json
+++ b/apps/api/turbo.json
@@ -1,6 +1,8 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "extends": ["//"],
+  "extends": [
+    "//"
+  ],
   "tasks": {
     "build": {
       "env": [
@@ -36,6 +38,7 @@
         "MAX_TRADE_PERCENTAGE",
         "NODE_ENV",
         "NOVES_API_KEY",
+        "API_PREFIX",
         "PORTFOLIO_PRICE_FRESHNESS_MS",
         "PORTFOLIO_SNAPSHOT_INTERVAL_MS",
         "PORT",


### PR DESCRIPTION
# Summary

- Assuming we are going to continue using prefixed routing in the load balancer off of `https://api.competitions.recall.network/` (such as `sandbox`), we should standardize our approach that works both when running the server outside and inside containerization
- These changes primarily edit the main server file to absorb the routing, and uses the dependency injection `config` object, but also impacts the health check endpoint within the docker configuration, as well as ensuring our client is properly constructed in `apps/api/e2e`