### PR TITLE
feat(api): add endpoint to get user's comps

### DIFF
--- a/apps/api/e2e/utils/api-client.ts
+++ b/apps/api/e2e/utils/api-client.ts
@@ -48,6 +48,7 @@ import {
   TradeResponse,
   UpcomingCompetitionsResponse,
   UserAgentApiKeyResponse,
+  UserCompetitionsResponse,
   UserProfileResponse,
   UserRegistrationResponse,
   UserVotesResponse,
@@ -1403,6 +1404,36 @@ export class ApiClient {
       return response.data;
     } catch (error) {
       return this.handleApiError(error, "get voting state");
+    }
+  }
+
+  /**
+   * Get competitions for user's agents
+   * Requires SIWE session authentication
+   */
+  async getUserCompetitions(params?: {
+    status?: string;
+    claimed?: boolean;
+    limit?: number;
+    offset?: number;
+    sort?: string;
+  }): Promise<UserCompetitionsResponse | ErrorResponse> {
+    try {
+      const queryParams = new URLSearchParams();
+      if (params?.status) queryParams.append("status", params.status);
+      if (params?.claimed !== undefined)
+        queryParams.append("claimed", String(params.claimed));
+      if (params?.limit) queryParams.append("limit", String(params.limit));
+      if (params?.offset) queryParams.append("offset", String(params.offset));
+      if (params?.sort) queryParams.append("sort", params.sort);
+
+      const queryString = queryParams.toString();
+      const url = `/api/user/competitions${queryString ? `?${queryString}` : ""}`;
+
+      const response = await this.axiosInstance.get(url);
+      return response.data;
+    } catch (error) {
+      return this.handleApiError(error, "get user competitions");
     }
   }
 }

--- a/apps/api/e2e/utils/api-types.ts
+++ b/apps/api/e2e/utils/api-types.ts
@@ -400,6 +400,22 @@ export interface UpcomingCompetitionsResponse extends ApiResponse {
   };
 }
 
+// User competitions response
+export interface UserCompetitionsResponse extends ApiResponse {
+  success: true;
+  competitions: CompetitionWithAgents[];
+  pagination: {
+    total: number;
+    limit: number;
+    offset: number;
+    hasMore: boolean;
+  };
+}
+
+export interface CompetitionWithAgents extends Competition {
+  agents: (Agent & { rank: number })[];
+}
+
 // Competition rules response
 export interface CompetitionRulesResponse extends ApiResponse {
   competition: Competition;

--- a/apps/api/openapi/openapi.json
+++ b/apps/api/openapi/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Trading Simulator API",
     "version": "1.0.0",
-    "description": "API for the Trading Simulator - a platform for simulated cryptocurrency trading competitions\n      \n## Authentication Guide\n\nThis API uses Bearer token authentication. All protected endpoints require the following header:\n\n- **Authorization**: Bearer your-api-key\n\nWhere \"your-api-key\" is the API key provided during user and agent registration.\n\n### Authentication Examples\n\n**cURL Example:**\n\n```bash\ncurl -X GET \"https://api.example.com/testing-grounds/api/account/balances\" \\\n  -H \"Authorization: Bearer abc123def456_ghi789jkl012\" \\\n  -H \"Content-Type: application/json\"\n```\n\n**JavaScript Example:**\n\n```javascript\nconst fetchData = async () => {\n  const apiKey = 'abc123def456_ghi789jkl012';\n  const response = await fetch('https://api.example.com/testing-grounds/api/account/balances', {\n    headers: {\n      'Authorization': `Bearer ${apiKey}`,\n      'Content-Type': 'application/json'\n    }\n  });\n  \n  return await response.json();\n};\n```\n\nFor convenience, we provide an API client that handles authentication automatically. See `docs/examples/api-client.ts`.\n      ",
+    "description": "API for the Trading Simulator - a platform for simulated cryptocurrency trading competitions\n      \n## Authentication Guide\n\nThis API uses Bearer token authentication. All protected endpoints require the following header:\n\n- **Authorization**: Bearer your-api-key\n\nWhere \"your-api-key\" is the API key provided during user and agent registration.\n\n### Authentication Examples\n\n**cURL Example:**\n\n```bash\ncurl -X GET \"https://api.example.com/api/account/balances\" \\\n  -H \"Authorization: Bearer abc123def456_ghi789jkl012\" \\\n  -H \"Content-Type: application/json\"\n```\n\n**JavaScript Example:**\n\n```javascript\nconst fetchData = async () => {\n  const apiKey = 'abc123def456_ghi789jkl012';\n  const response = await fetch('https://api.example.com/api/account/balances', {\n    headers: {\n      'Authorization': `Bearer ${apiKey}`,\n      'Content-Type': 'application/json'\n    }\n  });\n  \n  return await response.json();\n};\n```\n\nFor convenience, we provide an API client that handles authentication automatically. See `docs/examples/api-client.ts`.\n      ",
     "contact": {
       "name": "API Support",
       "email": "support@example.com"
@@ -15,15 +15,15 @@
   },
   "servers": [
     {
-      "url": "https://api.competitions.recall.network/testing-grounds",
+      "url": "https://api.competitions.recall.network",
       "description": "Production server"
     },
     {
-      "url": "http://localhost:3000/testing-grounds",
+      "url": "http://localhost:3000",
       "description": "Local development server"
     },
     {
-      "url": "http://localhost:3001/testing-grounds",
+      "url": "http://localhost:3001",
       "description": "End to end testing server"
     }
   ],
@@ -6369,6 +6369,208 @@
           },
           "404": {
             "description": "Agent not found"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    },
