### PR TITLE
feat(comps): enable sorting by status and startDate in user's competitions

### DIFF
--- a/apps/api/src/database/repositories/agent-repository.ts
+++ b/apps/api/src/database/repositories/agent-repository.ts
@@ -55,6 +55,7 @@ const agentCompetitionsOrderByFields: Record<string, AnyColumn> = {
   endDate: competitions.endDate,
   createdAt: competitions.createdAt,
   updatedAt: competitions.updatedAt,
+  status: competitions.status,
 };
 
 // Computed fields that need to be sorted at the service layer

--- a/apps/comps/components/competitions-table.tsx
+++ b/apps/comps/components/competitions-table.tsx
@@ -69,11 +69,12 @@ export const CompetitionsTable: React.FC<CompetitionsTableProps> = ({
       },
       {
         id: "status",
+        accessorKey: "status",
         header: () => "Status",
         cell: ({ row }) => (
           <CompetitionStatusBadge status={row.original.status} />
         ),
-        enableSorting: false,
+        enableSorting: true,
         size: 120,
         meta: {
           className: "content-center",
@@ -111,7 +112,8 @@ export const CompetitionsTable: React.FC<CompetitionsTableProps> = ({
         },
       },
       {
-        id: "date",
+        id: "startDate",
+        accessorKey: "startDate",
         header: () => "Date",
         cell: ({ row }) => (
           <span>
@@ -120,7 +122,7 @@ export const CompetitionsTable: React.FC<CompetitionsTableProps> = ({
               : "TBA"}
           </span>
         ),
-        enableSorting: false,
+        enableSorting: true,
         meta: {
           className: "hidden lg:flex items-center",
         },
@@ -182,9 +184,7 @@ export const CompetitionsTable: React.FC<CompetitionsTableProps> = ({
       const newSorting =
         typeof updater === "function" ? updater(sorting) : updater;
       setSorting(newSorting);
-      // Only the first column is sortable
       const sortString = newSorting
-        .filter((sort) => sort.id === "name")
         .map((sort) => `${sort.desc ? "-" : ""}${sort.id}`)
         .join(",");
       onSortChange(sortString);


### PR DESCRIPTION
* Enables `status` sorting in /user/competitions API
* Enables sorting by Status and Date columns on the User Profile page