### PR TITLE
fix(api): fix openapi spec for /user/competitions

### DIFF
--- a/apps/api/openapi/openapi.json
+++ b/apps/api/openapi/openapi.json
@@ -6586,6 +6586,22 @@
               "type": "string"
             },
             "description": "Sort order (e.g., \"startDate:desc\", \"name:asc\")"
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Optional filter for the competition status. Possible values (\"ended\", \"active\", \"pending\")"
+          },
+          {
+            "in": "query",
+            "name": "claimed",
+            "schema": {
+              "type": "boolean"
+            },
+            "description": "Optional filter for agents with claimed (claimed=true) or unclaimed rewards (claimed=false). Note, because rewards are not implemented, THIS IS NOT IMPLEMENTED YET."
           }
         ],
         "responses": {

--- a/apps/api/src/routes/user.routes.ts
+++ b/apps/api/src/routes/user.routes.ts
@@ -734,6 +734,16 @@ export function configureUserRoutes(
    *         schema:
    *           type: string
    *         description: Sort order (e.g., "startDate:desc", "name:asc")
+   *       - in: query
+   *         name: status
+   *         schema:
+   *           type: string
+   *         description: Optional filter for the competition status. Possible values ("ended", "active", "pending")
+   *       - in: query
+   *         name: claimed
+   *         schema:
+   *           type: boolean
+   *         description: Optional filter for agents with claimed (claimed=true) or unclaimed rewards (claimed=false). Note, because rewards are not implemented, THIS IS NOT IMPLEMENTED YET.
    *     responses:
    *       200:
    *         description: User agent competitions retrieved successfully

--- a/apps/api/src/services/index.ts
+++ b/apps/api/src/services/index.ts
@@ -71,9 +71,7 @@ class ServiceRegistry {
     this._voteManager = new VoteManager();
 
     // Initialize LeaderboardService with required dependencies
-    this._leaderboardService = new LeaderboardService(
-      this._agentManager,
-    );
+    this._leaderboardService = new LeaderboardService(this._agentManager);
 
     // Initialize and start the scheduler
     this._scheduler = new SchedulerService(


### PR DESCRIPTION
The spec for the `/api/user/competitions` endpoint did not have the available query filters listed.  This updates the spec, which in turn updates the swagger docs stie.