### PR TITLE
feat: allow users to fetch agent api keys

### DIFF
--- a/apps/api/e2e/utils/api-client.ts
+++ b/apps/api/e2e/utils/api-client.ts
@@ -47,6 +47,7 @@ import {
   TradeHistoryResponse,
   TradeResponse,
   UpcomingCompetitionsResponse,
+  UserAgentApiKeyResponse,
   UserProfileResponse,
   UserRegistrationResponse,
   UserVotesResponse,
@@ -1323,6 +1324,23 @@ export class ApiClient {
       return response.data;
     } catch (error) {
       return this.handleApiError(error, "get user agent");
+    }
+  }
+
+  /**
+   * Get the API key for a specific agent owned by the authenticated user
+   * @param agentId ID of the agent to get the API key for
+   */
+  async getUserAgentApiKey(
+    agentId: string,
+  ): Promise<UserAgentApiKeyResponse | ErrorResponse> {
+    try {
+      const response = await this.axiosInstance.get(
+        `/api/user/agents/${agentId}/api-key`,
+      );
+      return response.data;
+    } catch (error) {
+      return this.handleApiError(error, "get user agent API key");
     }
   }
 

--- a/apps/api/e2e/utils/api-types.ts
+++ b/apps/api/e2e/utils/api-types.ts
@@ -186,7 +186,7 @@ export interface AdminAgentsListResponse extends ApiResponse {
   agents: Agent[];
 }
 
