### PR TITLE
fix(api): count total active agents

### DIFF
--- a/apps/api/e2e/tests/leaderboard.test.ts
+++ b/apps/api/e2e/tests/leaderboard.test.ts
@@ -87,7 +87,7 @@ describe("Leaderboard API", () => {
       (await agentClient1.getGlobalLeaderboard()) as GlobalLeaderboardResponse;
     expect(leaderboard.success).toBe(true);
 
-    expect(leaderboard.stats.activeAgents).toBe(0);
+    expect(leaderboard.stats.activeAgents).toBe(2);
     expect(leaderboard.stats.totalTrades).toBe(2);
     expect(leaderboard.stats.totalVolume).toBeDefined();
     expect(leaderboard.stats.totalCompetitions).toBe(1);
@@ -167,7 +167,7 @@ describe("Leaderboard API", () => {
     expect(leaderboard.success).toBe(true);
 
     // Total stats shouldn't change; these represent all competitions, regardless of the query params
-    expect(leaderboard.stats.activeAgents).toBe(0);
+    expect(leaderboard.stats.activeAgents).toBe(2);
     expect(leaderboard.stats.totalTrades).toBe(2);
     expect(leaderboard.stats.totalVolume).toBeDefined();
     expect(leaderboard.stats.totalCompetitions).toBe(1);
@@ -270,7 +270,7 @@ describe("Leaderboard API", () => {
     expect(leaderboard.success).toBe(true);
 
     // Verify stats
-    expect(leaderboard.stats.activeAgents).toBe(0);
+    expect(leaderboard.stats.activeAgents).toBe(2);
     expect(leaderboard.stats.totalTrades).toBe(4);
     expect(leaderboard.stats.totalVolume).toBeDefined();
     expect(leaderboard.stats.totalCompetitions).toBe(2);

--- a/apps/api/src/database/repositories/leaderboard-repository.ts
+++ b/apps/api/src/database/repositories/leaderboard-repository.ts
@@ -1,9 +1,13 @@
 import { and, count as drizzleCount, eq, inArray, sum } from "drizzle-orm";
 
 import { db } from "@/database/db.js";
-import { competitions, votes } from "@/database/schema/core/defs.js";
+import { agents, competitions, votes } from "@/database/schema/core/defs.js";
 import { trades } from "@/database/schema/trading/defs.js";
-import { COMPETITION_STATUS, CompetitionType } from "@/types/index.js";
+import {
+  ACTOR_STATUS,
+  COMPETITION_STATUS,
+  CompetitionType,
+} from "@/types/index.js";
 
 /**
  * Leaderboard Repository
@@ -67,8 +71,15 @@ export async function getGlobalStats(type: CompetitionType): Promise<{
     .from(votes)
     .where(inArray(votes.competitionId, relevantCompetitionIds));
 
+  const totalActiveAgents = await db
+    .select({
+      totalActiveAgents: drizzleCount(agents.id),
+    })
+    .from(agents)
+    .where(eq(agents.status, ACTOR_STATUS.ACTIVE));
+
   return {
-    activeAgents: 0,
+    activeAgents: totalActiveAgents[0]?.totalActiveAgents ?? 0,
     totalTrades: tradeStatsResult[0]?.totalTrades ?? 0,
     totalVolume: tradeStatsResult[0]?.totalVolume ?? 0,
     totalCompetitions: relevantCompetitions.length,


### PR DESCRIPTION
- Populate the "active" agents in the leaderboards `activeAgents` instead of hardcoding as zero.
- Use the `agent_rank` table to give us an accurate representation of "active" agents (see #458 for more info re: agent "status" and why this query works well for our needs).