### PR TITLE
fix(api): include `hasMore` in /agents response

### DIFF
--- a/apps/api/src/controllers/agent.controller.ts
+++ b/apps/api/src/controllers/agent.controller.ts
@@ -145,14 +145,16 @@ export function makeAgentController(services: ServiceRegistry) {
           pagingParams,
         });
         const totalCount = await services.agentManager.countAgents(filter);
+        const { limit, offset } = pagingParams;
 
         // Return the agents
         res.status(200).json({
           success: true,
           pagination: {
             total: totalCount,
-            limit: pagingParams.limit,
-            offset: pagingParams.offset,
+            limit,
+            offset,
+            hasMore: limit + offset < totalCount,
           },
           agents: agents.map(
             services.agentManager.sanitizeAgent.bind(services.agentManager),

--- a/apps/api/src/routes/agents.routes.ts
+++ b/apps/api/src/routes/agents.routes.ts
@@ -32,7 +32,21 @@ export function configureAgentsRoutes(
    *         schema:
    *           type: string
    *         required: false
-   *         description: Optional field to sort by (default value is `createdDate`)
+   *         description: |
+   *           Optional field(s) to sort by. Supports single or multiple fields separated by commas.
+   *           Prefix with '-' for descending order (e.g., '-name' or 'name,-createdAt').
+   *           Available fields: id, ownerId, walletAddress, name, description, imageUrl, status, createdAt, updatedAt.
+   *           When not specified, results are returned in database order.
+   *         examples:
+   *           single_asc:
+   *             value: "name"
+   *             summary: "Sort by name ascending"
+   *           single_desc:
+   *             value: "-createdAt"
+   *             summary: "Sort by creation date descending (newest first)"
+   *           multi_field:
+   *             value: "status,-createdAt"
+   *             summary: "Sort by status ascending, then by creation date descending"
    *       - in: query
    *         name: limit
    *         schema:


### PR DESCRIPTION
part of #509 

Very small PR here.  I'll keep adding to this as I find more places the api needs fixes to pagination and sorting, but feel free to review.