-// Agent API key response
+// Agent API key response (admin endpoint)
 export interface AgentApiKeyResponse extends ApiResponse {
   success: true;
   agent: {
@@ -194,6 +194,14 @@ export interface AgentApiKeyResponse extends ApiResponse {
     name: string;
     apiKey: string;
   };
+}
+
+// User agent API key response (user endpoint)
+export interface UserAgentApiKeyResponse extends ApiResponse {
+  success: true;
+  agentId: string;
+  agentName: string;
+  apiKey: string;
 }
 
 /**

--- a/apps/api/openapi/API.md
+++ b/apps/api/openapi/API.md
@@ -1492,6 +1492,41 @@ Retrieve details of a specific agent owned by the authenticated user
 | --------------- | ------ |
 | SIWESession     |        |
 
+### /api/user/agents/{agentId}/api-key
+
+#### GET
+
+##### Summary:
+
+Get agent API key
+
+##### Description:
+
+Retrieve the API key for a specific agent owned by the authenticated user. This endpoint provides access to sensitive credentials and should be used sparingly.
+
+##### Parameters
+
+| Name    | Located in | Description                                | Required | Schema        |
+| ------- | ---------- | ------------------------------------------ | -------- | ------------- |
+| agentId | path       | The ID of the agent to get the API key for | Yes      | string (uuid) |
+
+##### Responses
+
+| Code | Description                                      |
+| ---- | ------------------------------------------------ |
+| 200  | API key retrieved successfully                   |
+| 400  | Invalid agent ID format                          |
+| 401  | User not authenticated                           |
+| 403  | Access denied (user doesn't own this agent)      |
+| 404  | Agent not found                                  |
+| 500  | Internal server error (e.g., decryption failure) |
+
+##### Security
+
+| Security Schema | Scopes |
+| --------------- | ------ |
+| SIWESession     |        |
+
 ### /api/user/agents/{agentId}/profile
 
 #### PUT

--- a/apps/api/openapi/openapi.json
+++ b/apps/api/openapi/openapi.json
@@ -6003,6 +6003,165 @@
         }
       }
     },
+    "/api/user/agents/{agentId}/api-key": {
+      "get": {
+        "summary": "Get agent API key",
+        "description": "Retrieve the API key for a specific agent owned by the authenticated user. This endpoint provides access to sensitive credentials and should be used sparingly.",
+        "tags": [
+          "User"
+        ],
+        "security": [
+          {
+            "SIWESession": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "agentId",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "The ID of the agent to get the API key for"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "API key retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "agentId": {
+                      "type": "string",
+                      "format": "uuid",
+                      "description": "The ID of the agent"
+                    },
+                    "agentName": {
+                      "type": "string",
+                      "description": "The name of the agent",
+                      "example": "Trading Bot Alpha"
+                    },
+                    "apiKey": {
+                      "type": "string",
+                      "description": "The decrypted API key for the agent (store this securely)",
+                      "example": "1234567890abcdef_fedcba0987654321"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid agent ID format",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": false
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Invalid request format: Agent ID is required"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "User not authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": false
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Authentication required"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied (user doesn't own this agent)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": false
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Access denied: You don't own this agent"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Agent not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": false
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Agent not found"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error (e.g., decryption failure)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": false
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "Failed to decrypt API key"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/user/agents/{agentId}/profile": {
       "put": {
         "summary": "Update agent profile",

--- a/apps/api/src/routes/user.routes.ts
+++ b/apps/api/src/routes/user.routes.ts
@@ -417,6 +417,115 @@ export function configureUserRoutes(
 
   /**
    * @openapi
+   * /api/user/agents/{agentId}/api-key:
+   *   get:
+   *     summary: Get agent API key
+   *     description: Retrieve the API key for a specific agent owned by the authenticated user. This endpoint provides access to sensitive credentials and should be used sparingly.
+   *     tags:
+   *       - User
+   *     security:
+   *       - SIWESession: []
+   *     parameters:
+   *       - in: path
+   *         name: agentId
+   *         required: true
+   *         schema:
+   *           type: string
+   *           format: uuid
+   *         description: The ID of the agent to get the API key for
+   *     responses:
+   *       200:
+   *         description: API key retrieved successfully
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   *               properties:
+   *                 success:
+   *                   type: boolean
+   *                   example: true
+   *                 agentId:
+   *                   type: string
+   *                   format: uuid
+   *                   description: The ID of the agent
+   *                 agentName:
+   *                   type: string
+   *                   description: The name of the agent
+   *                   example: "Trading Bot Alpha"
+   *                 apiKey:
+   *                   type: string
+   *                   description: The decrypted API key for the agent (store this securely)
+   *                   example: "1234567890abcdef_fedcba0987654321"
+   *       400:
+   *         description: Invalid agent ID format
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   *               properties:
+   *                 success:
+   *                   type: boolean
+   *                   example: false
+   *                 message:
+   *                   type: string
+   *                   example: "Invalid request format: Agent ID is required"
+   *       401:
+   *         description: User not authenticated
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   *               properties:
+   *                 success:
+   *                   type: boolean
+   *                   example: false
+   *                 message:
+   *                   type: string
+   *                   example: "Authentication required"
+   *       403:
+   *         description: Access denied (user doesn't own this agent)
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   *               properties:
+   *                 success:
+   *                   type: boolean
+   *                   example: false
+   *                 message:
+   *                   type: string
+   *                   example: "Access denied: You don't own this agent"
+   *       404:
+   *         description: Agent not found
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   *               properties:
+   *                 success:
+   *                   type: boolean
+   *                   example: false
+   *                 message:
+   *                   type: string
+   *                   example: "Agent not found"
+   *       500:
+   *         description: Internal server error (e.g., decryption failure)
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   *               properties:
+   *                 success:
+   *                   type: boolean
+   *                   example: false
+   *                 message:
+   *                   type: string
+   *                   example: "Failed to decrypt API key"
+   */
+  router.get("/agents/:agentId/api-key", userController.getAgentApiKey);
+
+  /**
+   * @openapi
    * /api/user/agents/{agentId}/profile:
    *   put:
    *     summary: Update agent profile


### PR DESCRIPTION
# Add User Agent API Key Access Endpoint

## Overview
Implements Issue #543 - adds endpoint for users to retrieve their own agent's API keys through the user interface.

## Changes
- **New Endpoint**: `GET /user/agents/:agentId/api-key` 
- **Authentication**: SIWE session-based auth with ownership verification
- **Response Format**: `{ success, agentId, agentName, apiKey }`
- **Security**: Audit logging + reuses battle-tested admin decryption infrastructure

## Technical Implementation
- **Controller**: New `getAgentApiKey` method in `UserController`
- **Route**: Added to `user.routes.ts` with comprehensive OpenAPI documentation
- **Types**: New `UserAgentApiKeyResponse` interface in API types
- **Infrastructure Reuse**: Leverages existing `AgentManager.getDecryptedApiKeyById()` 

## Security Considerations
- ✅ Ownership verification (user.id === agent.ownerId)
- ✅ Audit logging for credential access
- ✅ Separate endpoint (keeps agent queries fast/cacheable)
- ✅ Proper error handling for unauthorized access

## Testing
- ✅ Successful API key retrieval by owner
- ✅ Unauthorized access prevention (different user)
- ✅ Non-existent agent handling
- ✅ Authentication failure scenarios
- ✅ API key functionality verification

## Quality Standards
- ✅ All lint, format, and build checks pass
- ✅ Comprehensive TypeScript types
- ✅ Full OpenAPI documentation
- ✅ TSDoc coverage for new methods

## Scope
**Phase 1 Only**: API key **retrieval**. Reset functionality planned for separate PR (Phase 2).
**DOES NOT INCLUDE A REGENERATION OF API-SDK** 