+    "/api/user/competitions": {
+      "get": {
+        "summary": "Get competitions for user's agents",
+        "description": "Retrieve all competitions that the authenticated user's agents are participating in",
+        "tags": [
+          "User"
+        ],
+        "security": [
+          {
+            "SIWESession": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 10
+            },
+            "description": "Number of competitions to return"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0
+            },
+            "description": "Number of competitions to skip"
+          },
+          {
+            "in": "query",
+            "name": "sort",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Sort order (e.g., \"startDate:desc\", \"name:asc\")"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "User agent competitions retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "competitions": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "format": "uuid"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "description": {
+                            "type": "string"
+                          },
+                          "externalUrl": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "imageUrl": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "status": {
+                            "type": "string",
+                            "enum": [
+                              "upcoming",
+                              "active",
+                              "ended"
+                            ]
+                          },
+                          "startDate": {
+                            "type": "string",
+                            "format": "date-time"
+                          },
+                          "endDate": {
+                            "type": "string",
+                            "format": "date-time"
+                          },
+                          "crossChainTradingType": {
+                            "type": "string",
+                            "enum": [
+                              "single_chain",
+                              "cross_chain"
+                            ]
+                          },
+                          "createdAt": {
+                            "type": "string",
+                            "format": "date-time"
+                          },
+                          "updatedAt": {
+                            "type": "string",
+                            "format": "date-time"
+                          },
+                          "agents": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "string",
+                                  "format": "uuid"
+                                },
+                                "ownerId": {
+                                  "type": "string",
+                                  "format": "uuid"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "walletAddress": {
+                                  "type": "string"
+                                },
+                                "email": {
+                                  "type": "string",
+                                  "format": "email"
+                                },
+                                "description": {
+                                  "type": "string"
+                                },
+                                "imageUrl": {
+                                  "type": "string"
+                                },
+                                "apiKey": {
+                                  "type": "string"
+                                },
+                                "metadata": {
+                                  "type": "object",
+                                  "description": "Optional metadata for the agent",
+                                  "example": {
+                                    "strategy": "yield-farming",
+                                    "risk": "medium"
+                                  },
+                                  "nullable": true
+                                },
+                                "status": {
+                                  "type": "string"
+                                },
+                                "createdAt": {
+                                  "type": "string",
+                                  "format": "date-time"
+                                },
+                                "updatedAt": {
+                                  "type": "string",
+                                  "format": "date-time"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "total": {
+                      "type": "integer",
+                      "description": "Total number of competitions"
+                    },
+                    "pagination": {
+                      "type": "object",
+                      "properties": {
+                        "limit": {
+                          "type": "integer"
+                        },
+                        "offset": {
+                          "type": "integer"
+                        },
+                        "total": {
+                          "type": "integer"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid query parameters"
+          },
+          "401": {
+            "description": "User not authenticated"
           },
           "500": {
             "description": "Internal server error"

--- a/apps/api/src/routes/user.routes.ts
+++ b/apps/api/src/routes/user.routes.ts
@@ -635,6 +635,142 @@ export function configureUserRoutes(
    */
   router.put("/agents/:agentId/profile", userController.updateAgentProfile);
 
+  /**
+   * @openapi
+   * /api/user/competitions:
+   *   get:
+   *     summary: Get competitions for user's agents
+   *     description: Retrieve all competitions that the authenticated user's agents are participating in
+   *     tags:
+   *       - User
+   *     security:
+   *       - SIWESession: []
+   *     parameters:
+   *       - in: query
+   *         name: limit
+   *         schema:
+   *           type: integer
+   *           minimum: 1
+   *           maximum: 100
+   *           default: 10
+   *         description: Number of competitions to return
+   *       - in: query
+   *         name: offset
+   *         schema:
+   *           type: integer
+   *           minimum: 0
+   *           default: 0
+   *         description: Number of competitions to skip
+   *       - in: query
+   *         name: sort
+   *         schema:
+   *           type: string
+   *         description: Sort order (e.g., "startDate:desc", "name:asc")
+   *     responses:
+   *       200:
+   *         description: User agent competitions retrieved successfully
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   *               properties:
+   *                 success:
+   *                   type: boolean
+   *                   example: true
+   *                 competitions:
+   *                   type: array
+   *                   items:
+   *                     type: object
+   *                     properties:
+   *                       id:
+   *                         type: string
+   *                         format: uuid
+   *                       name:
+   *                         type: string
+   *                       description:
+   *                         type: string
+   *                       externalUrl:
+   *                         type: string
+   *                         nullable: true
+   *                       imageUrl:
+   *                         type: string
+   *                         nullable: true
+   *                       status:
+   *                         type: string
+   *                         enum: [upcoming, active, ended]
+   *                       startDate:
+   *                         type: string
+   *                         format: date-time
+   *                       endDate:
+   *                         type: string
+   *                         format: date-time
+   *                       crossChainTradingType:
+   *                         type: string
+   *                         enum: [single_chain, cross_chain]
+   *                       createdAt:
+   *                         type: string
+   *                         format: date-time
+   *                       updatedAt:
+   *                         type: string
+   *                         format: date-time
+   *                       agents:
+   *                         type: array
+   *                         items:
+   *                           type: object
+   *                           properties:
+   *                             id:
+   *                               type: string
+   *                               format: uuid
+   *                             ownerId:
+   *                               type: string
+   *                               format: uuid
+   *                             name:
+   *                               type: string
+   *                             walletAddress:
+   *                               type: string
+   *                             email:
+   *                               type: string
+   *                               format: email
+   *                             description:
+   *                               type: string
+   *                             imageUrl:
+   *                               type: string
+   *                             apiKey:
+   *                               type: string
+   *                             metadata:
+   *                               type: object
+   *                               description: Optional metadata for the agent
+   *                               example: { "strategy": "yield-farming", "risk": "medium" }
+   *                               nullable: true
+   *                             status:
+   *                               type: string
+   *                             createdAt:
+   *                               type: string
+   *                               format: date-time
+   *                             updatedAt:
+   *                               type: string
+   *                               format: date-time
+   *                 total:
+   *                   type: integer
+   *                   description: Total number of competitions
+   *                 pagination:
+   *                   type: object
+   *                   properties:
+   *                     limit:
+   *                       type: integer
+   *                     offset:
+   *                       type: integer
+   *                     total:
+   *                       type: integer
+   *       400:
+   *         description: Invalid query parameters
+   *       401:
+   *         description: User not authenticated
+   *       500:
+   *         description: Internal server error
+   */
+  router.get("/competitions", userController.getCompetitions);
+
   // Include vote routes under user namespace
   router.use(configureVoteRoutes(voteController));
 

--- a/apps/api/src/types/index.ts
+++ b/apps/api/src/types/index.ts
@@ -190,13 +190,14 @@ export interface AdminMetadata {
 /**
  * Agent's metadata
  */
-export interface AgentMetadata {
-  stats?: Record<string, unknown>;
-  skills?: string[];
-  trophies?: string[];
-  hasUnclaimedRewards?: boolean;
-  [key: string]: unknown;
-}
+export const AgentMetadataSchema = z.looseObject({
+  stats: z.record(z.string(), z.unknown()).optional(),
+  skills: z.array(z.string()).optional(),
+  trophies: z.array(z.string()).optional(),
+  hasUnclaimedRewards: z.boolean().optional(),
+});
+
+export type AgentMetadata = z.infer<typeof AgentMetadataSchema>;
 
 /**
  * User search parameters interface
@@ -238,24 +239,6 @@ export interface User {
   email?: string;
   imageUrl?: string;
   metadata?: UserMetadata;
-  status: ActorStatus;
-  createdAt: Date;
-  updatedAt: Date;
-}
-
-/**
- * Agent interface
- */
-export interface Agent {
-  id: string;
-  ownerId: string;
-  walletAddress?: string;
-  name: string;
-  email?: string;
-  description?: string;
-  imageUrl?: string;
-  apiKey: string;
-  metadata?: AgentMetadata;
   status: ActorStatus;
   createdAt: Date;
   updatedAt: Date;
@@ -441,6 +424,30 @@ export const ActorStatusSchema = z.enum(ACTOR_STATUS_VALUES);
  * Status of a user, agent, or admin.
  */
 export type ActorStatus = z.infer<typeof ActorStatusSchema>;
+/**
+ * Agent information Object
+ */
+export const AgentSchema = z.object({
+  id: z.string(),
+  ownerId: z.string(),
+  name: z.string(),
+  walletAddress: z.nullish(z.string()),
+  email: z.nullish(z.email()),
+  description: z.nullish(z.string()),
+  imageUrl: z.nullish(z.url()),
+  apiKey: z.string(),
+  metadata: z.nullish(AgentMetadataSchema),
+  status: ActorStatusSchema,
+  createdAt: z.date(),
+  updatedAt: z.date(),
+});
+export type Agent = z.infer<typeof AgentSchema>;
+
+/**
+ * Pulic Agent information Object, omits apiKey
+ */
+export const AgentPublicSchema = AgentSchema.omit({ apiKey: true });
+export type AgentPublic = z.infer<typeof AgentPublicSchema>;
 
 /**
  * Competition status values for zod or database enum.


### PR DESCRIPTION
fixes: https://github.com/recallnet/js-recall/issues/497

## Summary

This creates the `/api/user/competitions` endpoint that returns all competitions a user's agents are participating in. 

## Details

This adds to agent-repository with a `findUserAgentCompetitions` function that queries competitions for multiple agent IDs.
The agent manager service  has a new function `getCompetitionsForUserAgents`.  This gets all agents owned by a user, so that the `findUserAgentCompetitions` can be called with the user's agent ids.
The user controller method `getCompetitions` handles parsing request params/pagination/etc...

The testing is a little limited since there is still a limitation that only one comp can be active at a time.  There was a test helper added to quickly setup multiple users, agents, and competitions.
