### PR TITLE
fix(comps): fix hydration mismatch in siwe

### DIFF
--- a/apps/comps/components/siwe/index.tsx
+++ b/apps/comps/components/siwe/index.tsx
@@ -4,7 +4,7 @@ import { ConnectButton } from "@rainbow-me/rainbowkit";
 import { LogOut } from "lucide-react";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
-import React from "react";
+import React, { useEffect, useState } from "react";
 
 import { Button } from "@recallnet/ui2/components/button";
 import {
@@ -25,10 +25,15 @@ export const SIWEButton: React.FunctionComponent<
   const router = useRouter();
   const logout = useLogout();
   const { user } = useUserSession();
+  const [isMounted, setIsMounted] = useState(false);
+
+  useEffect(() => setIsMounted(true), []);
 
   const handleLogout = async () => {
     logout.mutate();
   };
+
+  if (!isMounted) return <div></div>;
 
   if (user) {
     return (


### PR DESCRIPTION
## Overview

The SIWE component has been generating hydration mismatch errors for me during local dev.  This ensures the server and initial client rendering match.

## Details

The issue comes from the `useUserSession` hook, which is behaving differently on the server vs. the client.  Specifically, the value of `user` on line 27 is available for the server's prerender, but it is null during the initial client render.  I _think_ this is due to the tanstack `useQuery` doing a fetch, which has a variable response between client and server.

What I did here simply leverages useState to only render after mounting, so there is no way there can be a hydration mismatch.
We could alternatively refactor the conditional rendering logic, but this seemed less complicated. I'm open to alternatives. 