### PR TITLE
fix(api): openapi doc correctly describes spec

### DIFF
--- a/apps/api/openapi/openapi.json
+++ b/apps/api/openapi/openapi.json
@@ -2880,6 +2880,51 @@
             },
             "required": true,
             "description": "The UUID of the agent"
+          },
+          {
+            "in": "query",
+            "name": "sort",
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "description": "Optional field(s) to sort by. Supports single or multiple fields separated by commas.\nPrefix with '-' for descending order (e.g., '-name' or 'name,-createdAt').\n"
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "description": "Optional field to choose max size of result set (default value is `10`)"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "description": "Optional field to choose offset of result set (default value is `0`)"
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "description": "Optional field to filter results to only include competitions with given status."
+          },
+          {
+            "in": "query",
+            "name": "claimed",
+            "schema": {
+              "type": "boolean"
+            },
+            "required": false,
+            "description": "Optional field to filter results to only include competitions with rewards that have been claimed if value is true, or unclaimed if value is false."
           }
         ],
         "responses": {

--- a/apps/api/src/controllers/agent.controller.ts
+++ b/apps/api/src/controllers/agent.controller.ts
@@ -18,6 +18,8 @@ import {
   UuidSchema,
 } from "@/types/index.js";
 
+import { ensureUuid } from "./request-helpers.js";
+
 /**
  * Agent Controller
  * Handles agent-specific trading operations with agent API key authentication
@@ -490,12 +492,7 @@ export function makeAgentController(services: ServiceRegistry) {
      */
     async getCompetitions(req: Request, res: Response, next: NextFunction) {
       try {
-        const { success: idSuccess, data: agentId } = UuidSchema.safeParse(
-          req.params.agentId,
-        );
-        if (!idSuccess) {
-          throw new ApiError(400, "Invalid agent ID");
-        }
+        const agentId = ensureUuid(req.params.agentId);
         const { success: paramsSuccess, data: params } =
           AgentCompetitionsParamsSchema.safeParse(req.query);
         if (!paramsSuccess) {

--- a/apps/api/src/controllers/agent.controller.ts
+++ b/apps/api/src/controllers/agent.controller.ts
@@ -18,7 +18,7 @@ import {
 } from "@/types/index.js";
 
 import {
-  ensureCompetitionFilters,
+  ensureAgentCompetitionFilters,
   ensurePaging,
   ensureUuid,
 } from "./request-helpers.js";
@@ -496,7 +496,7 @@ export function makeAgentController(services: ServiceRegistry) {
     async getCompetitions(req: Request, res: Response, next: NextFunction) {
       try {
         const agentId = ensureUuid(req.params.agentId);
-        const filters = ensureCompetitionFilters(req);
+        const filters = ensureAgentCompetitionFilters(req);
         const paging = ensurePaging(req);
 
         // Fetch all competitions associated with the agent

--- a/apps/api/src/controllers/agent.controller.ts
+++ b/apps/api/src/controllers/agent.controller.ts
@@ -9,7 +9,6 @@ import { getLatestPrice } from "@/database/repositories/price-repository.js";
 import { ApiError } from "@/middleware/errorHandler.js";
 import { ServiceRegistry } from "@/services/index.js";
 import {
-  AgentCompetitionsParamsSchema,
   AgentFilterSchema,
   AuthenticatedRequest,
   PagingParamsSchema,
@@ -18,7 +17,11 @@ import {
   UuidSchema,
 } from "@/types/index.js";
 
-import { ensureUuid } from "./request-helpers.js";
+import {
+  ensureCompetitionFilters,
+  ensurePaging,
+  ensureUuid,
+} from "./request-helpers.js";
 
 /**
  * Agent Controller
@@ -493,26 +496,24 @@ export function makeAgentController(services: ServiceRegistry) {
     async getCompetitions(req: Request, res: Response, next: NextFunction) {
       try {
         const agentId = ensureUuid(req.params.agentId);
-        const { success: paramsSuccess, data: params } =
-          AgentCompetitionsParamsSchema.safeParse(req.query);
-        if (!paramsSuccess) {
-          throw new ApiError(400, "Invalid sort filter page params");
-        }
+        const filters = ensureCompetitionFilters(req);
+        const paging = ensurePaging(req);
 
         // Fetch all competitions associated with the agent
         const results = await services.agentManager.getCompetitionsForAgent(
           agentId,
-          params,
+          filters,
+          paging,
         );
 
         res.status(200).json({
           success: true,
           competitions: results.competitions,
           pagination: {
-            limit: params.limit,
-            offset: params.offset,
+            limit: paging.limit,
+            offset: paging.offset,
             total: results.total,
-            hasMore: params.limit + params.offset < results.total,
+            hasMore: paging.limit + paging.offset < results.total,
           },
         });
       } catch (error) {

--- a/apps/api/src/controllers/request-helpers.ts
+++ b/apps/api/src/controllers/request-helpers.ts
@@ -1,13 +1,22 @@
 import { Request } from "express";
 
 import { ApiError } from "@/middleware/errorHandler.js";
-import { PagingParamsSchema } from "@/types/index.js";
+import { PagingParamsSchema, UuidSchema } from "@/types/index.js";
 
 export function ensureUserId(req: Request) {
   if (!req.userId) {
     throw new ApiError(400, "must be authenticated as a user");
   }
   return req.userId;
+}
+
+export function ensureUuid(uuid: string | undefined) {
+  const { success, data: id } = UuidSchema.safeParse(uuid);
+  if (!success) {
+    throw new ApiError(400, "Invalid UUID");
+  }
+
+  return id;
 }
 
 export function ensurePaging(req: Request) {

--- a/apps/api/src/controllers/request-helpers.ts
+++ b/apps/api/src/controllers/request-helpers.ts
@@ -31,7 +31,7 @@ export function ensurePaging(req: Request) {
 
   return data;
 }
-export function ensureCompetitionFilters(req: Request) {
+export function ensureAgentCompetitionFilters(req: Request) {
   const { success, data } = AgentCompetitionsParamsSchema.safeParse(req.query);
   if (!success) {
     throw new ApiError(400, "Invalid sort filter page params");

--- a/apps/api/src/controllers/request-helpers.ts
+++ b/apps/api/src/controllers/request-helpers.ts
@@ -1,7 +1,11 @@
 import { Request } from "express";
 
 import { ApiError } from "@/middleware/errorHandler.js";
-import { PagingParamsSchema, UuidSchema } from "@/types/index.js";
+import {
+  AgentCompetitionsParamsSchema,
+  PagingParamsSchema,
+  UuidSchema,
+} from "@/types/index.js";
 
 export function ensureUserId(req: Request) {
   if (!req.userId) {
@@ -23,6 +27,14 @@ export function ensurePaging(req: Request) {
   const { success, data, error } = PagingParamsSchema.safeParse(req.query);
   if (!success) {
     throw new ApiError(400, `Invalid pagination parameters: ${error.message}`);
+  }
+
+  return data;
+}
+export function ensureCompetitionFilters(req: Request) {
+  const { success, data } = AgentCompetitionsParamsSchema.safeParse(req.query);
+  if (!success) {
+    throw new ApiError(400, "Invalid sort filter page params");
   }
 
   return data;

--- a/apps/api/src/routes/agents.routes.ts
+++ b/apps/api/src/routes/agents.routes.ts
@@ -231,6 +231,38 @@ export function configureAgentsRoutes(
    *           type: string
    *         required: true
    *         description: The UUID of the agent
+   *       - in: query
+   *         name: sort
+   *         schema:
+   *           type: string
+   *         required: false
+   *         description: |
+   *           Optional field(s) to sort by. Supports single or multiple fields separated by commas.
+   *           Prefix with '-' for descending order (e.g., '-name' or 'name,-createdAt').
+   *       - in: query
+   *         name: limit
+   *         schema:
+   *           type: string
+   *         required: false
+   *         description: Optional field to choose max size of result set (default value is `10`)
+   *       - in: query
+   *         name: offset
+   *         schema:
+   *           type: string
+   *         required: false
+   *         description: Optional field to choose offset of result set (default value is `0`)
+   *       - in: query
+   *         name: status
+   *         schema:
+   *           type: string
+   *         required: false
+   *         description: Optional field to filter results to only include competitions with given status.
+   *       - in: query
+   *         name: claimed
+   *         schema:
+   *           type: boolean
+   *         required: false
+   *         description: Optional field to filter results to only include competitions with rewards that have been claimed if value is true, or unclaimed if value is false.
    *     responses:
    *       200:
    *         description: Competitions retrieved successfully

--- a/apps/api/src/services/agent-manager.service.ts
+++ b/apps/api/src/services/agent-manager.service.ts
@@ -790,9 +790,14 @@ export class AgentManager {
    */
   async getCompetitionsForAgent(
     agentId: string,
-    params: AgentCompetitionsParams,
+    filters: AgentCompetitionsParams,
+    paging: PagingParams,
   ) {
     try {
+      const params = {
+        ...filters,
+        ...paging,
+      };
       console.log(
         `[AgentManager] Retrieving competitions for agent ${agentId} with params:`,
         params,


### PR DESCRIPTION
part of: https://github.com/recallnet/js-recall/issues/509
part of: https://github.com/recallnet/js-recall/issues/426

The openapi spec was not correctly describing the `/api/agents/{agentId}/competitions` pagination and filtering querystring options.  This updates the spec and does a little bit of work to dry out parsing of paging and filtering parameters.