### PR TITLE
feat (api): add sandbox toggle logic

### DIFF
--- a/.github/workflows/api-ci.yml
+++ b/.github/workflows/api-ci.yml
@@ -272,7 +272,7 @@ jobs:
           PORTFOLIO_PRICE_FRESHNESS_MS=10000
 
           # Optional: Sandbox
-          SANDBOX_MODE=false
+          SANDBOX=false
 
           # Optional: Disable ability for participants to view leaderboard activity
           DISABLE_PARTICIPANT_LEADERBOARD_ACCESS=false

--- a/.github/workflows/api-ci.yml
+++ b/.github/workflows/api-ci.yml
@@ -271,6 +271,9 @@ jobs:
           PORTFOLIO_SNAPSHOT_INTERVAL_MS=10000
           PORTFOLIO_PRICE_FRESHNESS_MS=10000
 
+          # Optional: Sandbox
+          SANDBOX_MODE=false
+
           # Optional: Disable ability for participants to view leaderboard activity
           DISABLE_PARTICIPANT_LEADERBOARD_ACCESS=false
           EOF

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -78,3 +78,6 @@ API_DOMAIN=http://localhost:3000
 
 # Optional: API prefix (e.g., API_PREFIX=development -> /development/api/...)
 API_PREFIX=
+
+# Optional: If true, will auto-add new agents to an active competition
+SANDBOX=

--- a/apps/api/.env.test
+++ b/apps/api/.env.test
@@ -65,3 +65,6 @@ API_DOMAIN=http://localhost:3001
 # Optional: API prefix
 API_PREFIX=testing
 
+# Optional: If true, will auto-add new agents to an active competition
+SANDBOX=false
+

--- a/apps/api/.env.test
+++ b/apps/api/.env.test
@@ -68,4 +68,3 @@ API_PREFIX=testing
 # Optional: If true, will auto-add new agents to an active competition
 SANDBOX=false
 
-ROOT_ENCRYPTION_KEY=b619da62a10d9e0c515e80ef5e2cc5c887ad11c2857d348abdf18fded0c5e6ae

--- a/apps/api/.env.test
+++ b/apps/api/.env.test
@@ -68,3 +68,4 @@ API_PREFIX=testing
 # Optional: If true, will auto-add new agents to an active competition
 SANDBOX=false
 
+ROOT_ENCRYPTION_KEY=b619da62a10d9e0c515e80ef5e2cc5c887ad11c2857d348abdf18fded0c5e6ae

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -712,14 +712,15 @@ The application will automatically detect and use the base64-encoded certificate
 
 ### Server Configuration
 
-| Variable                  | Required | Default       | Description                                               |
-| ------------------------- | -------- | ------------- | --------------------------------------------------------- |
-| `PORT`                    | Optional | `3000`        | Server port number                                        |
-| `NODE_ENV`                | Optional | `development` | Environment mode (`development`, `production`, or `test`) |
-| `ENABLE_CORS`             | Optional | `true`        | Enable Cross-Origin Resource Sharing                      |
-| `MAX_PAYLOAD_SIZE`        | Optional | `1mb`         | Maximum request body size                                 |
-| `RATE_LIMIT_WINDOW_MS`    | Optional | `60000`       | Rate limiting window in milliseconds                      |
-| `RATE_LIMIT_MAX_REQUESTS` | Optional | `100`         | Maximum requests per rate limit window                    |
+| Variable                  | Required | Default       | Description                                                 |
+| ------------------------- | -------- | ------------- | ----------------------------------------------------------- |
+| `PORT`                    | Optional | `3000`        | Server port number                                          |
+| `NODE_ENV`                | Optional | `development` | Environment mode (`development`, `production`, or `test`)   |
+| `ENABLE_CORS`             | Optional | `true`        | Enable Cross-Origin Resource Sharing                        |
+| `MAX_PAYLOAD_SIZE`        | Optional | `1mb`         | Maximum request body size                                   |
+| `RATE_LIMIT_WINDOW_MS`    | Optional | `60000`       | Rate limiting window in milliseconds                        |
+| `RATE_LIMIT_MAX_REQUESTS` | Optional | `100`         | Maximum requests per rate limit window                      |
+| `SANDBOX`                 | Optional | `false`       | Enable sandbox mode for automatic agent competition joining |
 
 ### Chain Configuration
 
@@ -735,6 +736,53 @@ The application will automatically detect and use the base64-encoded certificate
 | Variable                                 | Required | Default | Description                                                                                         |
 | ---------------------------------------- | -------- | ------- | --------------------------------------------------------------------------------------------------- |
 | `DISABLE_PARTICIPANT_LEADERBOARD_ACCESS` | Optional | `false` | When set to `true`, only admins can view the leaderboard while participants are blocked from access |
+
+## Sandbox Mode
+
+The Multi-Chain Trading Simulator includes a sandbox mode feature designed to streamline agent onboarding and testing workflows. When enabled, sandbox mode automatically joins newly registered agents to any active competition, eliminating the need for manual competition enrollment.
+
+### Purpose and Use Cases
+
+Sandbox mode is particularly useful for:
+
+- **Development and Testing**: Quickly test agent implementations without manual setup steps
+- **Demo Environments**: Streamline agent onboarding for demonstrations and showcases
+- **Automated Testing**: Enable continuous integration workflows where agents need immediate competition access
+- **Educational Environments**: Allow students or developers to focus on agent logic rather than setup procedures
+
+### How Sandbox Mode Works
+
+When `SANDBOX=true` is set in your environment configuration:
+
+1. **Agent Registration**: When a new agent is registered via the `/admin/agents` POST endpoint
+2. **Active Competition Check**: The system automatically checks for any currently active competition
+3. **Auto-Join Process**: If an active competition exists, the agent is automatically:
+   - Added to the competition participant list
+   - Given fresh starting balances across all supported chains
+   - Assigned an initial portfolio snapshot for performance tracking
+4. **Graceful Handling**: If no active competition exists or auto-join fails, the agent registration still succeeds
+
+### Configuration
+
+Enable sandbox mode by setting the environment variable:
+
+```bash
+SANDBOX=true
+```
+
+When disabled (default behavior):
+
+```bash
+SANDBOX=false
+# or omit the variable entirely
+```
+
+### Important Considerations
+
+- **Production Use**: Sandbox mode should typically be disabled in production environments to maintain controlled competition participation
+- **Error Handling**: Agent registration always succeeds even if auto-join fails, ensuring robust operation
+- **Competition State**: Only agents registered while a competition is actively running will be auto-joined
+- **Testing**: The feature includes comprehensive test coverage to ensure reliable operation across different scenarios
 
 ### Initial Token Balances
 

--- a/apps/api/drizzle/meta/0016_snapshot.json
+++ b/apps/api/drizzle/meta/0016_snapshot.json
@@ -153,44 +153,32 @@
         "admins_username_unique": {
           "name": "admins_username_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "username"
-          ]
+          "columns": ["username"]
         },
         "admins_email_unique": {
           "name": "admins_email_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "email"
-          ]
+          "columns": ["email"]
         },
         "admins_api_key_unique": {
           "name": "admins_api_key_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "api_key"
-          ]
+          "columns": ["api_key"]
         },
         "admins_username_key": {
           "name": "admins_username_key",
           "nullsNotDistinct": false,
-          "columns": [
-            "username"
-          ]
+          "columns": ["username"]
         },
         "admins_email_key": {
           "name": "admins_email_key",
           "nullsNotDistinct": false,
-          "columns": [
-            "email"
-          ]
+          "columns": ["email"]
         },
         "admins_api_key_key": {
           "name": "admins_api_key_key",
           "nullsNotDistinct": false,
-          "columns": [
-            "api_key"
-          ]
+          "columns": ["api_key"]
         }
       },
       "policies": {},
@@ -291,12 +279,8 @@
           "name": "agent_nonces_agent_id_fkey",
           "tableFrom": "agent_nonces",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -306,9 +290,7 @@
         "agent_nonces_nonce_unique": {
           "name": "agent_nonces_nonce_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "nonce"
-          ]
+          "columns": ["nonce"]
         }
       },
       "policies": {},
@@ -475,12 +457,8 @@
           "name": "agents_owner_id_fkey",
           "tableFrom": "agents",
           "tableTo": "users",
-          "columnsFrom": [
-            "owner_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["owner_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -490,38 +468,27 @@
         "agents_wallet_address_unique": {
           "name": "agents_wallet_address_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "wallet_address"
-          ]
+          "columns": ["wallet_address"]
         },
         "agents_email_unique": {
           "name": "agents_email_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "email"
-          ]
+          "columns": ["email"]
         },
         "agents_owner_id_name_key": {
           "name": "agents_owner_id_name_key",
           "nullsNotDistinct": false,
-          "columns": [
-            "owner_id",
-            "name"
-          ]
+          "columns": ["owner_id", "name"]
         },
         "agents_api_key_key": {
           "name": "agents_api_key_key",
           "nullsNotDistinct": false,
-          "columns": [
-            "api_key"
-          ]
+          "columns": ["api_key"]
         },
         "agents_wallet_address_key": {
           "name": "agents_wallet_address_key",
           "nullsNotDistinct": false,
-          "columns": [
-            "wallet_address"
-          ]
+          "columns": ["wallet_address"]
         }
       },
       "policies": {},
@@ -646,12 +613,8 @@
           "name": "competition_agents_competition_id_fkey",
           "tableFrom": "competition_agents",
           "tableTo": "competitions",
-          "columnsFrom": [
-            "competition_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["competition_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -659,12 +622,8 @@
           "name": "competition_agents_agent_id_fkey",
           "tableFrom": "competition_agents",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -672,10 +631,7 @@
       "compositePrimaryKeys": {
         "competition_agents_pkey": {
           "name": "competition_agents_pkey",
-          "columns": [
-            "competition_id",
-            "agent_id"
-          ]
+          "columns": ["competition_id", "agent_id"]
         }
       },
       "uniqueConstraints": {},
@@ -895,12 +851,8 @@
           "name": "competitions_leaderboard_agent_id_fkey",
           "tableFrom": "competitions_leaderboard",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -908,12 +860,8 @@
           "name": "competitions_leaderboard_competition_id_fkey",
           "tableFrom": "competitions_leaderboard",
           "tableTo": "competitions",
-          "columnsFrom": [
-            "competition_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["competition_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -1025,23 +973,17 @@
         "users_wallet_address_unique": {
           "name": "users_wallet_address_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "wallet_address"
-          ]
+          "columns": ["wallet_address"]
         },
         "users_email_unique": {
           "name": "users_email_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "email"
-          ]
+          "columns": ["email"]
         },
         "users_wallet_address_key": {
           "name": "users_wallet_address_key",
           "nullsNotDistinct": false,
-          "columns": [
-            "wallet_address"
-          ]
+          "columns": ["wallet_address"]
         }
       },
       "policies": {},
@@ -1155,12 +1097,8 @@
           "name": "votes_user_id_fkey",
           "tableFrom": "votes",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -1168,12 +1106,8 @@
           "name": "votes_agent_id_fkey",
           "tableFrom": "votes",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -1181,12 +1115,8 @@
           "name": "votes_competition_id_fkey",
           "tableFrom": "votes",
           "tableTo": "competitions",
-          "columnsFrom": [
-            "competition_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["competition_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -1196,11 +1126,7 @@
         "votes_user_agent_competition_key": {
           "name": "votes_user_agent_competition_key",
           "nullsNotDistinct": false,
-          "columns": [
-            "user_id",
-            "agent_id",
-            "competition_id"
-          ]
+          "columns": ["user_id", "agent_id", "competition_id"]
         }
       },
       "policies": {},
@@ -1278,12 +1204,8 @@
           "name": "agent_rank_agent_id_fkey",
           "tableFrom": "agent_rank",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -1293,9 +1215,7 @@
         "unique_agent_rank_agent_id": {
           "name": "unique_agent_rank_agent_id",
           "nullsNotDistinct": false,
-          "columns": [
-            "agent_id"
-          ]
+          "columns": ["agent_id"]
         }
       },
       "policies": {},
@@ -1408,12 +1328,8 @@
           "name": "agent_rank_history_agent_id_fkey",
           "tableFrom": "agent_rank_history",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -1421,12 +1337,8 @@
           "name": "agent_rank_history_competition_id_fkey",
           "tableFrom": "agent_rank_history",
           "tableTo": "competitions",
-          "columnsFrom": [
-            "competition_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["competition_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -1586,12 +1498,8 @@
           "name": "object_index_competition_id_fkey",
           "tableFrom": "object_index",
           "tableTo": "competitions",
-          "columnsFrom": [
-            "competition_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["competition_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         },
@@ -1599,12 +1507,8 @@
           "name": "object_index_agent_id_fkey",
           "tableFrom": "object_index",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -1707,12 +1611,8 @@
           "name": "balances_agent_id_fkey",
           "tableFrom": "balances",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -1722,10 +1622,7 @@
         "balances_agent_id_token_address_key": {
           "name": "balances_agent_id_token_address_key",
           "nullsNotDistinct": false,
-          "columns": [
-            "agent_id",
-            "token_address"
-          ]
+          "columns": ["agent_id", "token_address"]
         }
       },
       "policies": {},
@@ -1811,12 +1708,8 @@
           "name": "portfolio_snapshots_agent_id_fkey",
           "tableFrom": "portfolio_snapshots",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -1824,12 +1717,8 @@
           "name": "portfolio_snapshots_competition_id_fkey",
           "tableFrom": "portfolio_snapshots",
           "tableTo": "competitions",
-          "columnsFrom": [
-            "competition_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["competition_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -1931,12 +1820,8 @@
           "tableFrom": "portfolio_token_values",
           "tableTo": "portfolio_snapshots",
           "schemaTo": "trading_comps",
-          "columnsFrom": [
-            "portfolio_snapshot_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["portfolio_snapshot_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -2359,12 +2244,8 @@
           "name": "trades_agent_id_fkey",
           "tableFrom": "trades",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -2372,12 +2253,8 @@
           "name": "trades_competition_id_fkey",
           "tableFrom": "trades",
           "tableTo": "competitions",
-          "columnsFrom": [
-            "competition_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["competition_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -2429,12 +2306,8 @@
           "name": "trading_competitions_competitionId_competitions_id_fk",
           "tableFrom": "trading_competitions",
           "tableTo": "competitions",
-          "columnsFrom": [
-            "competitionId"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["competitionId"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "cascade"
         }
@@ -2481,9 +2354,7 @@
         "epochs_number_unique": {
           "name": "epochs_number_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "number"
-          ]
+          "columns": ["number"]
         }
       },
       "policies": {},
@@ -2583,12 +2454,8 @@
           "name": "rewards_epoch_epochs_id_fk",
           "tableFrom": "rewards",
           "tableTo": "epochs",
-          "columnsFrom": [
-            "epoch"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["epoch"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -2657,12 +2524,8 @@
           "name": "rewards_roots_epoch_epochs_id_fk",
           "tableFrom": "rewards_roots",
           "tableTo": "epochs",
-          "columnsFrom": [
-            "epoch"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["epoch"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -2791,12 +2654,8 @@
           "name": "rewards_tree_epoch_epochs_id_fk",
           "tableFrom": "rewards_tree",
           "tableTo": "epochs",
-          "columnsFrom": [
-            "epoch"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["epoch"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -2920,12 +2779,8 @@
           "name": "stakes_user_id_users_id_fk",
           "tableFrom": "stakes",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -2933,12 +2788,8 @@
           "name": "stakes_epoch_created_epochs_id_fk",
           "tableFrom": "stakes",
           "tableTo": "epochs",
-          "columnsFrom": [
-            "epoch_created"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["epoch_created"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -3028,12 +2879,8 @@
           "name": "vote_assignments_stake_id_stakes_id_fk",
           "tableFrom": "vote_assignments",
           "tableTo": "stakes",
-          "columnsFrom": [
-            "stake_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["stake_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -3041,12 +2888,8 @@
           "name": "vote_assignments_user_id_users_id_fk",
           "tableFrom": "vote_assignments",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -3054,12 +2897,8 @@
           "name": "vote_assignments_epoch_epochs_id_fk",
           "tableFrom": "vote_assignments",
           "tableTo": "epochs",
-          "columnsFrom": [
-            "epoch"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["epoch"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -3067,11 +2906,7 @@
       "compositePrimaryKeys": {
         "vote_assignments_pkey": {
           "name": "vote_assignments_pkey",
-          "columns": [
-            "stake_id",
-            "user_id",
-            "epoch"
-          ]
+          "columns": ["stake_id", "user_id", "epoch"]
         }
       },
       "uniqueConstraints": {},
@@ -3140,12 +2975,8 @@
           "name": "votes_available_epoch_epochs_id_fk",
           "tableFrom": "votes_available",
           "tableTo": "epochs",
-          "columnsFrom": [
-            "epoch"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["epoch"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -3153,10 +2984,7 @@
       "compositePrimaryKeys": {
         "votes_available_pkey": {
           "name": "votes_available_pkey",
-          "columns": [
-            "address",
-            "epoch"
-          ]
+          "columns": ["address", "epoch"]
         }
       },
       "uniqueConstraints": {},
@@ -3250,12 +3078,8 @@
           "name": "votes_performed_user_id_users_id_fk",
           "tableFrom": "votes_performed",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -3263,12 +3087,8 @@
           "name": "votes_performed_agent_id_agents_id_fk",
           "tableFrom": "votes_performed",
           "tableTo": "agents",
-          "columnsFrom": [
-            "agent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -3276,12 +3096,8 @@
           "name": "votes_performed_epoch_epochs_id_fk",
           "tableFrom": "votes_performed",
           "tableTo": "epochs",
-          "columnsFrom": [
-            "epoch"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["epoch"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -3289,11 +3105,7 @@
       "compositePrimaryKeys": {
         "votes_performed_pkey": {
           "name": "votes_performed_pkey",
-          "columns": [
-            "user_id",
-            "agent_id",
-            "epoch"
-          ]
+          "columns": ["user_id", "agent_id", "epoch"]
         }
       },
       "uniqueConstraints": {},
@@ -3306,46 +3118,27 @@
     "public.actor_status": {
       "name": "actor_status",
       "schema": "public",
-      "values": [
-        "active",
-        "inactive",
-        "suspended",
-        "deleted"
-      ]
+      "values": ["active", "inactive", "suspended", "deleted"]
     },
     "public.competition_agent_status": {
       "name": "competition_agent_status",
       "schema": "public",
-      "values": [
-        "active",
-        "withdrawn",
-        "disqualified"
-      ]
+      "values": ["active", "withdrawn", "disqualified"]
     },
     "public.competition_status": {
       "name": "competition_status",
       "schema": "public",
-      "values": [
-        "pending",
-        "active",
-        "ended"
-      ]
+      "values": ["pending", "active", "ended"]
     },
     "public.competition_type": {
       "name": "competition_type",
       "schema": "public",
-      "values": [
-        "trading"
-      ]
+      "values": ["trading"]
     },
     "trading_comps.cross_chain_trading_type": {
       "name": "cross_chain_trading_type",
       "schema": "trading_comps",
-      "values": [
-        "disallowAll",
-        "disallowXParent",
-        "allow"
-      ]
+      "values": ["disallowAll", "disallowXParent", "allow"]
     },
     "public.sync_data_type": {
       "name": "sync_data_type",

--- a/apps/api/e2e/setup.ts
+++ b/apps/api/e2e/setup.ts
@@ -59,6 +59,10 @@ export async function setup() {
     (arg) => arg.includes("base-trades.test") || arg.includes("base-trades"),
   );
 
+  const isSandboxTest = args.some(
+    (arg) => arg.includes("sandbox.test") || arg.includes("sandbox"),
+  );
+
   if (envTestExists) {
     // Save original values for debugging
     const originalBaseUsdcBalance = process.env.INITIAL_BASE_USDC_BALANCE;
@@ -79,6 +83,10 @@ export async function setup() {
         ignoreProcessEnv: false,
       }),
       ...(isBaseTradingTest && {
+        //
+        ignoreProcessEnv: false,
+      }),
+      ...(isSandboxTest && {
         //
         ignoreProcessEnv: false,
       }),
@@ -135,6 +143,10 @@ export async function setup() {
     console.log(
       `MAX_TRADE_PERCENTAGE set to: ${process.env.MAX_TRADE_PERCENTAGE}`,
     );
+  }
+  if (isSandboxTest) {
+    process.env.SANDBOX = "true";
+    console.log(`SANDBOX set to: ${process.env.SANDBOX}`);
   }
 
   // Ensure TEST_MODE is set

--- a/apps/api/e2e/setup.ts
+++ b/apps/api/e2e/setup.ts
@@ -147,6 +147,9 @@ export async function setup() {
   if (isSandboxTest) {
     process.env.SANDBOX = "true";
     console.log(`SANDBOX set to: ${process.env.SANDBOX}`);
+  } else {
+    process.env.SANDBOX = "false";
+    console.log(`SANDBOX set to: ${process.env.SANDBOX}`);
   }
 
   // Ensure TEST_MODE is set

--- a/apps/api/e2e/tests/object-index.test.ts
+++ b/apps/api/e2e/tests/object-index.test.ts
@@ -1,17 +1,19 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import axios from "axios";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import config from "@/config/index.js";
+
 import { ApiClient } from "../utils/api-client.js";
+import { BlockchainType } from "../utils/api-types.js";
 import { getBaseUrl } from "../utils/server.js";
-import { 
+import {
   ADMIN_EMAIL,
   ADMIN_PASSWORD,
   ADMIN_USERNAME,
   cleanupTestState,
   registerUserAndAgentAndGetClient,
-  startTestCompetition
+  startTestCompetition,
 } from "../utils/test-helpers.js";
-import { BlockchainType } from "../utils/api-types.js";
-import config from "@/config/index.js";
 
 describe("Object Index Tests", () => {
   let adminClient: ApiClient;
@@ -22,7 +24,7 @@ describe("Object Index Tests", () => {
 
   beforeEach(async () => {
     await cleanupTestState();
-    
+
     // Create admin account directly using the setup endpoint
     const adminResponse = await axios.post(`${getBaseUrl()}/api/admin/setup`, {
       username: ADMIN_USERNAME,
@@ -31,17 +33,17 @@ describe("Object Index Tests", () => {
     });
     adminApiKey = adminResponse.data.admin.apiKey;
     adminClient = new ApiClient(adminApiKey);
-    
+
     // Set up user and agent
     const setup = await registerUserAndAgentAndGetClient({ adminApiKey });
     agentClient = setup.client;
     agentId = setup.agent.id;
-    
+
     // Create and start a test competition
     const competition = await startTestCompetition(
       adminClient,
       "Test Competition for Object Index",
-      [agentId]
+      [agentId],
     );
     competitionId = competition.competition.id;
   });
@@ -55,75 +57,81 @@ describe("Object Index Tests", () => {
       // Make some trades
       const usdcTokenAddress = config.specificChainTokens.svm.usdc;
       const solTokenAddress = config.specificChainTokens.svm.sol;
-      
+
       const tradeResponse1 = await agentClient.executeTrade({
         fromToken: usdcTokenAddress,
         toToken: solTokenAddress,
         amount: "100",
         fromChain: BlockchainType.SVM,
         toChain: BlockchainType.SVM,
-        reason: "Test trade 1"
+        reason: "Test trade 1",
       });
-      
+
       if ("error" in tradeResponse1) {
         throw new Error(`Trade failed: ${tradeResponse1.error}`);
       }
-      
+
       const tradeResponse2 = await agentClient.executeTrade({
         fromToken: solTokenAddress,
         toToken: usdcTokenAddress,
         amount: "0.1",
         fromChain: BlockchainType.SVM,
         toChain: BlockchainType.SVM,
-        reason: "Test trade 2"
+        reason: "Test trade 2",
       });
-      
+
       if ("error" in tradeResponse2) {
         throw new Error(`Trade failed: ${tradeResponse2.error}`);
       }
-      
+
       // End the competition
       const endResponse = await adminClient.endCompetition(competitionId);
       if ("error" in endResponse) {
         throw new Error(`Failed to end competition: ${endResponse.error}`);
       }
-      
+
       // Wait a bit for async processing
-      await new Promise(resolve => setTimeout(resolve, 1000));
-      
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+
       // Manually sync object index after competition ends
       const syncResponse = await adminClient.syncObjectIndex({
-        competitionId
+        competitionId,
       });
-      
+
       if ("error" in syncResponse) {
         throw new Error(`Failed to sync object index: ${syncResponse.error}`);
       }
-      
+
       // Check object_index entries
       const objectIndexResponse = await adminClient.getObjectIndex({
         competitionId,
-        limit: 100
+        limit: 100,
       });
-      
+
       if ("error" in objectIndexResponse) {
-        throw new Error(`Failed to get object index: ${objectIndexResponse.error}`);
+        throw new Error(
+          `Failed to get object index: ${objectIndexResponse.error}`,
+        );
       }
-      
+
       // Verify we have entries
       expect(objectIndexResponse.success).toBe(true);
       expect(objectIndexResponse.data.entries.length).toBeGreaterThan(0);
-      
+
       // Check for different data types
-      const dataTypes = new Set(objectIndexResponse.data.entries.map(e => e.dataType));
-      
+      const dataTypes = new Set(
+        objectIndexResponse.data.entries.map((e) => e.dataType),
+      );
+
       // Should have at least trades
       expect(dataTypes.has("trade")).toBe(true);
-      
+
       // Verify trade entries
-      const tradeEntries = objectIndexResponse.data.entries.filter(e => e.dataType === "trade");
+      const tradeEntries = objectIndexResponse.data.entries.filter(
+        (e) => e.dataType === "trade",
+      );
       expect(tradeEntries.length).toBeGreaterThanOrEqual(2); // We made 2 trades
-      
+
       // Verify trade data structure
       for (const entry of tradeEntries) {
         expect(entry.competitionId).toBe(competitionId);
@@ -132,7 +140,7 @@ describe("Object Index Tests", () => {
         expect(entry.data).toBeTruthy();
         expect(entry.sizeBytes).toBeGreaterThan(0);
         expect(entry.metadata).toBeTruthy();
-        
+
         // Parse and verify trade data
         const tradeData = JSON.parse(entry.data);
         expect(tradeData).toHaveProperty("id");
@@ -148,52 +156,54 @@ describe("Object Index Tests", () => {
       // Make a trade
       const usdcTokenAddress = config.specificChainTokens.svm.usdc;
       const solTokenAddress = config.specificChainTokens.svm.sol;
-      
+
       const tradeResponse = await agentClient.executeTrade({
         fromToken: usdcTokenAddress,
         toToken: solTokenAddress,
         amount: "50",
         fromChain: BlockchainType.SVM,
         toChain: BlockchainType.SVM,
-        reason: "Test trade for sync"
+        reason: "Test trade for sync",
       });
-      
+
       if ("error" in tradeResponse) {
         throw new Error(`Trade failed: ${tradeResponse.error}`);
       }
-      
+
       // Wait a bit for trade to be processed
-      await new Promise(resolve => setTimeout(resolve, 500));
-      
+      await new Promise((resolve) => setTimeout(resolve, 500));
+
       // Manually trigger sync for specific data types
       const syncResponse = await adminClient.syncObjectIndex({
         competitionId,
-        dataTypes: ["trade"]
+        dataTypes: ["trade"],
       });
-      
+
       if ("error" in syncResponse) {
         throw new Error(`Sync failed: ${syncResponse.error}`);
       }
-      
+
       expect(syncResponse.success).toBe(true);
       expect(syncResponse.dataTypes).toContain("trade");
-      
+
       // Wait for sync to complete
-      await new Promise(resolve => setTimeout(resolve, 500));
-      
+      await new Promise((resolve) => setTimeout(resolve, 500));
+
       // Verify the data was synced
       const objectIndexResponse = await adminClient.getObjectIndex({
         competitionId,
-        dataType: "trade"
+        dataType: "trade",
       });
-      
+
       if ("error" in objectIndexResponse) {
-        throw new Error(`Failed to get object index: ${objectIndexResponse.error}`);
+        throw new Error(
+          `Failed to get object index: ${objectIndexResponse.error}`,
+        );
       }
-      
+
       expect(objectIndexResponse.success).toBe(true);
       expect(objectIndexResponse.data.entries.length).toBeGreaterThanOrEqual(1);
-      
+
       // Verify the synced trade
       const syncedTrade = objectIndexResponse.data.entries[0];
       if (syncedTrade) {
@@ -207,47 +217,49 @@ describe("Object Index Tests", () => {
       // Make some activity
       const usdcTokenAddress = config.specificChainTokens.svm.usdc;
       const solTokenAddress = config.specificChainTokens.svm.sol;
-      
+
       const tradeResponse = await agentClient.executeTrade({
         fromToken: usdcTokenAddress,
         toToken: solTokenAddress,
         amount: "25",
         fromChain: BlockchainType.SVM,
         toChain: BlockchainType.SVM,
-        reason: "Test trade for full sync"
+        reason: "Test trade for full sync",
       });
-      
+
       if ("error" in tradeResponse) {
         throw new Error(`Trade failed: ${tradeResponse.error}`);
       }
-      
+
       // Wait a bit for trade to be processed
-      await new Promise(resolve => setTimeout(resolve, 500));
-      
+      await new Promise((resolve) => setTimeout(resolve, 500));
+
       // Sync without specifying data types (should use defaults)
       const syncResponse = await adminClient.syncObjectIndex({
-        competitionId
+        competitionId,
       });
-      
+
       if ("error" in syncResponse) {
         throw new Error(`Sync failed: ${syncResponse.error}`);
       }
-      
+
       expect(syncResponse.success).toBe(true);
       expect(syncResponse.dataTypes.length).toBeGreaterThan(0);
-      
+
       // Wait for sync to complete
-      await new Promise(resolve => setTimeout(resolve, 500));
-      
+      await new Promise((resolve) => setTimeout(resolve, 500));
+
       // Check what was synced
       const objectIndexResponse = await adminClient.getObjectIndex({
-        competitionId
+        competitionId,
       });
-      
+
       if ("error" in objectIndexResponse) {
-        throw new Error(`Failed to get object index: ${objectIndexResponse.error}`);
+        throw new Error(
+          `Failed to get object index: ${objectIndexResponse.error}`,
+        );
       }
-      
+
       expect(objectIndexResponse.success).toBe(true);
       expect(objectIndexResponse.data.entries.length).toBeGreaterThan(0);
     });
@@ -256,7 +268,7 @@ describe("Object Index Tests", () => {
       // Create multiple trades
       const usdcTokenAddress = config.specificChainTokens.svm.usdc;
       const solTokenAddress = config.specificChainTokens.svm.sol;
-      
+
       for (let i = 0; i < 5; i++) {
         const tradeResponse = await agentClient.executeTrade({
           fromToken: usdcTokenAddress,
@@ -264,61 +276,61 @@ describe("Object Index Tests", () => {
           amount: String(10 + i),
           fromChain: BlockchainType.SVM,
           toChain: BlockchainType.SVM,
-          reason: `Test trade ${i}`
+          reason: `Test trade ${i}`,
         });
-        
+
         if ("error" in tradeResponse) {
           throw new Error(`Trade ${i} failed: ${tradeResponse.error}`);
         }
       }
-      
+
       // Wait for trades to be processed
-      await new Promise(resolve => setTimeout(resolve, 1000));
-      
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+
       // Sync the trades
       const syncResponse = await adminClient.syncObjectIndex({
         competitionId,
-        dataTypes: ["trade"]
+        dataTypes: ["trade"],
       });
-      
+
       if ("error" in syncResponse) {
         throw new Error(`Sync failed: ${syncResponse.error}`);
       }
-      
+
       // Wait for sync to complete
-      await new Promise(resolve => setTimeout(resolve, 500));
-      
+      await new Promise((resolve) => setTimeout(resolve, 500));
+
       // Test pagination
       const page1 = await adminClient.getObjectIndex({
         competitionId,
         dataType: "trade",
         limit: 2,
-        offset: 0
+        offset: 0,
       });
-      
+
       if ("error" in page1) {
         throw new Error(`Failed to get page 1: ${page1.error}`);
       }
-      
+
       const page2 = await adminClient.getObjectIndex({
         competitionId,
         dataType: "trade",
         limit: 2,
-        offset: 2
+        offset: 2,
       });
-      
+
       if ("error" in page2) {
         throw new Error(`Failed to get page 2: ${page2.error}`);
       }
-      
+
       expect(page1.data.entries.length).toBe(2);
       expect(page2.data.entries.length).toBe(2);
       expect(page1.data.pagination.total).toBeGreaterThanOrEqual(5);
       expect(page2.data.pagination.total).toBeGreaterThanOrEqual(5);
-      
+
       // Ensure different entries
-      const page1Ids = page1.data.entries.map(e => e.id);
-      const page2Ids = page2.data.entries.map(e => e.id);
+      const page1Ids = page1.data.entries.map((e) => e.id);
+      const page2Ids = page2.data.entries.map((e) => e.id);
       expect(page1Ids).not.toEqual(page2Ids);
     });
 
@@ -327,87 +339,95 @@ describe("Object Index Tests", () => {
       const setup2 = await registerUserAndAgentAndGetClient({ adminApiKey });
       const agent2Client = setup2.client;
       const agent2Id = setup2.agent.id;
-      
+
       // End the existing competition first
       const endResponse = await adminClient.endCompetition(competitionId);
       if ("error" in endResponse) {
         console.error("Failed to end existing competition:", endResponse.error);
       }
-      
+
       // Wait a bit for the competition to be fully ended
-      await new Promise(resolve => setTimeout(resolve, 500));
-      
+      await new Promise((resolve) => setTimeout(resolve, 500));
+
       // Create a new competition with both agents
       const newCompetition = await startTestCompetition(
         adminClient,
         "Test Competition for Multiple Agents",
-        [agentId, agent2Id]
+        [agentId, agent2Id],
       );
       const newCompetitionId = newCompetition.competition.id;
-      
+
       // Make trades with both agents
       const usdcTokenAddress = config.specificChainTokens.svm.usdc;
       const solTokenAddress = config.specificChainTokens.svm.sol;
-      
+
       await agentClient.executeTrade({
         fromToken: usdcTokenAddress,
         toToken: solTokenAddress,
         amount: "100",
         fromChain: BlockchainType.SVM,
         toChain: BlockchainType.SVM,
-        reason: "Agent 1 trade"
+        reason: "Agent 1 trade",
       });
-      
+
       await agent2Client.executeTrade({
         fromToken: usdcTokenAddress,
         toToken: solTokenAddress,
         amount: "200",
         fromChain: BlockchainType.SVM,
         toChain: BlockchainType.SVM,
-        reason: "Agent 2 trade"
+        reason: "Agent 2 trade",
       });
-      
+
       // Wait for trades to be processed
-      await new Promise(resolve => setTimeout(resolve, 1000));
-      
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+
       // Sync trades
       const syncResp = await adminClient.syncObjectIndex({
         competitionId: newCompetitionId,
-        dataTypes: ["trade"]
+        dataTypes: ["trade"],
       });
-      
+
       if ("error" in syncResp) {
         throw new Error(`Sync failed: ${syncResp.error}`);
       }
-      
+
       // Wait for sync to complete
-      await new Promise(resolve => setTimeout(resolve, 500));
-      
+      await new Promise((resolve) => setTimeout(resolve, 500));
+
       // Filter by first agent
       const agent1Entries = await adminClient.getObjectIndex({
         competitionId: newCompetitionId,
         agentId,
-        dataType: "trade"
+        dataType: "trade",
       });
-      
+
       if ("error" in agent1Entries) {
-        throw new Error(`Failed to get agent 1 entries: ${agent1Entries.error}`);
+        throw new Error(
+          `Failed to get agent 1 entries: ${agent1Entries.error}`,
+        );
       }
-      
+
       // Filter by second agent
       const agent2Entries = await adminClient.getObjectIndex({
         competitionId: newCompetitionId,
         agentId: agent2Id,
-        dataType: "trade"
+        dataType: "trade",
       });
-      
+
       if ("error" in agent2Entries) {
-        throw new Error(`Failed to get agent 2 entries: ${agent2Entries.error}`);
+        throw new Error(
+          `Failed to get agent 2 entries: ${agent2Entries.error}`,
+        );
       }
-      
+
       // Verify filtering works
-      expect(agent1Entries.data.entries.every(e => e.agentId === agentId)).toBe(true);
-      expect(agent2Entries.data.entries.every(e => e.agentId === agent2Id)).toBe(true);
+      expect(
+        agent1Entries.data.entries.every((e) => e.agentId === agentId),
+      ).toBe(true);
+      expect(
+        agent2Entries.data.entries.every((e) => e.agentId === agent2Id),
+      ).toBe(true);
       expect(agent1Entries.data.entries.length).toBeGreaterThanOrEqual(1);
       expect(agent2Entries.data.entries.length).toBeGreaterThanOrEqual(1);
     });
@@ -416,20 +436,20 @@ describe("Object Index Tests", () => {
   describe("Error handling", () => {
     it("should require admin authentication", async () => {
       const nonAdminClient = new ApiClient("invalid-api-key");
-      
+
       const syncResponse = await nonAdminClient.syncObjectIndex({
-        competitionId
+        competitionId,
       });
-      
+
       expect("error" in syncResponse).toBe(true);
       if ("error" in syncResponse) {
         expect(syncResponse.status).toBe(401);
       }
-      
+
       const getResponse = await nonAdminClient.getObjectIndex({
-        competitionId
+        competitionId,
       });
-      
+
       expect("error" in getResponse).toBe(true);
       if ("error" in getResponse) {
         expect(getResponse.status).toBe(401);
@@ -439,9 +459,9 @@ describe("Object Index Tests", () => {
     it("should validate data types", async () => {
       const syncResponse = await adminClient.syncObjectIndex({
         competitionId,
-        dataTypes: ["invalid_type"]
+        dataTypes: ["invalid_type"],
       });
-      
+
       expect("error" in syncResponse).toBe(true);
       if ("error" in syncResponse) {
         expect(syncResponse.status).toBe(400);
@@ -450,20 +470,20 @@ describe("Object Index Tests", () => {
 
     it("should validate UUIDs", async () => {
       const invalidUuid = "not-a-uuid";
-      
+
       const syncResponse = await adminClient.syncObjectIndex({
-        competitionId: invalidUuid
+        competitionId: invalidUuid,
       });
-      
+
       expect("error" in syncResponse).toBe(true);
       if ("error" in syncResponse) {
         expect(syncResponse.status).toBe(400);
       }
-      
+
       const getResponse = await adminClient.getObjectIndex({
-        competitionId: invalidUuid
+        competitionId: invalidUuid,
       });
-      
+
       expect("error" in getResponse).toBe(true);
       if ("error" in getResponse) {
         expect(getResponse.status).toBe(400);

--- a/apps/api/e2e/tests/sandbox.test.ts
+++ b/apps/api/e2e/tests/sandbox.test.ts
@@ -16,6 +16,7 @@ import {
   cleanupTestState,
   createTestClient,
   generateRandomEthAddress,
+  wait,
 } from "@/e2e/utils/test-helpers.js";
 
 describe("Sandbox Mode", () => {
@@ -98,6 +99,9 @@ describe("Sandbox Mode", () => {
 
       expect(agentResponse.success).toBe(true);
       const agent = (agentResponse as AdminAgentResponse).agent;
+
+      // Wait for sandbox auto-join logic to complete
+      await wait(1500);
 
       // Verify the agent was automatically joined to the competition
       const competitionAgentsResponse = await adminClient.getCompetitionAgents(
@@ -231,6 +235,9 @@ describe("Sandbox Mode", () => {
       expect(agentResponse.success).toBe(true);
       const agent = (agentResponse as AdminAgentResponse).agent;
 
+      // Wait for sandbox auto-join logic to complete
+      await wait(1500);
+
       // Verify the agent was joined to the competition
       const competitionAgentsResponse = await adminClient.getCompetitionAgents(
         competition.id,
@@ -260,6 +267,9 @@ describe("Sandbox Mode", () => {
       expect(duplicateAgentResponse.success).toBe(true);
       const duplicateAgent = (duplicateAgentResponse as AdminAgentResponse)
         .agent;
+
+      // Wait for sandbox auto-join logic to complete for the second agent
+      await wait(1500);
 
       // Verify both agents are in the competition (no duplicates, no errors)
       const finalCompetitionAgentsResponse =

--- a/apps/api/e2e/tests/sandbox.test.ts
+++ b/apps/api/e2e/tests/sandbox.test.ts
@@ -6,6 +6,7 @@ import {
   AdminAgentResponse,
   CompetitionAgentsResponse,
   CreateCompetitionResponse,
+  UserRegistrationResponse,
 } from "@/e2e/utils/api-types.js";
 import { getBaseUrl } from "@/e2e/utils/server.js";
 import {
@@ -24,22 +25,40 @@ describe("Sandbox Mode", () => {
   beforeEach(async () => {
     await cleanupTestState();
 
-    // Create admin account
-    const response = await axios.post(`${getBaseUrl()}/api/admin/create`, {
+    // Create admin account directly using the setup endpoint
+    const response = await axios.post(`${getBaseUrl()}/api/admin/setup`, {
       username: ADMIN_USERNAME,
       password: ADMIN_PASSWORD,
       email: ADMIN_EMAIL,
     });
 
-    adminApiKey = response.data.apiKey;
-    adminClient = createTestClient(adminApiKey);
+    // Store the admin API key for authentication
+    adminApiKey = response.data.admin.apiKey;
+    adminClient = createTestClient();
+
+    // Login as admin
+    const loginSuccess = await adminClient.loginAsAdmin(adminApiKey);
+    expect(loginSuccess).toBe(true);
   });
 
   describe("when SANDBOX=true", () => {
     // Note: SANDBOX=true is set automatically by the test setup when running sandbox tests
 
     test("should automatically join newly registered agent to active competition", async () => {
-      // Create and start a competition
+      // First create a dummy user+agent to start the competition with (to avoid "no agents provided" error)
+      const dummyUserResponse = await adminClient.registerUser({
+        walletAddress: generateRandomEthAddress(),
+        name: "Dummy User",
+        email: "dummy@example.com",
+        agentName: "Dummy Agent",
+        agentDescription: "Dummy agent for competition startup",
+        agentWalletAddress: generateRandomEthAddress(),
+      });
+      expect(dummyUserResponse.success).toBe(true);
+      const dummyAgent = (dummyUserResponse as UserRegistrationResponse).agent;
+      expect(dummyAgent).toBeDefined();
+
+      // Create and start a competition with the dummy agent
       const competitionResponse = await adminClient.createCompetition(
         "Test Competition",
         "A test competition for sandbox mode",
@@ -50,14 +69,24 @@ describe("Sandbox Mode", () => {
 
       const startResponse = await adminClient.startExistingCompetition(
         competition.id,
-        [],
+        [dummyAgent!.id],
       );
       expect(startResponse).toHaveProperty("success", true);
 
-      // Register a new agent
+      // Now register a user first (just the user, no agent)
+      const userResponse = await adminClient.registerUser({
+        walletAddress: generateRandomEthAddress(),
+        name: "Test User",
+        email: "testuser@example.com",
+        // Note: NOT providing agent parameters to create just a user
+      });
+      expect(userResponse.success).toBe(true);
+      const user = (userResponse as UserRegistrationResponse).user;
+
+      // Then register an agent for that user (this should trigger sandbox auto-join)
       const agentResponse = await adminClient.registerAgent({
         user: {
-          walletAddress: generateRandomEthAddress(),
+          id: user.id,
         },
         agent: {
           name: "Test Agent",
@@ -84,10 +113,19 @@ describe("Sandbox Mode", () => {
     });
 
     test("should handle case when no active competition exists", async () => {
-      // Register a new agent when no competition is active
+      // Register a user first (just the user, no agent)
+      const userResponse = await adminClient.registerUser({
+        walletAddress: generateRandomEthAddress(),
+        name: "Test User No Competition",
+        email: "testuser2@example.com",
+      });
+      expect(userResponse.success).toBe(true);
+      const user = (userResponse as UserRegistrationResponse).user;
+
+      // Then register an agent for that user when no competition is active
       const agentResponse = await adminClient.registerAgent({
         user: {
-          walletAddress: generateRandomEthAddress(),
+          id: user.id,
         },
         agent: {
           name: "Test Agent No Competition",
@@ -111,10 +149,19 @@ describe("Sandbox Mode", () => {
       );
       expect(competitionResponse.success).toBe(true);
 
-      // Register a new agent - should succeed even if auto-join fails
+      // Register a user first (just the user, no agent)
+      const userResponse = await adminClient.registerUser({
+        walletAddress: generateRandomEthAddress(),
+        name: "Test User Graceful Fail",
+        email: "testuser3@example.com",
+      });
+      expect(userResponse.success).toBe(true);
+      const user = (userResponse as UserRegistrationResponse).user;
+
+      // Then register an agent for that user - should succeed even if auto-join fails
       const agentResponse = await adminClient.registerAgent({
         user: {
-          walletAddress: generateRandomEthAddress(),
+          id: user.id,
         },
         agent: {
           name: "Test Agent Graceful Fail",
@@ -131,63 +178,24 @@ describe("Sandbox Mode", () => {
     });
   });
 
-  describe("when SANDBOX=false or not set", () => {
-    // Note: When not running sandbox-specific tests, SANDBOX will be false/undefined
-
-    test("should NOT automatically join newly registered agent to active competition", async () => {
-      // Create and start a competition
-      const competitionResponse = await adminClient.createCompetition(
-        "Test Competition No Auto Join",
-        "A test competition without auto-join",
-      );
-      expect(competitionResponse.success).toBe(true);
-      const competition = (competitionResponse as CreateCompetitionResponse)
-        .competition;
-
-      const startResponse = await adminClient.startExistingCompetition(
-        competition.id,
-        [],
-      );
-      expect(startResponse.success).toBe(true);
-
-      // Register a new agent
-      const agentResponse = await adminClient.registerAgent({
-        user: {
-          walletAddress: generateRandomEthAddress(),
-        },
-        agent: {
-          name: "Test Agent No Auto Join",
-          email: "test4@example.com",
-          description: "A test agent that should not auto-join",
-          walletAddress: generateRandomEthAddress(),
-        },
-      });
-
-      expect(agentResponse.success).toBe(true);
-      const agent = (agentResponse as AdminAgentResponse).agent;
-
-      // Verify the agent was NOT automatically joined to the competition
-      const competitionAgentsResponse = await adminClient.getCompetitionAgents(
-        competition.id,
-      );
-      expect(competitionAgentsResponse.success).toBe(true);
-
-      const competitionAgents = (
-        competitionAgentsResponse as CompetitionAgentsResponse
-      ).agents;
-      const joinedAgent = competitionAgents.find((a) => a.id === agent.id);
-      expect(joinedAgent).toBeUndefined();
-    });
-  });
-
   describe("configuration", () => {
     test("should have sandbox mode enabled when running sandbox tests", async () => {
       // This test verifies that the environment variable is properly set by the test setup
       // The actual sandbox behavior is tested in the other test cases
 
+      // Register a user first (just the user, no agent)
+      const userResponse = await adminClient.registerUser({
+        walletAddress: generateRandomEthAddress(),
+        name: "Test User Config Check",
+        email: "testuser-config@example.com",
+      });
+      expect(userResponse.success).toBe(true);
+      const user = (userResponse as UserRegistrationResponse).user;
+
+      // Then register an agent for that user
       const agentResponse = await adminClient.registerAgent({
         user: {
-          walletAddress: generateRandomEthAddress(),
+          id: user.id,
         },
         agent: {
           name: "Test Agent Config Check",

--- a/apps/api/e2e/tests/sandbox.test.ts
+++ b/apps/api/e2e/tests/sandbox.test.ts
@@ -42,7 +42,7 @@ describe("Sandbox Mode", () => {
     expect(loginSuccess).toBe(true);
   });
 
-  describe("when SANDBOX=true", () => {
+  describe("when SANDBOX=true, trigger automatic adding agents to active sandbox competition", () => {
     // Note: SANDBOX=true is set automatically by the test setup when running sandbox tests
 
     test("should automatically join newly registered agent to active competition", async () => {
@@ -145,7 +145,7 @@ describe("Sandbox Mode", () => {
       expect(agent.id).toBeDefined();
     });
 
-    test("should gracefully handle auto-join failures", async () => {
+    test("sandbox should gracefully handle auto-join failures", async () => {
       // Create a competition but don't start it (PENDING state)
       const competitionResponse = await adminClient.createCompetition(
         "Pending Competition",
@@ -181,7 +181,7 @@ describe("Sandbox Mode", () => {
       expect(agent.id).toBeDefined();
     });
 
-    test("should skip auto-join if agent is already in the competition", async () => {
+    test("sandbox should skip auto-join if agent is already in the competition", async () => {
       // First create a dummy user+agent to start the competition with
       const dummyUserResponse = await adminClient.registerUser({
         walletAddress: generateRandomEthAddress(),
@@ -291,7 +291,7 @@ describe("Sandbox Mode", () => {
     });
   });
 
-  describe("configuration", () => {
+  describe("sandbox configuration", () => {
     test("should have sandbox mode enabled when running sandbox tests", async () => {
       // This test verifies that the environment variable is properly set by the test setup
       // The actual sandbox behavior is tested in the other test cases

--- a/apps/api/e2e/tests/sandbox.test.ts
+++ b/apps/api/e2e/tests/sandbox.test.ts
@@ -1,0 +1,205 @@
+import axios from "axios";
+import { beforeEach, describe, expect, test } from "vitest";
+
+import { ApiClient } from "@/e2e/utils/api-client.js";
+import {
+  AdminAgentResponse,
+  CompetitionAgentsResponse,
+  CreateCompetitionResponse,
+} from "@/e2e/utils/api-types.js";
+import { getBaseUrl } from "@/e2e/utils/server.js";
+import {
+  ADMIN_EMAIL,
+  ADMIN_PASSWORD,
+  ADMIN_USERNAME,
+  cleanupTestState,
+  createTestClient,
+  generateRandomEthAddress,
+} from "@/e2e/utils/test-helpers.js";
+
+describe("Sandbox Mode", () => {
+  let adminApiKey: string;
+  let adminClient: ApiClient;
+
+  beforeEach(async () => {
+    await cleanupTestState();
+
+    // Create admin account
+    const response = await axios.post(`${getBaseUrl()}/api/admin/create`, {
+      username: ADMIN_USERNAME,
+      password: ADMIN_PASSWORD,
+      email: ADMIN_EMAIL,
+    });
+
+    adminApiKey = response.data.apiKey;
+    adminClient = createTestClient(adminApiKey);
+  });
+
+  describe("when SANDBOX=true", () => {
+    // Note: SANDBOX=true is set automatically by the test setup when running sandbox tests
+
+    test("should automatically join newly registered agent to active competition", async () => {
+      // Create and start a competition
+      const competitionResponse = await adminClient.createCompetition(
+        "Test Competition",
+        "A test competition for sandbox mode",
+      );
+      expect(competitionResponse.success).toBe(true);
+      const competition = (competitionResponse as CreateCompetitionResponse)
+        .competition;
+
+      const startResponse = await adminClient.startExistingCompetition(
+        competition.id,
+        [],
+      );
+      expect(startResponse).toHaveProperty("success", true);
+
+      // Register a new agent
+      const agentResponse = await adminClient.registerAgent({
+        user: {
+          walletAddress: generateRandomEthAddress(),
+        },
+        agent: {
+          name: "Test Agent",
+          email: "test@example.com",
+          description: "A test agent",
+          walletAddress: generateRandomEthAddress(),
+        },
+      });
+
+      expect(agentResponse.success).toBe(true);
+      const agent = (agentResponse as AdminAgentResponse).agent;
+
+      // Verify the agent was automatically joined to the competition
+      const competitionAgentsResponse = await adminClient.getCompetitionAgents(
+        competition.id,
+      );
+      expect(competitionAgentsResponse.success).toBe(true);
+
+      const competitionAgents = (
+        competitionAgentsResponse as CompetitionAgentsResponse
+      ).agents;
+      const joinedAgent = competitionAgents.find((a) => a.id === agent.id);
+      expect(joinedAgent).toBeDefined();
+    });
+
+    test("should handle case when no active competition exists", async () => {
+      // Register a new agent when no competition is active
+      const agentResponse = await adminClient.registerAgent({
+        user: {
+          walletAddress: generateRandomEthAddress(),
+        },
+        agent: {
+          name: "Test Agent No Competition",
+          email: "test2@example.com",
+          description: "A test agent with no active competition",
+          walletAddress: generateRandomEthAddress(),
+        },
+      });
+
+      // Should still succeed in registering the agent
+      expect(agentResponse.success).toBe(true);
+      const agent = (agentResponse as AdminAgentResponse).agent;
+      expect(agent.id).toBeDefined();
+    });
+
+    test("should gracefully handle auto-join failures", async () => {
+      // Create a competition but don't start it (PENDING state)
+      const competitionResponse = await adminClient.createCompetition(
+        "Pending Competition",
+        "A competition that's not started yet",
+      );
+      expect(competitionResponse.success).toBe(true);
+
+      // Register a new agent - should succeed even if auto-join fails
+      const agentResponse = await adminClient.registerAgent({
+        user: {
+          walletAddress: generateRandomEthAddress(),
+        },
+        agent: {
+          name: "Test Agent Graceful Fail",
+          email: "test3@example.com",
+          description: "A test agent for graceful failure",
+          walletAddress: generateRandomEthAddress(),
+        },
+      });
+
+      // Agent registration should still succeed
+      expect(agentResponse.success).toBe(true);
+      const agent = (agentResponse as AdminAgentResponse).agent;
+      expect(agent.id).toBeDefined();
+    });
+  });
+
+  describe("when SANDBOX=false or not set", () => {
+    // Note: When not running sandbox-specific tests, SANDBOX will be false/undefined
+
+    test("should NOT automatically join newly registered agent to active competition", async () => {
+      // Create and start a competition
+      const competitionResponse = await adminClient.createCompetition(
+        "Test Competition No Auto Join",
+        "A test competition without auto-join",
+      );
+      expect(competitionResponse.success).toBe(true);
+      const competition = (competitionResponse as CreateCompetitionResponse)
+        .competition;
+
+      const startResponse = await adminClient.startExistingCompetition(
+        competition.id,
+        [],
+      );
+      expect(startResponse.success).toBe(true);
+
+      // Register a new agent
+      const agentResponse = await adminClient.registerAgent({
+        user: {
+          walletAddress: generateRandomEthAddress(),
+        },
+        agent: {
+          name: "Test Agent No Auto Join",
+          email: "test4@example.com",
+          description: "A test agent that should not auto-join",
+          walletAddress: generateRandomEthAddress(),
+        },
+      });
+
+      expect(agentResponse.success).toBe(true);
+      const agent = (agentResponse as AdminAgentResponse).agent;
+
+      // Verify the agent was NOT automatically joined to the competition
+      const competitionAgentsResponse = await adminClient.getCompetitionAgents(
+        competition.id,
+      );
+      expect(competitionAgentsResponse.success).toBe(true);
+
+      const competitionAgents = (
+        competitionAgentsResponse as CompetitionAgentsResponse
+      ).agents;
+      const joinedAgent = competitionAgents.find((a) => a.id === agent.id);
+      expect(joinedAgent).toBeUndefined();
+    });
+  });
+
+  describe("configuration", () => {
+    test("should have sandbox mode enabled when running sandbox tests", async () => {
+      // This test verifies that the environment variable is properly set by the test setup
+      // The actual sandbox behavior is tested in the other test cases
+
+      const agentResponse = await adminClient.registerAgent({
+        user: {
+          walletAddress: generateRandomEthAddress(),
+        },
+        agent: {
+          name: "Test Agent Config Check",
+          email: "test-config@example.com",
+          description: "Agent to verify config is working",
+          walletAddress: generateRandomEthAddress(),
+        },
+      });
+      expect(agentResponse).toHaveProperty("success", true);
+
+      // The actual sandbox behavior (auto-joining) is tested in the other test cases
+      // This test just ensures the basic registration works when sandbox mode is enabled
+    });
+  });
+});

--- a/apps/api/e2e/utils/api-client.ts
+++ b/apps/api/e2e/utils/api-client.ts
@@ -1572,9 +1572,20 @@ export class ApiClient {
   async syncObjectIndex(params?: {
     competitionId?: string;
     dataTypes?: string[];
-  }): Promise<{ success: boolean; message: string; dataTypes: string[]; competitionId: string } | ErrorResponse> {
+  }): Promise<
+    | {
+        success: boolean;
+        message: string;
+        dataTypes: string[];
+        competitionId: string;
+      }
+    | ErrorResponse
+  > {
     try {
-      const response = await this.axiosInstance.post("/api/admin/object-index/sync", params || {});
+      const response = await this.axiosInstance.post(
+        "/api/admin/object-index/sync",
+        params || {},
+      );
       return response.data;
     } catch (error) {
       return this.handleApiError(error, "sync object index");
@@ -1591,30 +1602,34 @@ export class ApiClient {
     dataType?: string;
     limit?: number;
     offset?: number;
-  }): Promise<{
-    success: boolean;
-    data: {
-      entries: Array<{
-        id: string;
-        competitionId: string | null;
-        agentId: string;
-        dataType: string;
-        data: string;
-        sizeBytes: number;
-        metadata: Record<string, unknown>;
-        eventTimestamp: string;
-        createdAt: string;
-      }>;
-      pagination: {
-        total: number;
-        limit: number;
-        offset: number;
-      };
-    };
-  } | ErrorResponse> {
+  }): Promise<
+    | {
+        success: boolean;
+        data: {
+          entries: Array<{
+            id: string;
+            competitionId: string | null;
+            agentId: string;
+            dataType: string;
+            data: string;
+            sizeBytes: number;
+            metadata: Record<string, unknown>;
+            eventTimestamp: string;
+            createdAt: string;
+          }>;
+          pagination: {
+            total: number;
+            limit: number;
+            offset: number;
+          };
+        };
+      }
+    | ErrorResponse
+  > {
     try {
       const queryParams = new URLSearchParams();
-      if (params?.competitionId) queryParams.append("competitionId", params.competitionId);
+      if (params?.competitionId)
+        queryParams.append("competitionId", params.competitionId);
       if (params?.agentId) queryParams.append("agentId", params.agentId);
       if (params?.dataType) queryParams.append("dataType", params.dataType);
       if (params?.limit) queryParams.append("limit", String(params.limit));

--- a/apps/api/e2e/utils/log-reporter.ts
+++ b/apps/api/e2e/utils/log-reporter.ts
@@ -40,7 +40,7 @@ class LogReporter implements Reporter {
     this.log(`[Test] Starting test: ${testCase.fullName}`);
 
     // Update test context manager with current test name
-    const testName = testCase.fullName || testCase.name || "";
+    const testName = (testCase.fullName || testCase.name || "").toLowerCase();
     if (testName.includes("sandbox")) {
       testContextManager.setCurrentTestFile("sandbox.test");
     } else if (testName.includes("leaderboard")) {

--- a/apps/api/e2e/utils/log-reporter.ts
+++ b/apps/api/e2e/utils/log-reporter.ts
@@ -9,6 +9,8 @@ import type {
 } from "vitest/node";
 import type { TestCase } from "vitest/node";
 
+import { testContextManager } from "./test-context-manager.js";
+
 /**
  * Custom Vitest reporter that logs test results to e2e-server.log file
  * and tracks test failures through Vitest's proper reporter API.
@@ -36,6 +38,20 @@ class LogReporter implements Reporter {
    */
   onTestCaseReady(testCase: TestCase): void {
     this.log(`[Test] Starting test: ${testCase.fullName}`);
+
+    // Update test context manager with current test name
+    const testName = testCase.fullName || testCase.name || "";
+    if (testName.includes("sandbox")) {
+      testContextManager.setCurrentTestFile("sandbox.test");
+    } else if (testName.includes("leaderboard")) {
+      testContextManager.setCurrentTestFile("leaderboard-access.test");
+    } else if (testName.includes("trading")) {
+      testContextManager.setCurrentTestFile("trading.test");
+    } else if (testName.includes("base-trades")) {
+      testContextManager.setCurrentTestFile("base-trades.test");
+    } else {
+      testContextManager.setCurrentTestFile("other.test");
+    }
   }
 
   /**

--- a/apps/api/e2e/utils/test-context-manager.ts
+++ b/apps/api/e2e/utils/test-context-manager.ts
@@ -1,0 +1,270 @@
+/**
+ * Test Context Manager
+ *
+ * This utility manages global test context and environment variables during test execution.
+ * It allows tests to dynamically configure environment variables based on the current test context.
+ */
+import fs from "fs";
+import path from "path";
+
+/**
+ * Interface for test-specific environment configurations
+ */
+interface TestEnvironmentConfig {
+  [key: string]: string | undefined;
+}
+
+/**
+ * Interface for test context information
+ */
+interface TestContext {
+  testFile?: string;
+  testName?: string;
+  suiteName?: string;
+  environmentOverrides?: TestEnvironmentConfig;
+}
+
+/**
+ * Interface for debug information returned by getDebugInfo()
+ */
+interface TestContextDebugInfo {
+  currentContext: TestContext;
+  originalEnvValues: Record<string, string | undefined>;
+  initialized: boolean;
+  relevantEnvVars: {
+    SANDBOX?: string;
+    DISABLE_PARTICIPANT_LEADERBOARD_ACCESS?: string;
+    MAX_TRADE_PERCENTAGE?: string;
+    TEST_MODE?: string;
+  };
+}
+
+/**
+ * Global test context manager singleton
+ */
+class TestContextManager {
+  private static instance: TestContextManager;
+  private currentContext: TestContext = {};
+  private originalEnvValues: Record<string, string | undefined> = {};
+  private initialized = false;
+
+  private constructor() {}
+
+  /**
+   * Get the singleton instance
+   */
+  static getInstance(): TestContextManager {
+    if (!TestContextManager.instance) {
+      TestContextManager.instance = new TestContextManager();
+    }
+    return TestContextManager.instance;
+  }
+
+  /**
+   * Initialize the test context manager
+   */
+  initialize(): void {
+    if (this.initialized) {
+      return;
+    }
+
+    this.log("Initializing Test Context Manager");
+    this.initialized = true;
+  }
+
+  /**
+   * Set the current test context
+   */
+  setTestContext(context: TestContext): void {
+    this.currentContext = { ...context };
+    this.log(`Test context updated: ${JSON.stringify(context)}`);
+
+    // Apply environment overrides if provided
+    if (context.environmentOverrides) {
+      this.applyEnvironmentOverrides(context.environmentOverrides);
+    } else {
+      // Auto-detect environment overrides based on test file patterns
+      this.autoApplyEnvironmentOverrides();
+    }
+  }
+
+  /**
+   * Get the current test context
+   */
+  getCurrentContext(): TestContext {
+    return { ...this.currentContext };
+  }
+
+  /**
+   * Get a specific environment variable, considering any active overrides
+   */
+  getEnvironmentVariable(key: string): string | undefined {
+    return process.env[key];
+  }
+
+  /**
+   * Apply environment variable overrides
+   */
+  private applyEnvironmentOverrides(overrides: TestEnvironmentConfig): void {
+    for (const [key, value] of Object.entries(overrides)) {
+      // Store original value if we haven't already
+      if (!(key in this.originalEnvValues)) {
+        this.originalEnvValues[key] = process.env[key];
+      }
+
+      // Apply override
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+
+      this.log(`Environment override applied: ${key}=${value || "undefined"}`);
+    }
+  }
+
+  /**
+   * Auto-detect and apply environment overrides based on test file patterns
+   */
+  private autoApplyEnvironmentOverrides(): void {
+    const testFile = this.currentContext.testFile;
+    if (!testFile) {
+      return;
+    }
+
+    const overrides: TestEnvironmentConfig = {};
+
+    // Pattern-based environment configuration
+    if (testFile.includes("sandbox.test")) {
+      overrides.SANDBOX = "true";
+    } else {
+      overrides.SANDBOX = "false";
+    }
+
+    if (testFile.includes("leaderboard-access.test")) {
+      overrides.DISABLE_PARTICIPANT_LEADERBOARD_ACCESS = "true";
+    } else {
+      overrides.DISABLE_PARTICIPANT_LEADERBOARD_ACCESS = "false";
+    }
+
+    if (testFile.includes("trading.test")) {
+      overrides.MAX_TRADE_PERCENTAGE = "10";
+    }
+
+    if (testFile.includes("base-trades.test")) {
+      overrides.MAX_TRADE_PERCENTAGE = "15";
+    }
+
+    // Apply the detected overrides
+    if (Object.keys(overrides).length > 0) {
+      this.applyEnvironmentOverrides(overrides);
+    }
+  }
+
+  /**
+   * Clear test context and restore original environment variables
+   */
+  clearTestContext(): void {
+    this.log("Clearing test context and restoring environment variables");
+
+    // Restore original environment variables
+    for (const [key, originalValue] of Object.entries(this.originalEnvValues)) {
+      if (originalValue === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = originalValue;
+      }
+    }
+
+    this.originalEnvValues = {};
+    this.currentContext = {};
+  }
+
+  /**
+   * Reset the manager (for testing purposes)
+   */
+  reset(): void {
+    this.clearTestContext();
+    this.initialized = false;
+  }
+
+  /**
+   * Log messages with test context
+   */
+  private log(message: string): void {
+    const logFile = path.resolve(__dirname, "../e2e-server.log");
+    const timestamp = new Date().toISOString();
+    const logMessage = `[${timestamp}] [TestContextManager] ${message}`;
+
+    console.log(logMessage);
+
+    // Append to log file if it exists
+    try {
+      if (fs.existsSync(logFile)) {
+        fs.appendFileSync(logFile, logMessage + "\n");
+      }
+    } catch (error) {
+      // Ignore file write errors
+      console.error(
+        `[TestContextManager] Failed to write to log file: ${error}`,
+      );
+    }
+  }
+
+  /**
+   * Get debug information about the current state
+   */
+  getDebugInfo(): TestContextDebugInfo {
+    return {
+      currentContext: this.currentContext,
+      originalEnvValues: this.originalEnvValues,
+      initialized: this.initialized,
+      relevantEnvVars: {
+        SANDBOX: process.env.SANDBOX,
+        DISABLE_PARTICIPANT_LEADERBOARD_ACCESS:
+          process.env.DISABLE_PARTICIPANT_LEADERBOARD_ACCESS,
+        MAX_TRADE_PERCENTAGE: process.env.MAX_TRADE_PERCENTAGE,
+        TEST_MODE: process.env.TEST_MODE,
+      },
+    };
+  }
+}
+
+// Export singleton instance
+export const testContextManager = TestContextManager.getInstance();
+
+/**
+ * Helper function to extract test file name from the call stack
+ */
+export function getCurrentTestFile(): string | undefined {
+  const stack = new Error().stack;
+  if (!stack) return undefined;
+
+  const lines = stack.split("\n");
+  for (const line of lines) {
+    if (line.includes(".test.") && line.includes("e2e/tests/")) {
+      const match = line.match(/\/e2e\/tests\/([^)]+\.test\.[jt]s)/);
+      return match ? match[1] : undefined;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Helper function to set up test context with automatic file detection
+ */
+export function setupTestContext(options: Partial<TestContext> = {}): void {
+  const testFile = options.testFile || getCurrentTestFile();
+
+  testContextManager.setTestContext({
+    testFile,
+    ...options,
+  });
+}
+
+/**
+ * Helper function to clear test context
+ */
+export function clearTestContext(): void {
+  testContextManager.clearTestContext();
+}

--- a/apps/api/e2e/utils/test-context-manager.ts
+++ b/apps/api/e2e/utils/test-context-manager.ts
@@ -68,7 +68,6 @@ class TestContextManager {
       return;
     }
 
-    this.log("Initializing Test Context Manager");
     this.initialized = true;
   }
 
@@ -77,7 +76,6 @@ class TestContextManager {
    */
   setTestContext(context: TestContext): void {
     this.currentContext = { ...context };
-    this.log(`Test context updated: ${JSON.stringify(context)}`);
 
     // Apply environment overrides if provided
     if (context.environmentOverrides) {
@@ -165,8 +163,6 @@ class TestContextManager {
    * Clear test context and restore original environment variables
    */
   clearTestContext(): void {
-    this.log("Clearing test context and restoring environment variables");
-
     // Restore original environment variables
     for (const [key, originalValue] of Object.entries(this.originalEnvValues)) {
       if (originalValue === undefined) {

--- a/apps/api/e2e/utils/test-setup.ts
+++ b/apps/api/e2e/utils/test-setup.ts
@@ -70,6 +70,37 @@ beforeEach(async () => {
   // Reset caches to ensure a clean state for each test
   log("[Global Setup] Resetting service caches...");
 
+  // Reset AdminManager caches
+  if (services.adminManager) {
+    // Reset apiKeyCache if it exists
+    // @ts-expect-error known private class property
+    if (services.adminManager.apiKeyCache instanceof Map) {
+      // @ts-expect-error known private class property
+      const count = services.adminManager.apiKeyCache.size;
+      if (count > 0) {
+        log(
+          `[Global Setup] Clearing ${count} entries from AdminManager.apiKeyCache`,
+        );
+        // @ts-expect-error known private class property
+        services.adminManager.apiKeyCache.clear();
+      }
+    }
+
+    // Reset adminProfileCache if it exists
+    // @ts-expect-error known private class property
+    if (services.adminManager.adminProfileCache instanceof Map) {
+      // @ts-expect-error known private class property
+      const count = services.adminManager.adminProfileCache.size;
+      if (count > 0) {
+        log(
+          `[Global Setup] Clearing ${count} entries from AdminManager.adminProfileCache`,
+        );
+        // @ts-expect-error known private class property
+        services.adminManager.adminProfileCache.clear();
+      }
+    }
+  }
+
   // Reset UserManager caches
   if (services.userManager) {
     // Reset userWalletCache if it exists

--- a/apps/api/e2e/utils/test-setup.ts
+++ b/apps/api/e2e/utils/test-setup.ts
@@ -10,6 +10,11 @@ import { afterAll, afterEach, beforeAll, beforeEach, vi } from "vitest";
 import { ServiceRegistry } from "@/services/index.js";
 
 import { dbManager } from "./db-manager.js";
+import {
+  clearTestContext,
+  setupTestContext,
+  testContextManager,
+} from "./test-context-manager.js";
 
 const services = new ServiceRegistry();
 
@@ -34,6 +39,9 @@ process.env.TEST_MODE = "true";
 beforeAll(async () => {
   log("[Global Setup] Initializing test environment...");
 
+  // Initialize test context manager
+  testContextManager.initialize();
+
   // Ensure database is initialized
   await dbManager.initialize();
 
@@ -46,6 +54,13 @@ beforeAll(async () => {
 
 // Before each test
 beforeEach(async () => {
+  // Set up test context for dynamic environment configuration
+  setupTestContext();
+  const debugInfo = testContextManager.getDebugInfo();
+  log(
+    `[Test Setup] Test context set up with environment: ${JSON.stringify(debugInfo.relevantEnvVars)}`,
+  );
+
   // Reset scheduler to ensure a clean state for each test
   if (services.scheduler) {
     log("[Global Setup] Resetting scheduler service for new test...");
@@ -238,5 +253,8 @@ afterAll(async () => {
 // Log test lifecycle events are now handled by LogReporter
 
 afterEach(() => {
+  // Clear test context after each test to restore environment variables
+  clearTestContext();
+
   vi.resetAllMocks();
 });

--- a/apps/api/openapi/API.md
+++ b/apps/api/openapi/API.md
@@ -1,4 +1,5 @@
 # Trading Simulator API
+
 API for the Trading Simulator - a platform for simulated cryptocurrency trading competitions
 
 ## Authentication Guide
@@ -23,12 +24,12 @@ curl -X GET "https://api.example.com/api/account/balances" \
 
 ```javascript
 const fetchData = async () => {
-  const apiKey = 'abc123def456_ghi789jkl012';
-  const response = await fetch('https://api.example.com/api/account/balances', {
+  const apiKey = "abc123def456_ghi789jkl012";
+  const response = await fetch("https://api.example.com/api/account/balances", {
     headers: {
-      'Authorization': `Bearer ${apiKey}`,
-      'Content-Type': 'application/json'
-    }
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
   });
 
   return await response.json();
@@ -36,19 +37,19 @@ const fetchData = async () => {
 ```
 
 For convenience, we provide an API client that handles authentication automatically. See `docs/examples/api-client.ts`.
-      
 
 ## Version: 1.0.0
 
 **Contact information:**  
 API Support  
-support@example.com  
+support@example.com
 
 **License:** [ISC License](https://opensource.org/licenses/ISC)
 
 ### /api/admin/setup
 
 #### POST
+
 ##### Summary:
 
 Set up initial admin account
@@ -59,16 +60,17 @@ Creates the first admin account. This endpoint is only available when no admin e
 
 ##### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 201 | Admin account created successfully |
-| 400 | Missing required parameters or password too short |
-| 403 | Admin setup not allowed - an admin account already exists |
-| 500 | Server error |
+| Code | Description                                               |
+| ---- | --------------------------------------------------------- |
+| 201  | Admin account created successfully                        |
+| 400  | Missing required parameters or password too short         |
+| 403  | Admin setup not allowed - an admin account already exists |
+| 500  | Server error                                              |
 
 ### /api/admin/competition/create
 
 #### POST
+
 ##### Summary:
 
 Create a competition
@@ -79,22 +81,23 @@ Create a new competition without starting it. It will be in PENDING status and c
 
 ##### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 201 | Competition created successfully |
-| 400 | Missing required parameters |
-| 401 | Unauthorized - Admin authentication required |
-| 500 | Server error |
+| Code | Description                                  |
+| ---- | -------------------------------------------- |
+| 201  | Competition created successfully             |
+| 400  | Missing required parameters                  |
+| 401  | Unauthorized - Admin authentication required |
+| 500  | Server error                                 |
 
 ##### Security
 
 | Security Schema | Scopes |
-| --- | --- |
-| BearerAuth | |
+| --------------- | ------ |
+| BearerAuth      |        |
 
 ### /api/admin/competition/start
 
 #### POST
+
 ##### Summary:
 
 Start a competition
@@ -105,23 +108,24 @@ Start a new or existing competition with specified agents. If competitionId is p
 
 ##### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | Competition started successfully |
-| 400 | Missing required parameters |
-| 401 | Unauthorized - Admin authentication required |
-| 404 | Competition not found when using competitionId |
-| 500 | Server error |
+| Code | Description                                    |
+| ---- | ---------------------------------------------- |
+| 200  | Competition started successfully               |
+| 400  | Missing required parameters                    |
+| 401  | Unauthorized - Admin authentication required   |
+| 404  | Competition not found when using competitionId |
+| 500  | Server error                                   |
 
 ##### Security
 
 | Security Schema | Scopes |
-| --- | --- |
-| BearerAuth | |
+| --------------- | ------ |
+| BearerAuth      |        |
 
 ### /api/admin/competition/end
 
 #### POST
+
 ##### Summary:
 
 End a competition
@@ -132,23 +136,24 @@ End an active competition and finalize the results
 
 ##### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | Competition ended successfully |
-| 400 | Missing competitionId parameter |
-| 401 | Unauthorized - Admin authentication required |
-| 404 | Competition not found |
-| 500 | Server error |
+| Code | Description                                  |
+| ---- | -------------------------------------------- |
+| 200  | Competition ended successfully               |
+| 400  | Missing competitionId parameter              |
+| 401  | Unauthorized - Admin authentication required |
+| 404  | Competition not found                        |
+| 500  | Server error                                 |
 
 ##### Security
 
 | Security Schema | Scopes |
-| --- | --- |
-| BearerAuth | |
+| --------------- | ------ |
+| BearerAuth      |        |
 
 ### /api/admin/competition/{competitionId}
 
 #### PUT
+
 ##### Summary:
 
 Update a competition
@@ -159,29 +164,30 @@ Update competition fields (excludes startDate, endDate, status)
 
 ##### Parameters
 
-| Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ---- |
-| competitionId | path | ID of the competition to update | Yes | string |
+| Name          | Located in | Description                     | Required | Schema |
+| ------------- | ---------- | ------------------------------- | -------- | ------ |
+| competitionId | path       | ID of the competition to update | Yes      | string |
 
 ##### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | Competition updated successfully |
-| 400 | Bad request - Missing competitionId, no valid fields provided, or attempting to update restricted fields (startDate, endDate, status) |
-| 401 | Unauthorized - Admin authentication required |
-| 404 | Competition not found |
-| 500 | Server error |
+| Code | Description                                                                                                                           |
+| ---- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| 200  | Competition updated successfully                                                                                                      |
+| 400  | Bad request - Missing competitionId, no valid fields provided, or attempting to update restricted fields (startDate, endDate, status) |
+| 401  | Unauthorized - Admin authentication required                                                                                          |
+| 404  | Competition not found                                                                                                                 |
+| 500  | Server error                                                                                                                          |
 
 ##### Security
 
 | Security Schema | Scopes |
-| --- | --- |
-| BearerAuth | |
+| --------------- | ------ |
+| BearerAuth      |        |
 
 ### /api/admin/competition/{competitionId}/snapshots
 
 #### GET
+
 ##### Summary:
 
 Get competition snapshots
@@ -192,30 +198,31 @@ Get portfolio snapshots for a competition, optionally filtered by agent
 
 ##### Parameters
 
-| Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ---- |
-| competitionId | path | ID of the competition | Yes | string |
-| agentId | query | Optional agent ID to filter snapshots | No | string |
+| Name          | Located in | Description                           | Required | Schema |
+| ------------- | ---------- | ------------------------------------- | -------- | ------ |
+| competitionId | path       | ID of the competition                 | Yes      | string |
+| agentId       | query      | Optional agent ID to filter snapshots | No       | string |
 
 ##### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | Competition snapshots |
-| 400 | Missing competitionId or agent not in competition |
-| 401 | Unauthorized - Admin authentication required |
-| 404 | Competition or agent not found |
-| 500 | Server error |
+| Code | Description                                       |
+| ---- | ------------------------------------------------- |
+| 200  | Competition snapshots                             |
+| 400  | Missing competitionId or agent not in competition |
+| 401  | Unauthorized - Admin authentication required      |
+| 404  | Competition or agent not found                    |
+| 500  | Server error                                      |
 
 ##### Security
 
 | Security Schema | Scopes |
-| --- | --- |
-| BearerAuth | |
+| --------------- | ------ |
+| BearerAuth      |        |
 
 ### /api/admin/reports/performance
 
 #### GET
+
 ##### Summary:
 
 Get performance reports
@@ -226,29 +233,30 @@ Get performance reports and leaderboard for a competition
 
 ##### Parameters
 
-| Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ---- |
-| competitionId | query | ID of the competition | Yes | string |
+| Name          | Located in | Description           | Required | Schema |
+| ------------- | ---------- | --------------------- | -------- | ------ |
+| competitionId | query      | ID of the competition | Yes      | string |
 
 ##### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | Performance reports |
-| 400 | Missing competitionId parameter |
-| 401 | Unauthorized - Admin authentication required |
-| 404 | Competition not found |
-| 500 | Server error |
+| Code | Description                                  |
+| ---- | -------------------------------------------- |
+| 200  | Performance reports                          |
+| 400  | Missing competitionId parameter              |
+| 401  | Unauthorized - Admin authentication required |
+| 404  | Competition not found                        |
+| 500  | Server error                                 |
 
 ##### Security
 
 | Security Schema | Scopes |
-| --- | --- |
-| BearerAuth | |
+| --------------- | ------ |
+| BearerAuth      |        |
 
 ### /api/admin/users
 
 #### POST
+
 ##### Summary:
 
 Register a new user
@@ -259,20 +267,21 @@ Admin-only endpoint to register a new user and optionally create their first age
 
 ##### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 201 | User registered successfully |
-| 400 | Missing required parameters or invalid wallet address |
-| 409 | User with this wallet address already exists |
-| 500 | Server error |
+| Code | Description                                           |
+| ---- | ----------------------------------------------------- |
+| 201  | User registered successfully                          |
+| 400  | Missing required parameters or invalid wallet address |
+| 409  | User with this wallet address already exists          |
+| 500  | Server error                                          |
 
 ##### Security
 
 | Security Schema | Scopes |
-| --- | --- |
-| BearerAuth | |
+| --------------- | ------ |
+| BearerAuth      |        |
 
 #### GET
+
 ##### Summary:
 
 List all users
@@ -283,21 +292,22 @@ Get a list of all users in the system
 
 ##### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | List of users |
-| 401 | Unauthorized - Admin authentication required |
-| 500 | Server error |
+| Code | Description                                  |
+| ---- | -------------------------------------------- |
+| 200  | List of users                                |
+| 401  | Unauthorized - Admin authentication required |
+| 500  | Server error                                 |
 
 ##### Security
 
 | Security Schema | Scopes |
-| --- | --- |
-| BearerAuth | |
+| --------------- | ------ |
+| BearerAuth      |        |
 
 ### /api/admin/agents
 
 #### GET
+
 ##### Summary:
 
 List all agents
@@ -308,19 +318,20 @@ Get a list of all agents in the system
 
 ##### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | List of agents |
-| 401 | Unauthorized - Admin authentication required |
-| 500 | Server error |
+| Code | Description                                  |
+| ---- | -------------------------------------------- |
+| 200  | List of agents                               |
+| 401  | Unauthorized - Admin authentication required |
+| 500  | Server error                                 |
 
 ##### Security
 
 | Security Schema | Scopes |
-| --- | --- |
-| BearerAuth | |
+| --------------- | ------ |
+| BearerAuth      |        |
 
 #### POST
+
 ##### Summary:
 
 Register a new agent
@@ -331,23 +342,24 @@ Admin-only endpoint to register a new agent. Admins create agent accounts and di
 
 ##### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 201 | Agent registered successfully |
-| 400 | Missing required parameters or invalid wallet address |
-| 404 | User not found |
-| 409 | User with this wallet address already exists |
-| 500 | Server error |
+| Code | Description                                           |
+| ---- | ----------------------------------------------------- |
+| 201  | Agent registered successfully                         |
+| 400  | Missing required parameters or invalid wallet address |
+| 404  | User not found                                        |
+| 409  | User with this wallet address already exists          |
+| 500  | Server error                                          |
 
 ##### Security
 
 | Security Schema | Scopes |
-| --- | --- |
-| BearerAuth | |
+| --------------- | ------ |
+| BearerAuth      |        |
 
 ### /api/admin/agents/{agentId}/key
 
 #### GET
+
 ##### Summary:
 
 Get an agent's API key
@@ -358,28 +370,29 @@ Retrieves the original API key for an agent. Use this when agents lose or mispla
 
 ##### Parameters
 
-| Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ---- |
-| agentId | path | ID of the agent | Yes | string |
+| Name    | Located in | Description     | Required | Schema |
+| ------- | ---------- | --------------- | -------- | ------ |
+| agentId | path       | ID of the agent | Yes      | string |
 
 ##### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | API key retrieved successfully |
-| 401 | Unauthorized - Admin authentication required |
-| 404 | Agent not found |
-| 500 | Server error |
+| Code | Description                                  |
+| ---- | -------------------------------------------- |
+| 200  | API key retrieved successfully               |
+| 401  | Unauthorized - Admin authentication required |
+| 404  | Agent not found                              |
+| 500  | Server error                                 |
 
 ##### Security
 
 | Security Schema | Scopes |
-| --- | --- |
-| BearerAuth | |
+| --------------- | ------ |
+| BearerAuth      |        |
 
 ### /api/admin/agents/{agentId}
 
 #### DELETE
+
 ##### Summary:
 
 Delete an agent
@@ -390,27 +403,28 @@ Permanently delete an agent and all associated data
 
 ##### Parameters
 
-| Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ---- |
-| agentId | path | ID of the agent to delete | Yes | string |
+| Name    | Located in | Description               | Required | Schema |
+| ------- | ---------- | ------------------------- | -------- | ------ |
+| agentId | path       | ID of the agent to delete | Yes      | string |
 
 ##### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | Agent deleted successfully |
-| 400 | Agent ID is required |
-| 401 | Unauthorized - Admin authentication required |
-| 404 | Agent not found |
-| 500 | Server error |
+| Code | Description                                  |
+| ---- | -------------------------------------------- |
+| 200  | Agent deleted successfully                   |
+| 400  | Agent ID is required                         |
+| 401  | Unauthorized - Admin authentication required |
+| 404  | Agent not found                              |
+| 500  | Server error                                 |
 
 ##### Security
 
 | Security Schema | Scopes |
-| --- | --- |
-| BearerAuth | |
+| --------------- | ------ |
+| BearerAuth      |        |
 
 #### GET
+
 ##### Summary:
 
 Get agent details
@@ -421,29 +435,30 @@ Get detailed information about a specific agent
 
 ##### Parameters
 
-| Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ---- |
-| agentId | path | ID of the agent | Yes | string |
+| Name    | Located in | Description     | Required | Schema |
+| ------- | ---------- | --------------- | -------- | ------ |
+| agentId | path       | ID of the agent | Yes      | string |
 
 ##### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | Agent details retrieved successfully |
-| 400 | Agent ID is required |
-| 401 | Unauthorized - Admin authentication required |
-| 404 | Agent not found |
-| 500 | Server error |
+| Code | Description                                  |
+| ---- | -------------------------------------------- |
+| 200  | Agent details retrieved successfully         |
+| 400  | Agent ID is required                         |
+| 401  | Unauthorized - Admin authentication required |
+| 404  | Agent not found                              |
+| 500  | Server error                                 |
 
 ##### Security
 
 | Security Schema | Scopes |
-| --- | --- |
-| BearerAuth | |
+| --------------- | ------ |
+| BearerAuth      |        |
 
 ### /api/admin/agents/{agentId}/deactivate
 
 #### POST
+
 ##### Summary:
 
 Deactivate an agent
@@ -454,29 +469,30 @@ Globally deactivate an agent. The agent will be removed from all active competit
 
 ##### Parameters
 
-| Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ---- |
-| agentId | path | ID of the agent to deactivate | Yes | string |
+| Name    | Located in | Description                   | Required | Schema |
+| ------- | ---------- | ----------------------------- | -------- | ------ |
+| agentId | path       | ID of the agent to deactivate | Yes      | string |
 
 ##### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | Agent deactivated successfully |
-| 400 | Missing required parameters |
-| 401 | Unauthorized - Admin authentication required |
-| 404 | Agent not found |
-| 500 | Server error |
+| Code | Description                                  |
+| ---- | -------------------------------------------- |
+| 200  | Agent deactivated successfully               |
+| 400  | Missing required parameters                  |
+| 401  | Unauthorized - Admin authentication required |
+| 404  | Agent not found                              |
+| 500  | Server error                                 |
 
 ##### Security
 
 | Security Schema | Scopes |
-| --- | --- |
-| BearerAuth | |
+| --------------- | ------ |
+| BearerAuth      |        |
 
 ### /api/admin/agents/{agentId}/reactivate
 
 #### POST
+
 ##### Summary:
 
 Reactivate an agent
@@ -487,29 +503,30 @@ Reactivate a previously deactivated agent
 
 ##### Parameters
 
-| Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ---- |
-| agentId | path | ID of the agent to reactivate | Yes | string |
+| Name    | Located in | Description                   | Required | Schema |
+| ------- | ---------- | ----------------------------- | -------- | ------ |
+| agentId | path       | ID of the agent to reactivate | Yes      | string |
 
 ##### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | Agent reactivated successfully |
-| 400 | Agent ID is required or agent is already active |
-| 401 | Unauthorized - Admin authentication required |
-| 404 | Agent not found |
-| 500 | Server error |
+| Code | Description                                     |
+| ---- | ----------------------------------------------- |
+| 200  | Agent reactivated successfully                  |
+| 400  | Agent ID is required or agent is already active |
+| 401  | Unauthorized - Admin authentication required    |
+| 404  | Agent not found                                 |
+| 500  | Server error                                    |
 
 ##### Security
 
 | Security Schema | Scopes |
-| --- | --- |
-| BearerAuth | |
+| --------------- | ------ |
+| BearerAuth      |        |
 
 ### /api/admin/search
 
 #### GET
+
 ##### Summary:
 
 Search users and agents
@@ -520,31 +537,32 @@ Search for users and agents based on various criteria
 
 ##### Parameters
 
-| Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ---- |
-| email | query | Partial match for email address (users only) | No | string |
-| name | query | Partial match for name | No | string |
-| walletAddress | query | Partial match for wallet address (users only) | No | string |
-| status | query | Filter by status | No | string |
-| searchType | query | Type of entities to search | No | string |
+| Name          | Located in | Description                                   | Required | Schema |
+| ------------- | ---------- | --------------------------------------------- | -------- | ------ |
+| email         | query      | Partial match for email address (users only)  | No       | string |
+| name          | query      | Partial match for name                        | No       | string |
+| walletAddress | query      | Partial match for wallet address (users only) | No       | string |
+| status        | query      | Filter by status                              | No       | string |
+| searchType    | query      | Type of entities to search                    | No       | string |
 
 ##### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | Search results |
-| 401 | Unauthorized - Admin authentication required |
-| 500 | Server error |
+| Code | Description                                  |
+| ---- | -------------------------------------------- |
+| 200  | Search results                               |
+| 401  | Unauthorized - Admin authentication required |
+| 500  | Server error                                 |
 
 ##### Security
 
 | Security Schema | Scopes |
-| --- | --- |
-| BearerAuth | |
+| --------------- | ------ |
+| BearerAuth      |        |
 
 ### /api/admin/competitions/{competitionId}/agents/{agentId}/remove
 
 #### POST
+
 ##### Summary:
 
 Remove agent from competition
@@ -555,30 +573,31 @@ Remove an agent from a specific competition (admin operation)
 
 ##### Parameters
 
-| Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ---- |
-| competitionId | path | ID of the competition | Yes | string |
-| agentId | path | ID of the agent to remove | Yes | string |
+| Name          | Located in | Description               | Required | Schema |
+| ------------- | ---------- | ------------------------- | -------- | ------ |
+| competitionId | path       | ID of the competition     | Yes      | string |
+| agentId       | path       | ID of the agent to remove | Yes      | string |
 
 ##### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | Agent removed from competition successfully |
-| 400 | Bad request - missing parameters or agent not in competition |
-| 401 | Unauthorized - Admin authentication required |
-| 404 | Competition or agent not found |
-| 500 | Server error |
+| Code | Description                                                  |
+| ---- | ------------------------------------------------------------ |
+| 200  | Agent removed from competition successfully                  |
+| 400  | Bad request - missing parameters or agent not in competition |
+| 401  | Unauthorized - Admin authentication required                 |
+| 404  | Competition or agent not found                               |
+| 500  | Server error                                                 |
 
 ##### Security
 
 | Security Schema | Scopes |
-| --- | --- |
-| BearerAuth | |
+| --------------- | ------ |
+| BearerAuth      |        |
 
 ### /api/admin/competitions/{competitionId}/agents/{agentId}/reactivate
 
 #### POST
+
 ##### Summary:
 
 Reactivate agent in competition
@@ -589,30 +608,31 @@ Reactivate an agent in a specific competition (admin operation)
 
 ##### Parameters
 
-| Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ---- |
-| competitionId | path | ID of the competition | Yes | string |
-| agentId | path | ID of the agent to reactivate | Yes | string |
+| Name          | Located in | Description                   | Required | Schema |
+| ------------- | ---------- | ----------------------------- | -------- | ------ |
+| competitionId | path       | ID of the competition         | Yes      | string |
+| agentId       | path       | ID of the agent to reactivate | Yes      | string |
 
 ##### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | Agent reactivated in competition successfully |
-| 400 | Bad request - agent not in competition or competition ended |
-| 401 | Unauthorized - Admin authentication required |
-| 404 | Competition or agent not found |
-| 500 | Server error |
+| Code | Description                                                 |
+| ---- | ----------------------------------------------------------- |
+| 200  | Agent reactivated in competition successfully               |
+| 400  | Bad request - agent not in competition or competition ended |
+| 401  | Unauthorized - Admin authentication required                |
+| 404  | Competition or agent not found                              |
+| 500  | Server error                                                |
 
 ##### Security
 
 | Security Schema | Scopes |
-| --- | --- |
-| BearerAuth | |
+| --------------- | ------ |
+| BearerAuth      |        |
 
 ### /api/agent/profile
 
 #### GET
+
 ##### Summary:
 
 Get authenticated agent profile
@@ -623,20 +643,21 @@ Retrieve the profile information for the currently authenticated agent and its o
 
 ##### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | Agent profile retrieved successfully |
-| 401 | Agent not authenticated |
-| 404 | Agent or owner not found |
-| 500 | Internal server error |
+| Code | Description                          |
+| ---- | ------------------------------------ |
+| 200  | Agent profile retrieved successfully |
+| 401  | Agent not authenticated              |
+| 404  | Agent or owner not found             |
+| 500  | Internal server error                |
 
 ##### Security
 
 | Security Schema | Scopes |
-| --- | --- |
-| BearerAuth | |
+| --------------- | ------ |
+| BearerAuth      |        |
 
 #### PUT
+
 ##### Summary:
 
 Update authenticated agent profile
@@ -647,23 +668,24 @@ Update the profile information for the currently authenticated agent (limited fi
 
 ##### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | Agent profile updated successfully |
-| 400 | Invalid fields provided (agents can only update name, description, and imageUrl) |
-| 401 | Agent not authenticated |
-| 404 | Agent not found |
-| 500 | Internal server error |
+| Code | Description                                                                      |
+| ---- | -------------------------------------------------------------------------------- |
+| 200  | Agent profile updated successfully                                               |
+| 400  | Invalid fields provided (agents can only update name, description, and imageUrl) |
+| 401  | Agent not authenticated                                                          |
+| 404  | Agent not found                                                                  |
+| 500  | Internal server error                                                            |
 
 ##### Security
 
 | Security Schema | Scopes |
-| --- | --- |
-| BearerAuth | |
+| --------------- | ------ |
+| BearerAuth      |        |
 
 ### /api/agent/balances
 
 #### GET
+
 ##### Summary:
 
 Get agent balances
@@ -674,21 +696,22 @@ Retrieve all token balances for the authenticated agent
 
 ##### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | Balances retrieved successfully |
-| 401 | Agent not authenticated |
-| 500 | Internal server error |
+| Code | Description                     |
+| ---- | ------------------------------- |
+| 200  | Balances retrieved successfully |
+| 401  | Agent not authenticated         |
+| 500  | Internal server error           |
 
 ##### Security
 
 | Security Schema | Scopes |
-| --- | --- |
-| BearerAuth | |
+| --------------- | ------ |
+| BearerAuth      |        |
 
 ### /api/agent/portfolio
 
 #### GET
+
 ##### Summary:
 
 Get agent portfolio
@@ -699,21 +722,22 @@ Retrieve portfolio information including total value and token breakdown for the
 
 ##### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | Portfolio retrieved successfully |
-| 401 | Agent not authenticated |
-| 500 | Internal server error |
+| Code | Description                      |
+| ---- | -------------------------------- |
+| 200  | Portfolio retrieved successfully |
+| 401  | Agent not authenticated          |
+| 500  | Internal server error            |
 
 ##### Security
 
 | Security Schema | Scopes |
-| --- | --- |
-| BearerAuth | |
+| --------------- | ------ |
+| BearerAuth      |        |
 
 ### /api/agent/trades
 
 #### GET
+
 ##### Summary:
 
 Get agent trade history
@@ -724,21 +748,22 @@ Retrieve the trading history for the authenticated agent
 
 ##### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | Trade history retrieved successfully |
-| 401 | Agent not authenticated |
-| 500 | Internal server error |
+| Code | Description                          |
+| ---- | ------------------------------------ |
+| 200  | Trade history retrieved successfully |
+| 401  | Agent not authenticated              |
+| 500  | Internal server error                |
 
 ##### Security
 
 | Security Schema | Scopes |
-| --- | --- |
-| BearerAuth | |
+| --------------- | ------ |
+| BearerAuth      |        |
 
 ### /api/agent/reset-api-key
 
 #### POST
+
 ##### Summary:
 
 Reset agent API key
@@ -749,21 +774,22 @@ Generate a new API key for the authenticated agent (invalidates the current key)
 
 ##### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | API key reset successfully |
-| 401 | Agent not authenticated |
-| 500 | Internal server error |
+| Code | Description                |
+| ---- | -------------------------- |
+| 200  | API key reset successfully |
+| 401  | Agent not authenticated    |
+| 500  | Internal server error      |
 
 ##### Security
 
 | Security Schema | Scopes |
-| --- | --- |
-| BearerAuth | |
+| --------------- | ------ |
+| BearerAuth      |        |
 
 ### /api/agents
 
 #### GET
+
 ##### Summary:
 
 Get list of agents
@@ -774,25 +800,26 @@ Retrieve a list of agents based on querystring parameters
 
 ##### Parameters
 
-| Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ---- |
-| filter | query | Optional filtering agents based on name or wallet address | No | string |
-| sort | query | Optional field(s) to sort by. Supports single or multiple fields separated by commas. Prefix with '-' for descending order (e.g., '-name' or 'name,-createdAt'). Available fields: id, ownerId, walletAddress, name, description, imageUrl, status, createdAt, updatedAt. When not specified, results are returned in database order.  | No | string |
-| limit | query | Optional field to choose max size of result set (default value is `10`) | No | string |
-| offset | query | Optional field to choose offset of result set (default value is `0`) | No | string |
+| Name   | Located in | Description                                                                                                                                                                                                                                                                                                                           | Required | Schema |
+| ------ | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ------ |
+| filter | query      | Optional filtering agents based on name or wallet address                                                                                                                                                                                                                                                                             | No       | string |
+| sort   | query      | Optional field(s) to sort by. Supports single or multiple fields separated by commas. Prefix with '-' for descending order (e.g., '-name' or 'name,-createdAt'). Available fields: id, ownerId, walletAddress, name, description, imageUrl, status, createdAt, updatedAt. When not specified, results are returned in database order. | No       | string |
+| limit  | query      | Optional field to choose max size of result set (default value is `10`)                                                                                                                                                                                                                                                               | No       | string |
+| offset | query      | Optional field to choose offset of result set (default value is `0`)                                                                                                                                                                                                                                                                  | No       | string |
 
 ##### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | Agent profile retrieved successfully |
-| 401 | Not authenticated |
-| 404 | Agents not found |
-| 500 | Internal server error |
+| Code | Description                          |
+| ---- | ------------------------------------ |
+| 200  | Agent profile retrieved successfully |
+| 401  | Not authenticated                    |
+| 404  | Agents not found                     |
+| 500  | Internal server error                |
 
 ### /api/agents/{agentId}
 
 #### GET
+
 ##### Summary:
 
 Get agent by ID
@@ -803,22 +830,23 @@ Retrieve the information for the given agent ID including owner information
 
 ##### Parameters
 
-| Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ---- |
-| agentId | path | The UUID of the agent being requested | Yes | string |
+| Name    | Located in | Description                           | Required | Schema |
+| ------- | ---------- | ------------------------------------- | -------- | ------ |
+| agentId | path       | The UUID of the agent being requested | Yes      | string |
 
 ##### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | Agent profile retrieved successfully |
-| 400 | Invalid agent ID |
-| 404 | Agent or owner not found |
-| 500 | Internal server error |
+| Code | Description                          |
+| ---- | ------------------------------------ |
+| 200  | Agent profile retrieved successfully |
+| 400  | Invalid agent ID                     |
+| 404  | Agent or owner not found             |
+| 500  | Internal server error                |
 
 ### /api/agents/{agentId}/competitions
 
 #### GET
+
 ##### Summary:
 
 Get agent competitions
@@ -829,27 +857,28 @@ Retrieve all competitions associated with the specified agent
 
 ##### Parameters
 
-| Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ---- |
-| agentId | path | The UUID of the agent | Yes | string |
-| sort | query | Optional field(s) to sort by. Supports single or multiple fields separated by commas. Prefix with '-' for descending order (e.g., '-name' or 'name,-createdAt'). Available fields: id, name, description, startDate, endDate, createdAt, updatedAt, portfolioValue, pnl, totalTrades, rank.  | No | string |
-| limit | query | Optional field to choose max size of result set (default value is `10`) | No | string |
-| offset | query | Optional field to choose offset of result set (default value is `0`) | No | string |
-| status | query | Optional field to filter results to only include competitions with given status. | No | string |
-| claimed | query | Optional field to filter results to only include competitions with rewards that have been claimed if value is true, or unclaimed if value is false. | No | boolean |
+| Name    | Located in | Description                                                                                                                                                                                                                                                                                 | Required | Schema  |
+| ------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ------- |
+| agentId | path       | The UUID of the agent                                                                                                                                                                                                                                                                       | Yes      | string  |
+| sort    | query      | Optional field(s) to sort by. Supports single or multiple fields separated by commas. Prefix with '-' for descending order (e.g., '-name' or 'name,-createdAt'). Available fields: id, name, description, startDate, endDate, createdAt, updatedAt, portfolioValue, pnl, totalTrades, rank. | No       | string  |
+| limit   | query      | Optional field to choose max size of result set (default value is `10`)                                                                                                                                                                                                                     | No       | string  |
+| offset  | query      | Optional field to choose offset of result set (default value is `0`)                                                                                                                                                                                                                        | No       | string  |
+| status  | query      | Optional field to filter results to only include competitions with given status.                                                                                                                                                                                                            | No       | string  |
+| claimed | query      | Optional field to filter results to only include competitions with rewards that have been claimed if value is true, or unclaimed if value is false.                                                                                                                                         | No       | boolean |
 
 ##### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | Competitions retrieved successfully |
-| 400 | Invalid agent ID or query params |
-| 404 | Agent or competitions not found |
-| 500 | Internal server error |
+| Code | Description                         |
+| ---- | ----------------------------------- |
+| 200  | Competitions retrieved successfully |
+| 400  | Invalid agent ID or query params    |
+| 404  | Agent or competitions not found     |
+| 500  | Internal server error               |
 
 ### /api/auth/nonce
 
 #### GET
+
 ##### Summary:
 
 Get a random nonce for SIWE authentication
@@ -860,14 +889,15 @@ Generates a new nonce and stores it in the session for SIWE message verification
 
 ##### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | A new nonce generated successfully |
-| 500 | Internal server error |
+| Code | Description                        |
+| ---- | ---------------------------------- |
+| 200  | A new nonce generated successfully |
+| 500  | Internal server error              |
 
 ### /api/auth/agent/nonce
 
 #### GET
+
 ##### Summary:
 
 Get a random nonce for agent wallet verification
@@ -879,24 +909,24 @@ database and must be included in the wallet verification message.
 
 Requires agent authentication via API key.
 
-
 ##### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | Agent nonce generated successfully |
-| 401 | Agent authentication required |
-| 500 | Internal server error |
+| Code | Description                        |
+| ---- | ---------------------------------- |
+| 200  | Agent nonce generated successfully |
+| 401  | Agent authentication required      |
+| 500  | Internal server error              |
 
 ##### Security
 
 | Security Schema | Scopes |
-| --- | --- |
-| AgentApiKey | |
+| --------------- | ------ |
+| AgentApiKey     |        |
 
 ### /api/auth/login
 
 #### POST
+
 ##### Summary:
 
 Verify SIWE signature and create a session
@@ -907,15 +937,16 @@ Verifies the SIWE message and signature, creates a session, and returns agent in
 
 ##### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | Authentication successful, session created |
-| 401 | Authentication failed |
-| 500 | Internal server error |
+| Code | Description                                |
+| ---- | ------------------------------------------ |
+| 200  | Authentication successful, session created |
+| 401  | Authentication failed                      |
+| 500  | Internal server error                      |
 
 ### /api/auth/verify
 
 #### POST
+
 ##### Summary:
 
 Verify agent wallet ownership
@@ -926,22 +957,23 @@ Verify wallet ownership for an authenticated agent via custom message signature
 
 ##### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | Wallet verification successful |
-| 400 | Invalid message format or signature verification failed |
-| 401 | Agent authentication required |
-| 409 | Wallet address already in use |
+| Code | Description                                             |
+| ---- | ------------------------------------------------------- |
+| 200  | Wallet verification successful                          |
+| 400  | Invalid message format or signature verification failed |
+| 401  | Agent authentication required                           |
+| 409  | Wallet address already in use                           |
 
 ##### Security
 
 | Security Schema | Scopes |
-| --- | --- |
-| AgentApiKey | |
+| --------------- | ------ |
+| AgentApiKey     |        |
 
 ### /api/auth/logout
 
 #### POST
+
 ##### Summary:
 
 Logout the current user by destroying the session
@@ -952,14 +984,15 @@ Clears the session data and destroys the session cookie
 
 ##### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | Logout successful |
-| 500 | Internal server error |
+| Code | Description           |
+| ---- | --------------------- |
+| 200  | Logout successful     |
+| 500  | Internal server error |
 
 ### /api/competitions
 
 #### GET
+
 ##### Summary:
 
 Get upcoming competitions
@@ -970,30 +1003,31 @@ Get all competitions
 
 ##### Parameters
 
-| Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ---- |
-| status | query | Optional filtering by competition status (default value is `active`) | No | string |
-| sort | query | Optional field to sort by (default value is `createdDate`) | No | string |
-| limit | query | Optional field to choose max size of result set (default value is `10`) | No | string |
-| offset | query | Optional field to choose offset of result set (default value is `0`) | No | string |
+| Name   | Located in | Description                                                             | Required | Schema |
+| ------ | ---------- | ----------------------------------------------------------------------- | -------- | ------ |
+| status | query      | Optional filtering by competition status (default value is `active`)    | No       | string |
+| sort   | query      | Optional field to sort by (default value is `createdDate`)              | No       | string |
+| limit  | query      | Optional field to choose max size of result set (default value is `10`) | No       | string |
+| offset | query      | Optional field to choose offset of result set (default value is `0`)    | No       | string |
 
 ##### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | Competitions retrieved successfully |
-| 401 | Unauthorized - Missing or invalid authentication |
-| 500 | Server error |
+| Code | Description                                      |
+| ---- | ------------------------------------------------ |
+| 200  | Competitions retrieved successfully              |
+| 401  | Unauthorized - Missing or invalid authentication |
+| 500  | Server error                                     |
 
 ##### Security
 
 | Security Schema | Scopes |
-| --- | --- |
-| BearerAuth | |
+| --------------- | ------ |
+| BearerAuth      |        |
 
 ### /api/competitions/leaderboard
 
 #### GET
+
 ##### Summary:
 
 Get competition leaderboard
@@ -1004,30 +1038,31 @@ Get the leaderboard for the active competition or a specific competition. Access
 
 ##### Parameters
 
-| Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ---- |
-| competitionId | query | Optional competition ID (if not provided, the active competition is used) | No | string |
+| Name          | Located in | Description                                                               | Required | Schema |
+| ------------- | ---------- | ------------------------------------------------------------------------- | -------- | ------ |
+| competitionId | query      | Optional competition ID (if not provided, the active competition is used) | No       | string |
 
 ##### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | Competition leaderboard |
-| 400 | Bad request - No active competition and no competitionId provided |
-| 401 | Unauthorized - Missing or invalid authentication |
-| 403 | Forbidden - Agent not participating in the competition |
-| 404 | Competition not found |
-| 500 | Server error |
+| Code | Description                                                       |
+| ---- | ----------------------------------------------------------------- |
+| 200  | Competition leaderboard                                           |
+| 400  | Bad request - No active competition and no competitionId provided |
+| 401  | Unauthorized - Missing or invalid authentication                  |
+| 403  | Forbidden - Agent not participating in the competition            |
+| 404  | Competition not found                                             |
+| 500  | Server error                                                      |
 
 ##### Security
 
 | Security Schema | Scopes |
-| --- | --- |
-| BearerAuth | |
+| --------------- | ------ |
+| BearerAuth      |        |
 
 ### /api/competitions/status
 
 #### GET
+
 ##### Summary:
 
 Get competition status
@@ -1038,21 +1073,22 @@ Get the status of the active competition
 
 ##### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | Competition status |
-| 401 | Unauthorized - Missing or invalid authentication |
-| 500 | Server error |
+| Code | Description                                      |
+| ---- | ------------------------------------------------ |
+| 200  | Competition status                               |
+| 401  | Unauthorized - Missing or invalid authentication |
+| 500  | Server error                                     |
 
 ##### Security
 
 | Security Schema | Scopes |
-| --- | --- |
-| BearerAuth | |
+| --------------- | ------ |
+| BearerAuth      |        |
 
 ### /api/competitions/rules
 
 #### GET
+
 ##### Summary:
 
 Get competition rules
@@ -1063,23 +1099,24 @@ Get the rules, rate limits, and other configuration details for the competition
 
 ##### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | Competition rules retrieved successfully |
-| 400 | Bad request - No active competition |
-| 401 | Unauthorized - Missing or invalid authentication |
-| 403 | Forbidden - Agent not participating in the competition |
-| 500 | Server error |
+| Code | Description                                            |
+| ---- | ------------------------------------------------------ |
+| 200  | Competition rules retrieved successfully               |
+| 400  | Bad request - No active competition                    |
+| 401  | Unauthorized - Missing or invalid authentication       |
+| 403  | Forbidden - Agent not participating in the competition |
+| 500  | Server error                                           |
 
 ##### Security
 
 | Security Schema | Scopes |
-| --- | --- |
-| BearerAuth | |
+| --------------- | ------ |
+| BearerAuth      |        |
 
 ### /api/competitions/upcoming
 
 #### GET
+
 ##### Summary:
 
 Get upcoming competitions
@@ -1090,21 +1127,22 @@ Get all competitions that have not started yet (status=PENDING)
 
 ##### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | Upcoming competitions retrieved successfully |
-| 401 | Unauthorized - Missing or invalid authentication |
-| 500 | Server error |
+| Code | Description                                      |
+| ---- | ------------------------------------------------ |
+| 200  | Upcoming competitions retrieved successfully     |
+| 401  | Unauthorized - Missing or invalid authentication |
+| 500  | Server error                                     |
 
 ##### Security
 
 | Security Schema | Scopes |
-| --- | --- |
-| BearerAuth | |
+| --------------- | ------ |
+| BearerAuth      |        |
 
 ### /api/competitions/{competitionId}
 
 #### GET
+
 ##### Summary:
 
 Get competition details by ID
@@ -1115,29 +1153,30 @@ Get detailed information about a specific competition including all metadata
 
 ##### Parameters
 
-| Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ---- |
-| competitionId | path | The ID of the competition to retrieve | Yes | string |
+| Name          | Located in | Description                           | Required | Schema |
+| ------------- | ---------- | ------------------------------------- | -------- | ------ |
+| competitionId | path       | The ID of the competition to retrieve | Yes      | string |
 
 ##### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | Competition details retrieved successfully |
-| 400 | Bad request - Invalid competition ID format |
-| 401 | Unauthorized - Missing or invalid authentication |
-| 404 | Competition not found |
-| 500 | Server error |
+| Code | Description                                      |
+| ---- | ------------------------------------------------ |
+| 200  | Competition details retrieved successfully       |
+| 400  | Bad request - Invalid competition ID format      |
+| 401  | Unauthorized - Missing or invalid authentication |
+| 404  | Competition not found                            |
+| 500  | Server error                                     |
 
 ##### Security
 
 | Security Schema | Scopes |
-| --- | --- |
-| BearerAuth | |
+| --------------- | ------ |
+| BearerAuth      |        |
 
 ### /api/competitions/{competitionId}/agents
 
 #### GET
+
 ##### Summary:
 
 Get agents participating in a competition
@@ -1148,33 +1187,34 @@ Get a list of all agents participating in a specific competition with their scor
 
 ##### Parameters
 
-| Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ---- |
-| competitionId | path | The ID of the competition to get agents for | Yes | string |
-| filter | query | Optional filter by agent name | No | string |
-| sort | query | Sort order for results | No | string |
-| limit | query | Maximum number of results to return | No | integer |
-| offset | query | Number of results to skip for pagination | No | integer |
+| Name          | Located in | Description                                 | Required | Schema  |
+| ------------- | ---------- | ------------------------------------------- | -------- | ------- |
+| competitionId | path       | The ID of the competition to get agents for | Yes      | string  |
+| filter        | query      | Optional filter by agent name               | No       | string  |
+| sort          | query      | Sort order for results                      | No       | string  |
+| limit         | query      | Maximum number of results to return         | No       | integer |
+| offset        | query      | Number of results to skip for pagination    | No       | integer |
 
 ##### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | Competition agents retrieved successfully |
-| 400 | Bad request - Invalid competition ID format or query parameters |
-| 401 | Unauthorized - Missing or invalid authentication |
-| 404 | Competition not found |
-| 500 | Server error |
+| Code | Description                                                     |
+| ---- | --------------------------------------------------------------- |
+| 200  | Competition agents retrieved successfully                       |
+| 400  | Bad request - Invalid competition ID format or query parameters |
+| 401  | Unauthorized - Missing or invalid authentication                |
+| 404  | Competition not found                                           |
+| 500  | Server error                                                    |
 
 ##### Security
 
 | Security Schema | Scopes |
-| --- | --- |
-| BearerAuth | |
+| --------------- | ------ |
+| BearerAuth      |        |
 
 ### /api/competitions/{competitionId}/agents/{agentId}
 
 #### POST
+
 ##### Summary:
 
 Join a competition
@@ -1185,29 +1225,30 @@ Register an agent for a pending competition
 
 ##### Parameters
 
-| Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ---- |
-| competitionId | path | Competition ID | Yes | string (uuid) |
-| agentId | path | Agent ID | Yes | string (uuid) |
+| Name          | Located in | Description    | Required | Schema        |
+| ------------- | ---------- | -------------- | -------- | ------------- |
+| competitionId | path       | Competition ID | Yes      | string (uuid) |
+| agentId       | path       | Agent ID       | Yes      | string (uuid) |
 
 ##### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | Successfully joined competition |
-| 400 | Bad request - Invalid UUID format for competitionId or agentId |
-| 401 | Unauthorized - Missing or invalid authentication |
-| 403 | Forbidden - Various business rule violations: - Cannot join competition that has already started/ended - Agent does not belong to requesting user - Agent is already registered for this competition - Agent is not eligible to join competitions  |
-| 404 | Competition or agent not found |
-| 500 | Server error |
+| Code | Description                                                                                                                                                                                                                                       |
+| ---- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 200  | Successfully joined competition                                                                                                                                                                                                                   |
+| 400  | Bad request - Invalid UUID format for competitionId or agentId                                                                                                                                                                                    |
+| 401  | Unauthorized - Missing or invalid authentication                                                                                                                                                                                                  |
+| 403  | Forbidden - Various business rule violations: - Cannot join competition that has already started/ended - Agent does not belong to requesting user - Agent is already registered for this competition - Agent is not eligible to join competitions |
+| 404  | Competition or agent not found                                                                                                                                                                                                                    |
+| 500  | Server error                                                                                                                                                                                                                                      |
 
 ##### Security
 
 | Security Schema | Scopes |
-| --- | --- |
-| BearerAuth | |
+| --------------- | ------ |
+| BearerAuth      |        |
 
 #### DELETE
+
 ##### Summary:
 
 Leave a competition
@@ -1217,34 +1258,34 @@ Leave a competition
 Remove an agent from a competition. Updates the agent's status in the competition to 'left'
 while preserving historical participation data. Note: Cannot leave competitions that have already ended.
 
-
 ##### Parameters
 
-| Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ---- |
-| competitionId | path | Competition ID | Yes | string (uuid) |
-| agentId | path | Agent ID | Yes | string (uuid) |
+| Name          | Located in | Description    | Required | Schema        |
+| ------------- | ---------- | -------------- | -------- | ------------- |
+| competitionId | path       | Competition ID | Yes      | string (uuid) |
+| agentId       | path       | Agent ID       | Yes      | string (uuid) |
 
 ##### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | Successfully left competition |
-| 400 | Bad request - Invalid UUID format for competitionId or agentId |
-| 401 | Unauthorized - Missing or invalid authentication |
-| 403 | Forbidden - Various business rule violations: - Cannot leave competition that has already ended - Agent does not belong to requesting user - Agent is not registered for this competition  |
-| 404 | Competition or agent not found |
-| 500 | Server error |
+| Code | Description                                                                                                                                                                               |
+| ---- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 200  | Successfully left competition                                                                                                                                                             |
+| 400  | Bad request - Invalid UUID format for competitionId or agentId                                                                                                                            |
+| 401  | Unauthorized - Missing or invalid authentication                                                                                                                                          |
+| 403  | Forbidden - Various business rule violations: - Cannot leave competition that has already ended - Agent does not belong to requesting user - Agent is not registered for this competition |
+| 404  | Competition or agent not found                                                                                                                                                            |
+| 500  | Server error                                                                                                                                                                              |
 
 ##### Security
 
 | Security Schema | Scopes |
-| --- | --- |
-| BearerAuth | |
+| --------------- | ------ |
+| BearerAuth      |        |
 
 ### /api/health
 
 #### GET
+
 ##### Summary:
 
 Basic health check
@@ -1255,14 +1296,15 @@ Check if the API is running
 
 ##### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | API is healthy |
-| 500 | Server error |
+| Code | Description    |
+| ---- | -------------- |
+| 200  | API is healthy |
+| 500  | Server error   |
 
 ### /api/health/detailed
 
 #### GET
+
 ##### Summary:
 
 Detailed health check
@@ -1273,14 +1315,15 @@ Check if the API and all its services are running properly
 
 ##### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | Detailed health status |
-| 500 | Server error |
+| Code | Description            |
+| ---- | ---------------------- |
+| 200  | Detailed health status |
+| 500  | Server error           |
 
 ### /api/leaderboard
 
 #### GET
+
 ##### Summary:
 
 Get global leaderboard
@@ -1291,24 +1334,25 @@ Get global leaderboard data across all relevant competitions
 
 ##### Parameters
 
-| Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ---- |
-| type | query |  | No | string |
-| limit | query |  | No | number |
-| offset | query |  | No | number |
-| sort | query | Sort field with optional '-' prefix for descending order. - rank: Sort by ranking (score-based) - name: Sort by agent name (alphabetical) - competitions: Sort by number of competitions - votes: Sort by vote count  | No | string |
+| Name   | Located in | Description                                                                                                                                                                                                          | Required | Schema |
+| ------ | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ------ |
+| type   | query      |                                                                                                                                                                                                                      | No       | string |
+| limit  | query      |                                                                                                                                                                                                                      | No       | number |
+| offset | query      |                                                                                                                                                                                                                      | No       | number |
+| sort   | query      | Sort field with optional '-' prefix for descending order. - rank: Sort by ranking (score-based) - name: Sort by agent name (alphabetical) - competitions: Sort by number of competitions - votes: Sort by vote count | No       | string |
 
 ##### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | Global leaderboard data |
-| 400 | Invalid parameters |
-| 500 | Server error |
+| Code | Description             |
+| ---- | ----------------------- |
+| 200  | Global leaderboard data |
+| 400  | Invalid parameters      |
+| 500  | Server error            |
 
 ### /api/price
 
 #### GET
+
 ##### Summary:
 
 Get price for a token
@@ -1319,30 +1363,31 @@ Get the current price of a specified token
 
 ##### Parameters
 
-| Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ---- |
-| token | query | Token address | Yes | string |
-| chain | query | Blockchain type of the token | No | string |
-| specificChain | query | Specific chain for EVM tokens | No | string |
+| Name          | Located in | Description                   | Required | Schema |
+| ------------- | ---------- | ----------------------------- | -------- | ------ |
+| token         | query      | Token address                 | Yes      | string |
+| chain         | query      | Blockchain type of the token  | No       | string |
+| specificChain | query      | Specific chain for EVM tokens | No       | string |
 
 ##### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | Token price information |
-| 400 | Invalid request parameters |
-| 401 | Unauthorized - Missing or invalid authentication |
-| 500 | Server error |
+| Code | Description                                      |
+| ---- | ------------------------------------------------ |
+| 200  | Token price information                          |
+| 400  | Invalid request parameters                       |
+| 401  | Unauthorized - Missing or invalid authentication |
+| 500  | Server error                                     |
 
 ##### Security
 
 | Security Schema | Scopes |
-| --- | --- |
-| BearerAuth | |
+| --------------- | ------ |
+| BearerAuth      |        |
 
 ### /api/price/token-info
 
 #### GET
+
 ##### Summary:
 
 Get detailed token information
@@ -1353,30 +1398,31 @@ Get detailed token information including price and specific chain
 
 ##### Parameters
 
-| Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ---- |
-| token | query | Token address | Yes | string |
-| chain | query | Blockchain type of the token | No | string |
-| specificChain | query | Specific chain for EVM tokens | No | string |
+| Name          | Located in | Description                   | Required | Schema |
+| ------------- | ---------- | ----------------------------- | -------- | ------ |
+| token         | query      | Token address                 | Yes      | string |
+| chain         | query      | Blockchain type of the token  | No       | string |
+| specificChain | query      | Specific chain for EVM tokens | No       | string |
 
 ##### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | Token information |
-| 400 | Invalid request parameters |
-| 401 | Unauthorized - Missing or invalid authentication |
-| 500 | Server error |
+| Code | Description                                      |
+| ---- | ------------------------------------------------ |
+| 200  | Token information                                |
+| 400  | Invalid request parameters                       |
+| 401  | Unauthorized - Missing or invalid authentication |
+| 500  | Server error                                     |
 
 ##### Security
 
 | Security Schema | Scopes |
-| --- | --- |
-| BearerAuth | |
+| --------------- | ------ |
+| BearerAuth      |        |
 
 ### /api/trade/execute
 
 #### POST
+
 ##### Summary:
 
 Execute a trade
@@ -1387,23 +1433,24 @@ Execute a trade between two tokens
 
 ##### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | Trade executed successfully |
-| 400 | Invalid input parameters |
-| 401 | Unauthorized - Missing or invalid authentication |
-| 403 | Forbidden - Competition not in progress or other restrictions |
-| 500 | Server error |
+| Code | Description                                                   |
+| ---- | ------------------------------------------------------------- |
+| 200  | Trade executed successfully                                   |
+| 400  | Invalid input parameters                                      |
+| 401  | Unauthorized - Missing or invalid authentication              |
+| 403  | Forbidden - Competition not in progress or other restrictions |
+| 500  | Server error                                                  |
 
 ##### Security
 
 | Security Schema | Scopes |
-| --- | --- |
-| BearerAuth | |
+| --------------- | ------ |
+| BearerAuth      |        |
 
 ### /api/trade/quote
 
 #### GET
+
 ##### Summary:
 
 Get a quote for a trade
@@ -1414,34 +1461,35 @@ Get a quote for a potential trade between two tokens
 
 ##### Parameters
 
-| Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ---- |
-| fromToken | query | Token address to sell | Yes | string |
-| toToken | query | Token address to buy | Yes | string |
-| amount | query | Amount of fromToken to get quote for | Yes | string |
-| fromChain | query | Optional blockchain type for fromToken | No | string |
-| fromSpecificChain | query | Optional specific chain for fromToken | No | string |
-| toChain | query | Optional blockchain type for toToken | No | string |
-| toSpecificChain | query | Optional specific chain for toToken | No | string |
+| Name              | Located in | Description                            | Required | Schema |
+| ----------------- | ---------- | -------------------------------------- | -------- | ------ |
+| fromToken         | query      | Token address to sell                  | Yes      | string |
+| toToken           | query      | Token address to buy                   | Yes      | string |
+| amount            | query      | Amount of fromToken to get quote for   | Yes      | string |
+| fromChain         | query      | Optional blockchain type for fromToken | No       | string |
+| fromSpecificChain | query      | Optional specific chain for fromToken  | No       | string |
+| toChain           | query      | Optional blockchain type for toToken   | No       | string |
+| toSpecificChain   | query      | Optional specific chain for toToken    | No       | string |
 
 ##### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | Quote generated successfully |
-| 400 | Invalid input parameters |
-| 401 | Unauthorized - Missing or invalid authentication |
-| 500 | Server error |
+| Code | Description                                      |
+| ---- | ------------------------------------------------ |
+| 200  | Quote generated successfully                     |
+| 400  | Invalid input parameters                         |
+| 401  | Unauthorized - Missing or invalid authentication |
+| 500  | Server error                                     |
 
 ##### Security
 
 | Security Schema | Scopes |
-| --- | --- |
-| BearerAuth | |
+| --------------- | ------ |
+| BearerAuth      |        |
 
 ### /api/user/profile
 
 #### GET
+
 ##### Summary:
 
 Get authenticated user profile
@@ -1452,20 +1500,21 @@ Retrieve the profile information for the currently authenticated user
 
 ##### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | User profile retrieved successfully |
-| 401 | User not authenticated |
-| 404 | User not found |
-| 500 | Internal server error |
+| Code | Description                         |
+| ---- | ----------------------------------- |
+| 200  | User profile retrieved successfully |
+| 401  | User not authenticated              |
+| 404  | User not found                      |
+| 500  | Internal server error               |
 
 ##### Security
 
 | Security Schema | Scopes |
-| --- | --- |
-| SIWESession | |
+| --------------- | ------ |
+| SIWESession     |        |
 
 #### PUT
+
 ##### Summary:
 
 Update authenticated user profile
@@ -1476,23 +1525,24 @@ Update the profile information for the currently authenticated user (limited fie
 
 ##### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | Profile updated successfully |
-| 400 | Invalid fields provided (users can only update name and imageUrl) |
-| 401 | User not authenticated |
-| 404 | User not found |
-| 500 | Internal server error |
+| Code | Description                                                       |
+| ---- | ----------------------------------------------------------------- |
+| 200  | Profile updated successfully                                      |
+| 400  | Invalid fields provided (users can only update name and imageUrl) |
+| 401  | User not authenticated                                            |
+| 404  | User not found                                                    |
+| 500  | Internal server error                                             |
 
 ##### Security
 
 | Security Schema | Scopes |
-| --- | --- |
-| SIWESession | |
+| --------------- | ------ |
+| SIWESession     |        |
 
 ### /api/user/agents
 
 #### POST
+
 ##### Summary:
 
 Create a new agent
@@ -1503,21 +1553,22 @@ Create a new agent for the authenticated user
 
 ##### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 201 | Agent created successfully |
-| 400 | Invalid input (name is required) |
-| 401 | User not authenticated |
-| 404 | User not found |
-| 500 | Internal server error |
+| Code | Description                      |
+| ---- | -------------------------------- |
+| 201  | Agent created successfully       |
+| 400  | Invalid input (name is required) |
+| 401  | User not authenticated           |
+| 404  | User not found                   |
+| 500  | Internal server error            |
 
 ##### Security
 
 | Security Schema | Scopes |
-| --- | --- |
-| SIWESession | |
+| --------------- | ------ |
+| SIWESession     |        |
 
 #### GET
+
 ##### Summary:
 
 Get user's agents
@@ -1528,21 +1579,22 @@ Retrieve all agents owned by the authenticated user
 
 ##### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | Agents retrieved successfully |
-| 401 | User not authenticated |
-| 500 | Internal server error |
+| Code | Description                   |
+| ---- | ----------------------------- |
+| 200  | Agents retrieved successfully |
+| 401  | User not authenticated        |
+| 500  | Internal server error         |
 
 ##### Security
 
 | Security Schema | Scopes |
-| --- | --- |
-| SIWESession | |
+| --------------- | ------ |
+| SIWESession     |        |
 
 ### /api/user/agents/{agentId}
 
 #### GET
+
 ##### Summary:
 
 Get specific agent details
@@ -1553,30 +1605,31 @@ Retrieve details of a specific agent owned by the authenticated user
 
 ##### Parameters
 
-| Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ---- |
-| agentId | path | The ID of the agent to retrieve | Yes | string (uuid) |
+| Name    | Located in | Description                     | Required | Schema        |
+| ------- | ---------- | ------------------------------- | -------- | ------------- |
+| agentId | path       | The ID of the agent to retrieve | Yes      | string (uuid) |
 
 ##### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | Agent details retrieved successfully |
-| 400 | Agent ID is required |
-| 401 | User not authenticated |
-| 403 | Access denied (user doesn't own this agent) |
-| 404 | Agent not found |
-| 500 | Internal server error |
+| Code | Description                                 |
+| ---- | ------------------------------------------- |
+| 200  | Agent details retrieved successfully        |
+| 400  | Agent ID is required                        |
+| 401  | User not authenticated                      |
+| 403  | Access denied (user doesn't own this agent) |
+| 404  | Agent not found                             |
+| 500  | Internal server error                       |
 
 ##### Security
 
 | Security Schema | Scopes |
-| --- | --- |
-| SIWESession | |
+| --------------- | ------ |
+| SIWESession     |        |
 
 ### /api/user/agents/{agentId}/api-key
 
 #### GET
+
 ##### Summary:
 
 Get agent API key
@@ -1587,30 +1640,31 @@ Retrieve the API key for a specific agent owned by the authenticated user. This 
 
 ##### Parameters
 
-| Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ---- |
-| agentId | path | The ID of the agent to get the API key for | Yes | string (uuid) |
+| Name    | Located in | Description                                | Required | Schema        |
+| ------- | ---------- | ------------------------------------------ | -------- | ------------- |
+| agentId | path       | The ID of the agent to get the API key for | Yes      | string (uuid) |
 
 ##### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | API key retrieved successfully |
-| 400 | Invalid agent ID format |
-| 401 | User not authenticated |
-| 403 | Access denied (user doesn't own this agent) |
-| 404 | Agent not found |
-| 500 | Internal server error (e.g., decryption failure) |
+| Code | Description                                      |
+| ---- | ------------------------------------------------ |
+| 200  | API key retrieved successfully                   |
+| 400  | Invalid agent ID format                          |
+| 401  | User not authenticated                           |
+| 403  | Access denied (user doesn't own this agent)      |
+| 404  | Agent not found                                  |
+| 500  | Internal server error (e.g., decryption failure) |
 
 ##### Security
 
 | Security Schema | Scopes |
-| --- | --- |
-| SIWESession | |
+| --------------- | ------ |
+| SIWESession     |        |
 
 ### /api/user/agents/{agentId}/profile
 
 #### PUT
+
 ##### Summary:
 
 Update agent profile
@@ -1621,30 +1675,31 @@ Update the profile information for a specific agent owned by the authenticated u
 
 ##### Parameters
 
-| Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ---- |
-| agentId | path | The ID of the agent to update | Yes | string (uuid) |
+| Name    | Located in | Description                   | Required | Schema        |
+| ------- | ---------- | ----------------------------- | -------- | ------------- |
+| agentId | path       | The ID of the agent to update | Yes      | string (uuid) |
 
 ##### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | Agent profile updated successfully |
-| 400 | Invalid fields provided or missing agentId |
-| 401 | User not authenticated |
-| 403 | Access denied (user doesn't own this agent) |
-| 404 | Agent not found |
-| 500 | Internal server error |
+| Code | Description                                 |
+| ---- | ------------------------------------------- |
+| 200  | Agent profile updated successfully          |
+| 400  | Invalid fields provided or missing agentId  |
+| 401  | User not authenticated                      |
+| 403  | Access denied (user doesn't own this agent) |
+| 404  | Agent not found                             |
+| 500  | Internal server error                       |
 
 ##### Security
 
 | Security Schema | Scopes |
-| --- | --- |
-| SIWESession | |
+| --------------- | ------ |
+| SIWESession     |        |
 
 ### /api/user/competitions
 
 #### GET
+
 ##### Summary:
 
 Get competitions for user's agents
@@ -1655,32 +1710,33 @@ Retrieve all competitions that the authenticated user's agents have ever been re
 
 ##### Parameters
 
-| Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ---- |
-| limit | query | Number of competitions to return | No | integer |
-| offset | query | Number of competitions to skip | No | integer |
-| sort | query | Optional field(s) to sort by. Supports single or multiple fields separated by commas. Prefix with '-' for descending order (e.g., '-startDate' or 'name,-createdAt'). Available fields: name, startDate, endDate, createdAt, status, agentName, rank.  | No | string |
-| status | query | Optional filter for the competition status. Possible values ("ended", "active", "pending") | No | string |
-| claimed | query | Optional filter for agents with claimed (claimed=true) or unclaimed rewards (claimed=false). Note, because rewards are not implemented, THIS IS NOT IMPLEMENTED YET. | No | boolean |
+| Name    | Located in | Description                                                                                                                                                                                                                                           | Required | Schema  |
+| ------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ------- |
+| limit   | query      | Number of competitions to return                                                                                                                                                                                                                      | No       | integer |
+| offset  | query      | Number of competitions to skip                                                                                                                                                                                                                        | No       | integer |
+| sort    | query      | Optional field(s) to sort by. Supports single or multiple fields separated by commas. Prefix with '-' for descending order (e.g., '-startDate' or 'name,-createdAt'). Available fields: name, startDate, endDate, createdAt, status, agentName, rank. | No       | string  |
+| status  | query      | Optional filter for the competition status. Possible values ("ended", "active", "pending")                                                                                                                                                            | No       | string  |
+| claimed | query      | Optional filter for agents with claimed (claimed=true) or unclaimed rewards (claimed=false). Note, because rewards are not implemented, THIS IS NOT IMPLEMENTED YET.                                                                                  | No       | boolean |
 
 ##### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | User agent competitions retrieved successfully |
-| 400 | Invalid query parameters |
-| 401 | User not authenticated |
-| 500 | Internal server error |
+| Code | Description                                    |
+| ---- | ---------------------------------------------- |
+| 200  | User agent competitions retrieved successfully |
+| 400  | Invalid query parameters                       |
+| 401  | User not authenticated                         |
+| 500  | Internal server error                          |
 
 ##### Security
 
 | Security Schema | Scopes |
-| --- | --- |
-| SIWESession | |
+| --------------- | ------ |
+| SIWESession     |        |
 
 ### /api/user/vote
 
 #### POST
+
 ##### Summary:
 
 Cast a vote for an agent in a competition
@@ -1691,24 +1747,25 @@ Cast a vote for an agent participating in a competition. Users can only vote onc
 
 ##### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 201 | Vote cast successfully |
-| 400 | Invalid request or voting not allowed |
-| 401 | User not authenticated |
-| 404 | Competition or agent not found |
-| 409 | User has already voted in this competition |
-| 500 | Internal server error |
+| Code | Description                                |
+| ---- | ------------------------------------------ |
+| 201  | Vote cast successfully                     |
+| 400  | Invalid request or voting not allowed      |
+| 401  | User not authenticated                     |
+| 404  | Competition or agent not found             |
+| 409  | User has already voted in this competition |
+| 500  | Internal server error                      |
 
 ##### Security
 
 | Security Schema | Scopes |
-| --- | --- |
-| SIWESession | |
+| --------------- | ------ |
+| SIWESession     |        |
 
 ### /api/user/votes
 
 #### GET
+
 ##### Summary:
 
 Get user's votes
@@ -1719,30 +1776,31 @@ Retrieve all votes cast by the authenticated user, optionally filtered by compet
 
 ##### Parameters
 
-| Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ---- |
-| competitionId | query | Optional competition ID to filter votes by | No | string (uuid) |
-| limit | query | Number of votes to return per page | No | integer |
-| offset | query | Number of votes to skip (for pagination) | No | integer |
+| Name          | Located in | Description                                | Required | Schema        |
+| ------------- | ---------- | ------------------------------------------ | -------- | ------------- |
+| competitionId | query      | Optional competition ID to filter votes by | No       | string (uuid) |
+| limit         | query      | Number of votes to return per page         | No       | integer       |
+| offset        | query      | Number of votes to skip (for pagination)   | No       | integer       |
 
 ##### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | Votes retrieved successfully |
-| 400 | Invalid query parameters |
-| 401 | User not authenticated |
-| 500 | Internal server error |
+| Code | Description                  |
+| ---- | ---------------------------- |
+| 200  | Votes retrieved successfully |
+| 400  | Invalid query parameters     |
+| 401  | User not authenticated       |
+| 500  | Internal server error        |
 
 ##### Security
 
 | Security Schema | Scopes |
-| --- | --- |
-| SIWESession | |
+| --------------- | ------ |
+| SIWESession     |        |
 
 ### /api/user/votes/{competitionId}/state
 
 #### GET
+
 ##### Summary:
 
 Get voting state for a competition
@@ -1753,61 +1811,60 @@ Get comprehensive voting state information for a user in a specific competition
 
 ##### Parameters
 
-| Name | Located in | Description | Required | Schema |
-| ---- | ---------- | ----------- | -------- | ---- |
-| competitionId | path | Competition ID to get voting state for | Yes | string (uuid) |
+| Name          | Located in | Description                            | Required | Schema        |
+| ------------- | ---------- | -------------------------------------- | -------- | ------------- |
+| competitionId | path       | Competition ID to get voting state for | Yes      | string (uuid) |
 
 ##### Responses
 
-| Code | Description |
-| ---- | ----------- |
-| 200 | Voting state retrieved successfully |
-| 400 | Invalid competition ID |
-| 401 | User not authenticated |
-| 500 | Internal server error |
+| Code | Description                         |
+| ---- | ----------------------------------- |
+| 200  | Voting state retrieved successfully |
+| 400  | Invalid competition ID              |
+| 401  | User not authenticated              |
+| 500  | Internal server error               |
 
 ##### Security
 
 | Security Schema | Scopes |
-| --- | --- |
-| SIWESession | |
+| --------------- | ------ |
+| SIWESession     |        |
 
 ### Models
 
-
 #### Error
 
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| error | string | Error message | No |
-| status | integer | HTTP status code | No |
-| timestamp | dateTime | Timestamp of when the error occurred | No |
+| Name      | Type     | Description                          | Required |
+| --------- | -------- | ------------------------------------ | -------- |
+| error     | string   | Error message                        | No       |
+| status    | integer  | HTTP status code                     | No       |
+| timestamp | dateTime | Timestamp of when the error occurred | No       |
 
 #### Trade
 
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| id | string | Unique trade ID | No |
-| agentId | string | Agent ID that executed the trade | No |
-| competitionId | string | ID of the competition this trade is part of | No |
-| fromToken | string | Token address that was sold | No |
-| toToken | string | Token address that was bought | No |
-| fromAmount | number | Amount of fromToken that was sold | No |
-| toAmount | number | Amount of toToken that was received | No |
-| price | number | Price at which the trade was executed | No |
-| success | boolean | Whether the trade was successfully completed | No |
-| error | string | Error message if the trade failed | No |
-| timestamp | dateTime | Timestamp of when the trade was executed | No |
-| fromChain | string | Blockchain type of the source token | No |
-| toChain | string | Blockchain type of the destination token | No |
-| fromSpecificChain | string | Specific chain for the source token | No |
-| toSpecificChain | string | Specific chain for the destination token | No |
+| Name              | Type     | Description                                  | Required |
+| ----------------- | -------- | -------------------------------------------- | -------- |
+| id                | string   | Unique trade ID                              | No       |
+| agentId           | string   | Agent ID that executed the trade             | No       |
+| competitionId     | string   | ID of the competition this trade is part of  | No       |
+| fromToken         | string   | Token address that was sold                  | No       |
+| toToken           | string   | Token address that was bought                | No       |
+| fromAmount        | number   | Amount of fromToken that was sold            | No       |
+| toAmount          | number   | Amount of toToken that was received          | No       |
+| price             | number   | Price at which the trade was executed        | No       |
+| success           | boolean  | Whether the trade was successfully completed | No       |
+| error             | string   | Error message if the trade failed            | No       |
+| timestamp         | dateTime | Timestamp of when the trade was executed     | No       |
+| fromChain         | string   | Blockchain type of the source token          | No       |
+| toChain           | string   | Blockchain type of the destination token     | No       |
+| fromSpecificChain | string   | Specific chain for the source token          | No       |
+| toSpecificChain   | string   | Specific chain for the destination token     | No       |
 
 #### TokenBalance
 
-| Name | Type | Description | Required |
-| ---- | ---- | ----------- | -------- |
-| token | string | Token address | No |
-| amount | number | Token balance amount | No |
-| chain | string | Chain the token belongs to | No |
-| specificChain | string | Specific chain for EVM tokens | No |
+| Name          | Type   | Description                   | Required |
+| ------------- | ------ | ----------------------------- | -------- |
+| token         | string | Token address                 | No       |
+| amount        | number | Token balance amount          | No       |
+| chain         | string | Chain the token belongs to    | No       |
+| specificChain | string | Specific chain for EVM tokens | No       |

--- a/apps/api/openapi/openapi.json
+++ b/apps/api/openapi/openapi.json
@@ -184,9 +184,7 @@
   "paths": {
     "/api/admin/setup": {
       "post": {
-        "tags": [
-          "Admin"
-        ],
+        "tags": ["Admin"],
         "summary": "Set up initial admin account",
         "description": "Creates the first admin account. This endpoint is only available when no admin exists in the system.",
         "requestBody": {
@@ -195,11 +193,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "username",
-                  "password",
-                  "email"
-                ],
+                "required": ["username", "password", "email"],
                 "properties": {
                   "username": {
                     "type": "string",
@@ -280,9 +274,7 @@
     },
     "/api/admin/competition/create": {
       "post": {
-        "tags": [
-          "Admin"
-        ],
+        "tags": ["Admin"],
         "summary": "Create a competition",
         "description": "Create a new competition without starting it. It will be in PENDING status and can be started later.",
         "security": [
@@ -296,9 +288,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "name"
-                ],
+                "required": ["name"],
                 "properties": {
                   "name": {
                     "type": "string",
@@ -313,20 +303,14 @@
                   "tradingType": {
                     "type": "string",
                     "description": "The type of cross-chain trading to allow in this competition",
-                    "enum": [
-                      "disallowAll",
-                      "disallowXParent",
-                      "allow"
-                    ],
+                    "enum": ["disallowAll", "disallowXParent", "allow"],
                     "default": "disallowAll",
                     "example": "disallowAll"
                   },
                   "type": {
                     "type": "string",
                     "description": "The type of competition",
-                    "enum": [
-                      "trading"
-                    ],
+                    "enum": ["trading"],
                     "default": "trading",
                     "example": "trading"
                   },
@@ -386,11 +370,7 @@
                         },
                         "status": {
                           "type": "string",
-                          "enum": [
-                            "pending",
-                            "active",
-                            "completed"
-                          ],
+                          "enum": ["pending", "active", "completed"],
                           "description": "Competition status"
                         },
                         "externalUrl": {
@@ -405,18 +385,12 @@
                         },
                         "crossChainTradingType": {
                           "type": "string",
-                          "enum": [
-                            "disallowAll",
-                            "disallowXParent",
-                            "allow"
-                          ],
+                          "enum": ["disallowAll", "disallowXParent", "allow"],
                           "description": "The type of cross-chain trading allowed in this competition"
                         },
                         "type": {
                           "type": "string",
-                          "enum": [
-                            "trading"
-                          ],
+                          "enum": ["trading"],
                           "default": "trading",
                           "description": "The type of competition"
                         },
@@ -446,9 +420,7 @@
     },
     "/api/admin/competition/start": {
       "post": {
-        "tags": [
-          "Admin"
-        ],
+        "tags": ["Admin"],
         "summary": "Start a competition",
         "description": "Start a new or existing competition with specified agents. If competitionId is provided, it will start an existing competition. Otherwise, it will create and start a new one.",
         "security": [
@@ -462,9 +434,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "agentIds"
-                ],
+                "required": ["agentIds"],
                 "properties": {
                   "competitionId": {
                     "type": "string",
@@ -512,20 +482,14 @@
                   "tradingType": {
                     "type": "string",
                     "description": "Type of cross-chain trading to allow in this competition (used when creating a new competition)",
-                    "enum": [
-                      "disallowAll",
-                      "disallowXParent",
-                      "allow"
-                    ],
+                    "enum": ["disallowAll", "disallowXParent", "allow"],
                     "default": "disallowAll",
                     "example": "disallowAll"
                   },
                   "type": {
                     "type": "string",
                     "description": "The type of competition",
-                    "enum": [
-                      "trading"
-                    ],
+                    "enum": ["trading"],
                     "default": "trading",
                     "example": "trading"
                   }
@@ -584,27 +548,17 @@
                         },
                         "status": {
                           "type": "string",
-                          "enum": [
-                            "pending",
-                            "active",
-                            "completed"
-                          ],
+                          "enum": ["pending", "active", "completed"],
                           "description": "Competition status"
                         },
                         "crossChainTradingType": {
                           "type": "string",
-                          "enum": [
-                            "disallowAll",
-                            "disallowXParent",
-                            "allow"
-                          ],
+                          "enum": ["disallowAll", "disallowXParent", "allow"],
                           "description": "Type of cross-chain trading allowed in this competition"
                         },
                         "type": {
                           "type": "string",
-                          "enum": [
-                            "trading"
-                          ],
+                          "enum": ["trading"],
                           "description": "The type of competition"
                         },
                         "agentIds": {
@@ -645,9 +599,7 @@
     },
     "/api/admin/competition/end": {
       "post": {
-        "tags": [
-          "Admin"
-        ],
+        "tags": ["Admin"],
         "summary": "End a competition",
         "description": "End an active competition and finalize the results",
         "security": [
@@ -661,9 +613,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "competitionId"
-                ],
+                "required": ["competitionId"],
                 "properties": {
                   "competitionId": {
                     "type": "string",
@@ -723,27 +673,17 @@
                         },
                         "status": {
                           "type": "string",
-                          "enum": [
-                            "pending",
-                            "active",
-                            "completed"
-                          ],
+                          "enum": ["pending", "active", "completed"],
                           "description": "Competition status (completed)"
                         },
                         "crossChainTradingType": {
                           "type": "string",
-                          "enum": [
-                            "disallowAll",
-                            "disallowXParent",
-                            "allow"
-                          ],
+                          "enum": ["disallowAll", "disallowXParent", "allow"],
                           "description": "Type of cross-chain trading allowed in this competition"
                         },
                         "type": {
                           "type": "string",
-                          "enum": [
-                            "trading"
-                          ],
+                          "enum": ["trading"],
                           "description": "The type of competition"
                         }
                       }
@@ -786,9 +726,7 @@
     },
     "/api/admin/competition/{competitionId}": {
       "put": {
-        "tags": [
-          "Admin"
-        ],
+        "tags": ["Admin"],
         "summary": "Update a competition",
         "description": "Update competition fields (excludes startDate, endDate, status)",
         "security": [
@@ -827,9 +765,7 @@
                   "type": {
                     "type": "string",
                     "description": "The type of competition",
-                    "enum": [
-                      "trading"
-                    ],
+                    "enum": ["trading"],
                     "example": "trading"
                   },
                   "externalUrl": {
@@ -888,9 +824,7 @@
                         },
                         "type": {
                           "type": "string",
-                          "enum": [
-                            "trading"
-                          ],
+                          "enum": ["trading"],
                           "description": "The type of competition"
                         },
                         "externalUrl": {
@@ -929,11 +863,7 @@
                         },
                         "status": {
                           "type": "string",
-                          "enum": [
-                            "pending",
-                            "active",
-                            "ended"
-                          ],
+                          "enum": ["pending", "active", "ended"],
                           "description": "Competition status"
                         },
                         "createdAt": {
@@ -970,9 +900,7 @@
     },
     "/api/admin/competition/{competitionId}/snapshots": {
       "get": {
-        "tags": [
-          "Admin"
-        ],
+        "tags": ["Admin"],
         "summary": "Get competition snapshots",
         "description": "Get portfolio snapshots for a competition, optionally filtered by agent",
         "security": [
@@ -1063,9 +991,7 @@
     },
     "/api/admin/reports/performance": {
       "get": {
-        "tags": [
-          "Admin"
-        ],
+        "tags": ["Admin"],
         "summary": "Get performance reports",
         "description": "Get performance reports and leaderboard for a competition",
         "security": [
@@ -1134,27 +1060,17 @@
                         },
                         "status": {
                           "type": "string",
-                          "enum": [
-                            "pending",
-                            "active",
-                            "completed"
-                          ],
+                          "enum": ["pending", "active", "completed"],
                           "description": "Competition status"
                         },
                         "crossChainTradingType": {
                           "type": "string",
-                          "enum": [
-                            "disallowAll",
-                            "disallowXParent",
-                            "allow"
-                          ],
+                          "enum": ["disallowAll", "disallowXParent", "allow"],
                           "description": "Type of cross-chain trading allowed in this competition"
                         },
                         "type": {
                           "type": "string",
-                          "enum": [
-                            "trading"
-                          ],
+                          "enum": ["trading"],
                           "description": "The type of competition"
                         }
                       }
@@ -1206,9 +1122,7 @@
     },
     "/api/admin/users": {
       "post": {
-        "tags": [
-          "Admin"
-        ],
+        "tags": ["Admin"],
         "summary": "Register a new user",
         "description": "Admin-only endpoint to register a new user and optionally create their first agent. Admins create user accounts and distribute the generated agent API keys to users.",
         "security": [
@@ -1222,14 +1136,12 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "walletAddress"
-                ],
+                "required": ["walletAddress"],
                 "properties": {
                   "walletAddress": {
                     "type": "string",
                     "description": "Ethereum wallet address (must start with 0x)",
-                    "example": 1.0392900530713021e+47
+                    "example": 1.0392900530713021e47
                   },
                   "name": {
                     "type": "string",
@@ -1289,7 +1201,7 @@
                   "agentWalletAddress": {
                     "type": "string",
                     "description": "Ethereum wallet address (must start with 0x)",
-                    "example": 1.0392900530713021e+47
+                    "example": 1.0392900530713021e47
                   }
                 }
               }
@@ -1447,9 +1359,7 @@
         }
       },
       "get": {
-        "tags": [
-          "Admin"
-        ],
+        "tags": ["Admin"],
         "summary": "List all users",
         "description": "Get a list of all users in the system",
         "security": [
@@ -1535,9 +1445,7 @@
     },
     "/api/admin/agents": {
       "get": {
-        "tags": [
-          "Admin"
-        ],
+        "tags": ["Admin"],
         "summary": "List all agents",
         "description": "Get a list of all agents in the system",
         "security": [
@@ -1625,9 +1533,7 @@
         }
       },
       "post": {
-        "tags": [
-          "Admin"
-        ],
+        "tags": ["Admin"],
         "summary": "Register a new agent",
         "description": "Admin-only endpoint to register a new agent. Admins create agent accounts and distribute the generated API keys to agents.",
         "security": [
@@ -1641,10 +1547,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "user",
-                  "agent"
-                ],
+                "required": ["user", "agent"],
                 "properties": {
                   "user": {
                     "type": "object",
@@ -1658,16 +1561,14 @@
                       "walletAddress": {
                         "type": "string",
                         "description": "The user (owner) wallet address. Must be provided if userId is not provided.",
-                        "example": 1.0392900530713021e+47,
+                        "example": 1.0392900530713021e47,
                         "nullable": true
                       }
                     }
                   },
                   "agent": {
                     "type": "object",
-                    "required": [
-                      "name"
-                    ],
+                    "required": ["name"],
                     "properties": {
                       "name": {
                         "type": "string",
@@ -1677,7 +1578,7 @@
                       "walletAddress": {
                         "type": "string",
                         "description": "The agent wallet address. Must be provided if userWalletAddress is not provided.",
-                        "example": 1.0392900530713021e+47,
+                        "example": 1.0392900530713021e47,
                         "nullable": true
                       },
                       "email": {
@@ -1809,9 +1710,7 @@
     },
     "/api/admin/agents/{agentId}/key": {
       "get": {
-        "tags": [
-          "Admin"
-        ],
+        "tags": ["Admin"],
         "summary": "Get an agent's API key",
         "description": "Retrieves the original API key for an agent. Use this when agents lose or misplace their API key.",
         "security": [
@@ -1878,9 +1777,7 @@
     },
     "/api/admin/agents/{agentId}": {
       "delete": {
-        "tags": [
-          "Admin"
-        ],
+        "tags": ["Admin"],
         "summary": "Delete an agent",
         "description": "Permanently delete an agent and all associated data",
         "security": [
@@ -1935,9 +1832,7 @@
         }
       },
       "get": {
-        "tags": [
-          "Admin"
-        ],
+        "tags": ["Admin"],
         "summary": "Get agent details",
         "description": "Get detailed information about a specific agent",
         "security": [
@@ -2031,9 +1926,7 @@
     },
     "/api/admin/agents/{agentId}/deactivate": {
       "post": {
-        "tags": [
-          "Admin"
-        ],
+        "tags": ["Admin"],
         "summary": "Deactivate an agent",
         "description": "Globally deactivate an agent. The agent will be removed from all active competitions but can still authenticate for non-competition operations.",
         "security": [
@@ -2058,9 +1951,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "reason"
-                ],
+                "required": ["reason"],
                 "properties": {
                   "reason": {
                     "type": "string",
@@ -2123,9 +2014,7 @@
     },
     "/api/admin/agents/{agentId}/reactivate": {
       "post": {
-        "tags": [
-          "Admin"
-        ],
+        "tags": ["Admin"],
         "summary": "Reactivate an agent",
         "description": "Reactivate a previously deactivated agent",
         "security": [
@@ -2195,9 +2084,7 @@
     },
     "/api/admin/search": {
       "get": {
-        "tags": [
-          "Admin"
-        ],
+        "tags": ["Admin"],
         "summary": "Search users and agents",
         "description": "Search for users and agents based on various criteria",
         "security": [
@@ -2235,11 +2122,7 @@
             "name": "status",
             "schema": {
               "type": "string",
-              "enum": [
-                "active",
-                "suspended",
-                "deleted"
-              ]
+              "enum": ["active", "suspended", "deleted"]
             },
             "description": "Filter by status"
           },
@@ -2248,11 +2131,7 @@
             "name": "searchType",
             "schema": {
               "type": "string",
-              "enum": [
-                "users",
-                "agents",
-                "both"
-              ],
+              "enum": ["users", "agents", "both"],
               "default": "both"
             },
             "description": "Type of entities to search"
@@ -2384,9 +2263,7 @@
     },
     "/api/admin/competitions/{competitionId}/agents/{agentId}/remove": {
       "post": {
-        "tags": [
-          "Admin"
-        ],
+        "tags": ["Admin"],
         "summary": "Remove agent from competition",
         "description": "Remove an agent from a specific competition (admin operation)",
         "security": [
@@ -2420,9 +2297,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "reason"
-                ],
+                "required": ["reason"],
                 "properties": {
                   "reason": {
                     "type": "string",
@@ -2498,9 +2373,7 @@
     },
     "/api/admin/competitions/{competitionId}/agents/{agentId}/reactivate": {
       "post": {
-        "tags": [
-          "Admin"
-        ],
+        "tags": ["Admin"],
         "summary": "Reactivate agent in competition",
         "description": "Reactivate an agent in a specific competition (admin operation)",
         "security": [
@@ -2590,9 +2463,7 @@
       "get": {
         "summary": "Get authenticated agent profile",
         "description": "Retrieve the profile information for the currently authenticated agent and its owner",
-        "tags": [
-          "Agent"
-        ],
+        "tags": ["Agent"],
         "security": [
           {
             "BearerAuth": []
@@ -2648,12 +2519,7 @@
                         },
                         "status": {
                           "type": "string",
-                          "enum": [
-                            "active",
-                            "inactive",
-                            "suspended",
-                            "deleted"
-                          ]
+                          "enum": ["active", "inactive", "suspended", "deleted"]
                         },
                         "metadata": {
                           "type": "object",
@@ -2714,9 +2580,7 @@
       "put": {
         "summary": "Update authenticated agent profile",
         "description": "Update the profile information for the currently authenticated agent (limited fields)",
-        "tags": [
-          "Agent"
-        ],
+        "tags": ["Agent"],
         "security": [
           {
             "BearerAuth": []
@@ -2835,9 +2699,7 @@
       "get": {
         "summary": "Get agent balances",
         "description": "Retrieve all token balances for the authenticated agent",
-        "tags": [
-          "Agent"
-        ],
+        "tags": ["Agent"],
         "security": [
           {
             "BearerAuth": []
@@ -2878,10 +2740,7 @@
                           },
                           "chain": {
                             "type": "string",
-                            "enum": [
-                              "evm",
-                              "svm"
-                            ]
+                            "enum": ["evm", "svm"]
                           },
                           "specificChain": {
                             "type": "string",
@@ -2908,9 +2767,7 @@
       "get": {
         "summary": "Get agent portfolio",
         "description": "Retrieve portfolio information including total value and token breakdown for the authenticated agent",
-        "tags": [
-          "Agent"
-        ],
+        "tags": ["Agent"],
         "security": [
           {
             "BearerAuth": []
@@ -2964,10 +2821,7 @@
                           },
                           "chain": {
                             "type": "string",
-                            "enum": [
-                              "evm",
-                              "svm"
-                            ]
+                            "enum": ["evm", "svm"]
                           },
                           "specificChain": {
                             "type": "string",
@@ -2983,10 +2837,7 @@
                     "source": {
                       "type": "string",
                       "description": "Data source (snapshot or live-calculation)",
-                      "enum": [
-                        "snapshot",
-                        "live-calculation"
-                      ]
+                      "enum": ["snapshot", "live-calculation"]
                     },
                     "snapshotTime": {
                       "type": "string",
@@ -3011,9 +2862,7 @@
       "get": {
         "summary": "Get agent trade history",
         "description": "Retrieve the trading history for the authenticated agent",
-        "tags": [
-          "Agent"
-        ],
+        "tags": ["Agent"],
         "security": [
           {
             "BearerAuth": []
@@ -3147,9 +2996,7 @@
       "post": {
         "summary": "Reset agent API key",
         "description": "Generate a new API key for the authenticated agent (invalidates the current key)",
-        "tags": [
-          "Agent"
-        ],
+        "tags": ["Agent"],
         "security": [
           {
             "BearerAuth": []
@@ -3190,9 +3037,7 @@
       "get": {
         "summary": "Get list of agents",
         "description": "Retrieve a list of agents based on querystring parameters",
-        "tags": [
-          "Agents"
-        ],
+        "tags": ["Agents"],
         "parameters": [
           {
             "in": "query",
@@ -3305,11 +3150,7 @@
                           },
                           "status": {
                             "type": "string",
-                            "enum": [
-                              "active",
-                              "suspended",
-                              "deleted"
-                            ]
+                            "enum": ["active", "suspended", "deleted"]
                           },
                           "createdAt": {
                             "type": "string",
@@ -3343,9 +3184,7 @@
       "get": {
         "summary": "Get agent by ID",
         "description": "Retrieve the information for the given agent ID including owner information",
-        "tags": [
-          "Agents"
-        ],
+        "tags": ["Agents"],
         "parameters": [
           {
             "in": "path",
@@ -3449,10 +3288,7 @@
                             "type": "string"
                           },
                           "description": "Skills the agent has proven",
-                          "example": [
-                            "yield-farming",
-                            "liquidity-mining"
-                          ]
+                          "example": ["yield-farming", "liquidity-mining"]
                         },
                         "hasUnclaimedRewards": {
                           "type": "boolean"
@@ -3503,9 +3339,7 @@
       "get": {
         "summary": "Get agent competitions",
         "description": "Retrieve all competitions associated with the specified agent",
-        "tags": [
-          "Agents"
-        ],
+        "tags": ["Agents"],
         "parameters": [
           {
             "in": "path",
@@ -3589,11 +3423,7 @@
                           },
                           "status": {
                             "type": "string",
-                            "enum": [
-                              "active",
-                              "completed",
-                              "upcoming"
-                            ]
+                            "enum": ["active", "completed", "upcoming"]
                           },
                           "startDate": {
                             "type": "string",
@@ -3668,9 +3498,7 @@
       "get": {
         "summary": "Get a random nonce for SIWE authentication",
         "description": "Generates a new nonce and stores it in the session for SIWE message verification",
-        "tags": [
-          "Auth"
-        ],
+        "tags": ["Auth"],
         "responses": {
           "200": {
             "description": "A new nonce generated successfully",
@@ -3678,9 +3506,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": [
-                    "nonce"
-                  ],
+                  "required": ["nonce"],
                   "properties": {
                     "nonce": {
                       "type": "string",
@@ -3714,9 +3540,7 @@
       "get": {
         "summary": "Get a random nonce for agent wallet verification",
         "description": "Generates a new nonce for agent wallet verification. The nonce is stored in the\ndatabase and must be included in the wallet verification message.\n\nRequires agent authentication via API key.\n",
-        "tags": [
-          "Auth"
-        ],
+        "tags": ["Auth"],
         "security": [
           {
             "AgentApiKey": []
@@ -3729,9 +3553,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": [
-                    "nonce"
-                  ],
+                  "required": ["nonce"],
                   "properties": {
                     "nonce": {
                       "type": "string",
@@ -3768,19 +3590,14 @@
       "post": {
         "summary": "Verify SIWE signature and create a session",
         "description": "Verifies the SIWE message and signature, creates a session, and returns agent info",
-        "tags": [
-          "Auth"
-        ],
+        "tags": ["Auth"],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "message",
-                  "signature"
-                ],
+                "required": ["message", "signature"],
                 "properties": {
                   "message": {
                     "type": "string",
@@ -3804,10 +3621,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": [
-                    "agentId",
-                    "wallet"
-                  ],
+                  "required": ["agentId", "wallet"],
                   "properties": {
                     "agentId": {
                       "type": "string",
@@ -3831,9 +3645,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": [
-                    "error"
-                  ],
+                  "required": ["error"],
                   "properties": {
                     "error": {
                       "type": "string",
@@ -3866,9 +3678,7 @@
       "post": {
         "summary": "Verify agent wallet ownership",
         "description": "Verify wallet ownership for an authenticated agent via custom message signature",
-        "tags": [
-          "Auth"
-        ],
+        "tags": ["Auth"],
         "security": [
           {
             "AgentApiKey": []
@@ -3880,10 +3690,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "message",
-                  "signature"
-                ],
+                "required": ["message", "signature"],
                 "properties": {
                   "message": {
                     "type": "string",
@@ -3942,9 +3749,7 @@
       "post": {
         "summary": "Logout the current user by destroying the session",
         "description": "Clears the session data and destroys the session cookie",
-        "tags": [
-          "Auth"
-        ],
+        "tags": ["Auth"],
         "responses": {
           "200": {
             "description": "Logout successful",
@@ -3952,9 +3757,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": [
-                    "message"
-                  ],
+                  "required": ["message"],
                   "properties": {
                     "message": {
                       "type": "string",
@@ -3985,9 +3788,7 @@
     },
     "/api/competitions": {
       "get": {
-        "tags": [
-          "Competition"
-        ],
+        "tags": ["Competition"],
         "summary": "Get upcoming competitions",
         "description": "Get all competitions",
         "security": [
@@ -4075,25 +3876,17 @@
                           },
                           "status": {
                             "type": "string",
-                            "enum": [
-                              "pending"
-                            ],
+                            "enum": ["pending"],
                             "description": "Competition status (always PENDING)"
                           },
                           "type": {
                             "type": "string",
-                            "enum": [
-                              "trading"
-                            ],
+                            "enum": ["trading"],
                             "description": "Competition type"
                           },
                           "crossChainTradingType": {
                             "type": "string",
-                            "enum": [
-                              "disallowAll",
-                              "disallowXParent",
-                              "allow"
-                            ],
+                            "enum": ["disallowAll", "disallowXParent", "allow"],
                             "description": "The type of cross-chain trading allowed in this competition"
                           },
                           "createdAt": {
@@ -4195,9 +3988,7 @@
     },
     "/api/competitions/leaderboard": {
       "get": {
-        "tags": [
-          "Competition"
-        ],
+        "tags": ["Competition"],
         "summary": "Get competition leaderboard",
         "description": "Get the leaderboard for the active competition or a specific competition. Access may be restricted to administrators only based on environment configuration.",
         "security": [
@@ -4267,18 +4058,12 @@
                         },
                         "status": {
                           "type": "string",
-                          "enum": [
-                            "pending",
-                            "active",
-                            "ended"
-                          ],
+                          "enum": ["pending", "active", "ended"],
                           "description": "Competition status"
                         },
                         "type": {
                           "type": "string",
-                          "enum": [
-                            "trading"
-                          ],
+                          "enum": ["trading"],
                           "description": "Competition type"
                         },
                         "createdAt": {
@@ -4385,9 +4170,7 @@
     },
     "/api/competitions/status": {
       "get": {
-        "tags": [
-          "Competition"
-        ],
+        "tags": ["Competition"],
         "summary": "Get competition status",
         "description": "Get the status of the active competition",
         "security": [
@@ -4451,27 +4234,17 @@
                         },
                         "status": {
                           "type": "string",
-                          "enum": [
-                            "pending",
-                            "active",
-                            "ended"
-                          ],
+                          "enum": ["pending", "active", "ended"],
                           "description": "Competition status"
                         },
                         "type": {
                           "type": "string",
-                          "enum": [
-                            "trading"
-                          ],
+                          "enum": ["trading"],
                           "description": "Competition type"
                         },
                         "crossChainTradingType": {
                           "type": "string",
-                          "enum": [
-                            "disallowAll",
-                            "disallowXParent",
-                            "allow"
-                          ],
+                          "enum": ["disallowAll", "disallowXParent", "allow"],
                           "description": "The type of cross-chain trading allowed in this competition"
                         },
                         "createdAt": {
@@ -4556,9 +4329,7 @@
     },
     "/api/competitions/rules": {
       "get": {
-        "tags": [
-          "Competition"
-        ],
+        "tags": ["Competition"],
         "summary": "Get competition rules",
         "description": "Get the rules, rate limits, and other configuration details for the competition",
         "security": [
@@ -4648,9 +4419,7 @@
     },
     "/api/competitions/upcoming": {
       "get": {
-        "tags": [
-          "Competition"
-        ],
+        "tags": ["Competition"],
         "summary": "Get upcoming competitions",
         "description": "Get all competitions that have not started yet (status=PENDING)",
         "security": [
@@ -4700,25 +4469,17 @@
                           },
                           "status": {
                             "type": "string",
-                            "enum": [
-                              "pending"
-                            ],
+                            "enum": ["pending"],
                             "description": "Competition status (always pending)"
                           },
                           "type": {
                             "type": "string",
-                            "enum": [
-                              "trading"
-                            ],
+                            "enum": ["trading"],
                             "description": "Competition type"
                           },
                           "crossChainTradingType": {
                             "type": "string",
-                            "enum": [
-                              "disallowAll",
-                              "disallowXParent",
-                              "allow"
-                            ],
+                            "enum": ["disallowAll", "disallowXParent", "allow"],
                             "description": "The type of cross-chain trading allowed in this competition"
                           },
                           "createdAt": {
@@ -4750,9 +4511,7 @@
     },
     "/api/competitions/{competitionId}": {
       "get": {
-        "tags": [
-          "Competition"
-        ],
+        "tags": ["Competition"],
         "summary": "Get competition details by ID",
         "description": "Get detailed information about a specific competition including all metadata",
         "security": [
@@ -4811,27 +4570,17 @@
                         },
                         "status": {
                           "type": "string",
-                          "enum": [
-                            "pending",
-                            "active",
-                            "completed"
-                          ],
+                          "enum": ["pending", "active", "completed"],
                           "description": "Competition status"
                         },
                         "type": {
                           "type": "string",
-                          "enum": [
-                            "trading"
-                          ],
+                          "enum": ["trading"],
                           "description": "Competition type"
                         },
                         "crossChainTradingType": {
                           "type": "string",
-                          "enum": [
-                            "disallowAll",
-                            "disallowXParent",
-                            "allow"
-                          ],
+                          "enum": ["disallowAll", "disallowXParent", "allow"],
                           "description": "The type of cross-chain trading allowed in this competition"
                         },
                         "startDate": {
@@ -4945,9 +4694,7 @@
     },
     "/api/competitions/{competitionId}/agents": {
       "get": {
-        "tags": [
-          "Competition"
-        ],
+        "tags": ["Competition"],
         "summary": "Get agents participating in a competition",
         "description": "Get a list of all agents participating in a specific competition with their scores and positions",
         "security": [
@@ -5155,9 +4902,7 @@
     },
     "/api/competitions/{competitionId}/agents/{agentId}": {
       "post": {
-        "tags": [
-          "Competition"
-        ],
+        "tags": ["Competition"],
         "summary": "Join a competition",
         "description": "Register an agent for a pending competition",
         "security": [
@@ -5226,9 +4971,7 @@
         }
       },
       "delete": {
-        "tags": [
-          "Competition"
-        ],
+        "tags": ["Competition"],
         "summary": "Leave a competition",
         "description": "Remove an agent from a competition. Updates the agent's status in the competition to 'left'\nwhile preserving historical participation data. Note: Cannot leave competitions that have already ended.\n",
         "security": [
@@ -5299,9 +5042,7 @@
     },
     "/api/health": {
       "get": {
-        "tags": [
-          "Health"
-        ],
+        "tags": ["Health"],
         "summary": "Basic health check",
         "description": "Check if the API is running",
         "responses": {
@@ -5343,9 +5084,7 @@
     },
     "/api/health/detailed": {
       "get": {
-        "tags": [
-          "Health"
-        ],
+        "tags": ["Health"],
         "summary": "Detailed health check",
         "description": "Check if the API and all its services are running properly",
         "responses": {
@@ -5422,9 +5161,7 @@
     },
     "/api/leaderboard": {
       "get": {
-        "tags": [
-          "Leaderboard"
-        ],
+        "tags": ["Leaderboard"],
         "summary": "Get global leaderboard",
         "description": "Get global leaderboard data across all relevant competitions",
         "parameters": [
@@ -5433,9 +5170,7 @@
             "name": "type",
             "schema": {
               "type": "string",
-              "enum": [
-                "trading"
-              ]
+              "enum": ["trading"]
             },
             "default": "trading"
           },
@@ -5600,9 +5335,7 @@
     },
     "/api/price": {
       "get": {
-        "tags": [
-          "Price"
-        ],
+        "tags": ["Price"],
         "summary": "Get price for a token",
         "description": "Get the current price of a specified token",
         "security": [
@@ -5626,10 +5359,7 @@
             "name": "chain",
             "schema": {
               "type": "string",
-              "enum": [
-                "evm",
-                "svm"
-              ]
+              "enum": ["evm", "svm"]
             },
             "required": false,
             "description": "Blockchain type of the token",
@@ -5683,10 +5413,7 @@
                     },
                     "chain": {
                       "type": "string",
-                      "enum": [
-                        "evm",
-                        "svm"
-                      ],
+                      "enum": ["evm", "svm"],
                       "description": "Blockchain type of the token"
                     },
                     "specificChain": {
@@ -5729,9 +5456,7 @@
     },
     "/api/price/token-info": {
       "get": {
-        "tags": [
-          "Price"
-        ],
+        "tags": ["Price"],
         "summary": "Get detailed token information",
         "description": "Get detailed token information including price and specific chain",
         "security": [
@@ -5755,10 +5480,7 @@
             "name": "chain",
             "schema": {
               "type": "string",
-              "enum": [
-                "evm",
-                "svm"
-              ]
+              "enum": ["evm", "svm"]
             },
             "required": false,
             "description": "Blockchain type of the token",
@@ -5812,10 +5534,7 @@
                     },
                     "chain": {
                       "type": "string",
-                      "enum": [
-                        "evm",
-                        "svm"
-                      ],
+                      "enum": ["evm", "svm"],
                       "description": "Blockchain type of the token"
                     },
                     "specificChain": {
@@ -5853,9 +5572,7 @@
     },
     "/api/trade/execute": {
       "post": {
-        "tags": [
-          "Trade"
-        ],
+        "tags": ["Trade"],
         "summary": "Execute a trade",
         "description": "Execute a trade between two tokens",
         "security": [
@@ -5869,12 +5586,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "fromToken",
-                  "toToken",
-                  "amount",
-                  "reason"
-                ],
+                "required": ["fromToken", "toToken", "amount", "reason"],
                 "properties": {
                   "fromToken": {
                     "type": "string",
@@ -6043,9 +5755,7 @@
     },
     "/api/trade/quote": {
       "get": {
-        "tags": [
-          "Trade"
-        ],
+        "tags": ["Trade"],
         "summary": "Get a quote for a trade",
         "description": "Get a quote for a potential trade between two tokens",
         "security": [
@@ -6221,9 +5931,7 @@
       "get": {
         "summary": "Get authenticated user profile",
         "description": "Retrieve the profile information for the currently authenticated user",
-        "tags": [
-          "User"
-        ],
+        "tags": ["User"],
         "security": [
           {
             "SIWESession": []
@@ -6266,12 +5974,7 @@
                         },
                         "status": {
                           "type": "string",
-                          "enum": [
-                            "active",
-                            "inactive",
-                            "suspended",
-                            "deleted"
-                          ]
+                          "enum": ["active", "inactive", "suspended", "deleted"]
                         },
                         "metadata": {
                           "type": "object",
@@ -6308,9 +6011,7 @@
       "put": {
         "summary": "Update authenticated user profile",
         "description": "Update the profile information for the currently authenticated user (limited fields)",
-        "tags": [
-          "User"
-        ],
+        "tags": ["User"],
         "security": [
           {
             "SIWESession": []
@@ -6426,9 +6127,7 @@
       "post": {
         "summary": "Create a new agent",
         "description": "Create a new agent for the authenticated user",
-        "tags": [
-          "User"
-        ],
+        "tags": ["User"],
         "security": [
           {
             "SIWESession": []
@@ -6440,9 +6139,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "name"
-                ],
+                "required": ["name"],
                 "properties": {
                   "name": {
                     "type": "string",
@@ -6525,12 +6222,7 @@
                         },
                         "status": {
                           "type": "string",
-                          "enum": [
-                            "active",
-                            "inactive",
-                            "suspended",
-                            "deleted"
-                          ]
+                          "enum": ["active", "inactive", "suspended", "deleted"]
                         },
                         "createdAt": {
                           "type": "string",
@@ -6584,9 +6276,7 @@
       "get": {
         "summary": "Get user's agents",
         "description": "Retrieve all agents owned by the authenticated user",
-        "tags": [
-          "User"
-        ],
+        "tags": ["User"],
         "security": [
           {
             "SIWESession": []
@@ -6747,9 +6437,7 @@
       "get": {
         "summary": "Get specific agent details",
         "description": "Retrieve details of a specific agent owned by the authenticated user",
-        "tags": [
-          "User"
-        ],
+        "tags": ["User"],
         "security": [
           {
             "SIWESession": []
@@ -6818,12 +6506,7 @@
                         },
                         "status": {
                           "type": "string",
-                          "enum": [
-                            "active",
-                            "inactive",
-                            "suspended",
-                            "deleted"
-                          ]
+                          "enum": ["active", "inactive", "suspended", "deleted"]
                         },
                         "stats": {
                           "type": "object",
@@ -6927,9 +6610,7 @@
       "get": {
         "summary": "Get agent API key",
         "description": "Retrieve the API key for a specific agent owned by the authenticated user. This endpoint provides access to sensitive credentials and should be used sparingly.",
-        "tags": [
-          "User"
-        ],
+        "tags": ["User"],
         "security": [
           {
             "SIWESession": []
@@ -7086,9 +6767,7 @@
       "put": {
         "summary": "Update agent profile",
         "description": "Update the profile information for a specific agent owned by the authenticated user",
-        "tags": [
-          "User"
-        ],
+        "tags": ["User"],
         "security": [
           {
             "SIWESession": []
@@ -7192,12 +6871,7 @@
                         },
                         "status": {
                           "type": "string",
-                          "enum": [
-                            "active",
-                            "inactive",
-                            "suspended",
-                            "deleted"
-                          ]
+                          "enum": ["active", "inactive", "suspended", "deleted"]
                         },
                         "deactivationReason": {
                           "type": "string",
@@ -7247,9 +6921,7 @@
       "get": {
         "summary": "Get competitions for user's agents",
         "description": "Retrieve all competitions that the authenticated user's agents have ever been registered for, regardless of current participation status",
-        "tags": [
-          "User"
-        ],
+        "tags": ["User"],
         "security": [
           {
             "SIWESession": []
@@ -7339,11 +7011,7 @@
                           },
                           "status": {
                             "type": "string",
-                            "enum": [
-                              "upcoming",
-                              "active",
-                              "ended"
-                            ]
+                            "enum": ["upcoming", "active", "ended"]
                           },
                           "startDate": {
                             "type": "string",
@@ -7355,10 +7023,7 @@
                           },
                           "crossChainTradingType": {
                             "type": "string",
-                            "enum": [
-                              "single_chain",
-                              "cross_chain"
-                            ]
+                            "enum": ["single_chain", "cross_chain"]
                           },
                           "createdAt": {
                             "type": "string",
@@ -7465,9 +7130,7 @@
       "post": {
         "summary": "Cast a vote for an agent in a competition",
         "description": "Cast a vote for an agent participating in a competition. Users can only vote once per competition.",
-        "tags": [
-          "Vote"
-        ],
+        "tags": ["Vote"],
         "security": [
           {
             "SIWESession": []
@@ -7479,10 +7142,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "agentId",
-                  "competitionId"
-                ],
+                "required": ["agentId", "competitionId"],
                 "properties": {
                   "agentId": {
                     "type": "string",
@@ -7608,9 +7268,7 @@
       "get": {
         "summary": "Get user's votes",
         "description": "Retrieve all votes cast by the authenticated user, optionally filtered by competition",
-        "tags": [
-          "Vote"
-        ],
+        "tags": ["Vote"],
         "security": [
           {
             "SIWESession": []
@@ -7727,9 +7385,7 @@
       "get": {
         "summary": "Get voting state for a competition",
         "description": "Get comprehensive voting state information for a user in a specific competition",
-        "tags": [
-          "Vote"
-        ],
+        "tags": ["Vote"],
         "security": [
           {
             "SIWESession": []

--- a/apps/api/src/config/index.ts
+++ b/apps/api/src/config/index.ts
@@ -245,6 +245,9 @@ export const config = {
   // Maximum trade size as percentage of portfolio value
   // Defaults to 25% if not specified
   maxTradePercentage: parseInt(process.env.MAX_TRADE_PERCENTAGE || "25", 10),
+  // Sandbox mode - automatically join newly registered agents to active competitions
+  // Defaults to false for security, must be explicitly enabled
+  sandbox: process.env.SANDBOX === "true",
 };
 
 /**

--- a/apps/api/src/controllers/admin.controller.ts
+++ b/apps/api/src/controllers/admin.controller.ts
@@ -714,11 +714,20 @@ export function makeAdminController(services: ServiceRegistry) {
         // Populate object_index with competition data
         try {
           await services.objectIndexService.populateTrades(competitionId);
-          await services.objectIndexService.populateAgentRankHistory(competitionId);
-          await services.objectIndexService.populateCompetitionsLeaderboard(competitionId);
-          console.log(`Successfully populated object_index for competition ${competitionId}`);
+          await services.objectIndexService.populateAgentRankHistory(
+            competitionId,
+          );
+          await services.objectIndexService.populateCompetitionsLeaderboard(
+            competitionId,
+          );
+          console.log(
+            `Successfully populated object_index for competition ${competitionId}`,
+          );
         } catch (error) {
-          console.error(`Failed to populate object_index for competition ${competitionId}:`, error);
+          console.error(
+            `Failed to populate object_index for competition ${competitionId}:`,
+            error,
+          );
           // Don't fail the request if object_index population fails
         }
 
@@ -748,36 +757,56 @@ export function makeAdminController(services: ServiceRegistry) {
           validatedCompetitionId = ensureUuid(competitionId);
         }
 
-        const defaultDataTypes = [SYNC_DATA_TYPE.TRADE, SYNC_DATA_TYPE.AGENT_RANK_HISTORY, SYNC_DATA_TYPE.COMPETITIONS_LEADERBOARD];
+        const defaultDataTypes = [
+          SYNC_DATA_TYPE.TRADE,
+          SYNC_DATA_TYPE.AGENT_RANK_HISTORY,
+          SYNC_DATA_TYPE.COMPETITIONS_LEADERBOARD,
+        ];
         let typesToSync: string[] = defaultDataTypes;
 
         if (dataTypes) {
-          const validationResults = dataTypes.map((dt: unknown) => SyncDataTypeSchema.safeParse(dt));
-          const hasErrors = validationResults.some((result: { success: boolean }) => !result.success);
+          const validationResults = dataTypes.map((dt: unknown) =>
+            SyncDataTypeSchema.safeParse(dt),
+          );
+          const hasErrors = validationResults.some(
+            (result: { success: boolean }) => !result.success,
+          );
 
           if (hasErrors) {
             throw new ApiError(400, "Invalid data type(s) provided");
           }
 
-          typesToSync = validationResults.map((result: { data?: string }) => result.data!).filter(Boolean);
+          typesToSync = validationResults
+            .map((result: { data?: string }) => result.data!)
+            .filter(Boolean);
         }
 
-        console.log(`Starting object index sync for types: ${typesToSync.join(', ')}`);
+        console.log(
+          `Starting object index sync for types: ${typesToSync.join(", ")}`,
+        );
 
         for (const dataType of typesToSync) {
           try {
             switch (dataType) {
               case SYNC_DATA_TYPE.TRADE:
-                await services.objectIndexService.populateTrades(validatedCompetitionId);
+                await services.objectIndexService.populateTrades(
+                  validatedCompetitionId,
+                );
                 break;
               case SYNC_DATA_TYPE.AGENT_RANK_HISTORY:
-                await services.objectIndexService.populateAgentRankHistory(validatedCompetitionId);
+                await services.objectIndexService.populateAgentRankHistory(
+                  validatedCompetitionId,
+                );
                 break;
               case SYNC_DATA_TYPE.COMPETITIONS_LEADERBOARD:
-                await services.objectIndexService.populateCompetitionsLeaderboard(validatedCompetitionId);
+                await services.objectIndexService.populateCompetitionsLeaderboard(
+                  validatedCompetitionId,
+                );
                 break;
               case SYNC_DATA_TYPE.PORTFOLIO_SNAPSHOT:
-                await services.objectIndexService.populatePortfolioSnapshots(validatedCompetitionId);
+                await services.objectIndexService.populatePortfolioSnapshots(
+                  validatedCompetitionId,
+                );
                 break;
               case SYNC_DATA_TYPE.AGENT_RANK:
                 await services.objectIndexService.populateAgentRank();
@@ -793,9 +822,9 @@ export function makeAdminController(services: ServiceRegistry) {
 
         res.status(200).json({
           success: true,
-          message: 'Object index sync initiated',
+          message: "Object index sync initiated",
           dataTypes: typesToSync,
-          competitionId: validatedCompetitionId || 'all'
+          competitionId: validatedCompetitionId || "all",
         });
       } catch (error) {
         next(error);
@@ -814,8 +843,8 @@ export function makeAdminController(services: ServiceRegistry) {
           competitionId,
           agentId,
           dataType,
-          limit = '100',
-          offset = '0'
+          limit = "100",
+          offset = "0",
         } = req.query;
 
         let validatedCompetitionId: string | undefined;
@@ -845,16 +874,16 @@ export function makeAdminController(services: ServiceRegistry) {
             {
               competitionId: validatedCompetitionId,
               agentId: validatedAgentId,
-              dataType: validatedDataType
+              dataType: validatedDataType,
             },
             limitNum,
-            offsetNum
+            offsetNum,
           ),
           objectIndexRepository.count({
             competitionId: validatedCompetitionId,
             agentId: validatedAgentId,
-            dataType: validatedDataType
-          })
+            dataType: validatedDataType,
+          }),
         ]);
 
         res.status(200).json({
@@ -864,9 +893,9 @@ export function makeAdminController(services: ServiceRegistry) {
             pagination: {
               total: totalCount,
               limit: limitNum,
-              offset: offsetNum
-            }
-          }
+              offset: offsetNum,
+            },
+          },
         });
       } catch (error) {
         next(error);

--- a/apps/api/src/database/repositories/agentrank-repository.ts
+++ b/apps/api/src/database/repositories/agentrank-repository.ts
@@ -235,7 +235,10 @@ export async function getAllAgentRankHistory(competitionId?: string) {
 
     return await query;
   } catch (error) {
-    console.error("[AgentRankRepository] Error in getAllAgentRankHistory:", error);
+    console.error(
+      "[AgentRankRepository] Error in getAllAgentRankHistory:",
+      error,
+    );
     throw error;
   }
 }
@@ -245,10 +248,7 @@ export async function getAllAgentRankHistory(competitionId?: string) {
  */
 export async function getAllRawAgentRanks() {
   try {
-    return await db
-      .select()
-      .from(agentRank)
-      .orderBy(desc(agentRank.ordinal));
+    return await db.select().from(agentRank).orderBy(desc(agentRank.ordinal));
   } catch (error) {
     console.error("[AgentRankRepository] Error in getAllRawAgentRanks:", error);
     throw error;

--- a/apps/api/src/database/repositories/competition-repository.ts
+++ b/apps/api/src/database/repositories/competition-repository.ts
@@ -825,7 +825,7 @@ export async function getPortfolioTokenValuesByIds(snapshotIds: number[]) {
     if (snapshotIds.length === 0) {
       return [];
     }
-    
+
     return await db
       .select()
       .from(portfolioTokenValues)

--- a/apps/api/src/database/repositories/object-index.repository.ts
+++ b/apps/api/src/database/repositories/object-index.repository.ts
@@ -1,23 +1,26 @@
+import { and, count, desc, eq } from "drizzle-orm";
+
 import { db } from "@/database/db.js";
 import { objectIndex } from "@/database/schema/syncing/defs.js";
 import { SyncDataType } from "@/types/index.js";
-import { and, count, desc, eq } from "drizzle-orm";
 
 export class ObjectIndexRepository {
   /**
    * Insert multiple object index entries
    */
-  async insertObjectIndexEntries(entries: Array<{
-    id: string;
-    competitionId: string | null;
-    agentId: string;
-    dataType: SyncDataType;
-    data: string;
-    sizeBytes: number;
-    metadata: unknown;
-    eventTimestamp: Date;
-    createdAt: Date;
-  }>) {
+  async insertObjectIndexEntries(
+    entries: Array<{
+      id: string;
+      competitionId: string | null;
+      agentId: string;
+      dataType: SyncDataType;
+      data: string;
+      sizeBytes: number;
+      metadata: unknown;
+      eventTimestamp: Date;
+      createdAt: Date;
+    }>,
+  ) {
     if (entries.length === 0) return;
     await db.insert(objectIndex).values(entries);
   }
@@ -48,7 +51,7 @@ export class ObjectIndexRepository {
     dataType?: SyncDataType;
   }) {
     const conditions = [];
-    
+
     if (filters?.competitionId) {
       conditions.push(eq(objectIndex.competitionId, filters.competitionId));
     }
@@ -59,9 +62,7 @@ export class ObjectIndexRepository {
       conditions.push(eq(objectIndex.dataType, filters.dataType));
     }
 
-    const query = db
-      .select({ count: count() })
-      .from(objectIndex);
+    const query = db.select({ count: count() }).from(objectIndex);
 
     if (conditions.length > 0) {
       query.where(and(...conditions));
@@ -81,10 +82,10 @@ export class ObjectIndexRepository {
       dataType?: SyncDataType;
     },
     limit = 100,
-    offset = 0
+    offset = 0,
   ) {
     const conditions = [];
-    
+
     if (filters?.competitionId) {
       conditions.push(eq(objectIndex.competitionId, filters.competitionId));
     }

--- a/apps/api/src/database/repositories/trade-repository.ts
+++ b/apps/api/src/database/repositories/trade-repository.ts
@@ -169,10 +169,7 @@ export async function count() {
  */
 export async function getAllTrades(competitionId?: string) {
   try {
-    const query = db
-      .select()
-      .from(trades)
-      .orderBy(desc(trades.timestamp));
+    const query = db.select().from(trades).orderBy(desc(trades.timestamp));
 
     if (competitionId) {
       query.where(eq(trades.competitionId, competitionId));

--- a/apps/api/src/scripts/populate-object-index.ts
+++ b/apps/api/src/scripts/populate-object-index.ts
@@ -8,28 +8,38 @@ interface PopulateOptions {
 }
 
 async function populateObjectIndex(options: PopulateOptions) {
-  const { dataTypes = [SYNC_DATA_TYPE.TRADE], competitionId, batchSize = 1000 } = options;
+  const {
+    dataTypes = [SYNC_DATA_TYPE.TRADE],
+    competitionId,
+    batchSize = 1000,
+  } = options;
   const services = ServiceRegistry.getInstance();
 
-  console.log('Starting object_index population...');
-  console.log('Options:', { dataTypes, competitionId, batchSize });
+  console.log("Starting object_index population...");
+  console.log("Options:", { dataTypes, competitionId, batchSize });
 
   for (const dataType of dataTypes) {
     console.log(`\nPopulating ${dataType} data...`);
-    
+
     try {
       switch (dataType) {
         case SYNC_DATA_TYPE.TRADE:
           await services.objectIndexService.populateTrades(competitionId);
           break;
         case SYNC_DATA_TYPE.AGENT_RANK_HISTORY:
-          await services.objectIndexService.populateAgentRankHistory(competitionId);
+          await services.objectIndexService.populateAgentRankHistory(
+            competitionId,
+          );
           break;
         case SYNC_DATA_TYPE.COMPETITIONS_LEADERBOARD:
-          await services.objectIndexService.populateCompetitionsLeaderboard(competitionId);
+          await services.objectIndexService.populateCompetitionsLeaderboard(
+            competitionId,
+          );
           break;
         case SYNC_DATA_TYPE.PORTFOLIO_SNAPSHOT:
-          await services.objectIndexService.populatePortfolioSnapshots(competitionId);
+          await services.objectIndexService.populatePortfolioSnapshots(
+            competitionId,
+          );
           break;
         case SYNC_DATA_TYPE.AGENT_RANK:
           await services.objectIndexService.populateAgentRank(); // No competitionId
@@ -43,7 +53,7 @@ async function populateObjectIndex(options: PopulateOptions) {
     }
   }
 
-  console.log('\nPopulation complete!');
+  console.log("\nPopulation complete!");
 }
 
 // Parse command line arguments
@@ -53,14 +63,14 @@ function parseArgs() {
 
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
-    
-    if (arg === '--data-types' && args[i + 1]) {
-      options.dataTypes = args[i + 1]!.split(',') as SyncDataType[];
+
+    if (arg === "--data-types" && args[i + 1]) {
+      options.dataTypes = args[i + 1]!.split(",") as SyncDataType[];
       i++;
-    } else if (arg === '--competition-id' && args[i + 1]) {
+    } else if (arg === "--competition-id" && args[i + 1]) {
       options.competitionId = args[i + 1];
       i++;
-    } else if (arg === '--batch-size' && args[i + 1]) {
+    } else if (arg === "--batch-size" && args[i + 1]) {
       options.batchSize = parseInt(args[i + 1]!, 10);
       i++;
     }
@@ -71,8 +81,12 @@ function parseArgs() {
 
 // Execute the script if run directly
 const defaultOptions: PopulateOptions = {
-  dataTypes: [SYNC_DATA_TYPE.TRADE, SYNC_DATA_TYPE.AGENT_RANK_HISTORY, SYNC_DATA_TYPE.COMPETITIONS_LEADERBOARD],
-  batchSize: 1000
+  dataTypes: [
+    SYNC_DATA_TYPE.TRADE,
+    SYNC_DATA_TYPE.AGENT_RANK_HISTORY,
+    SYNC_DATA_TYPE.COMPETITIONS_LEADERBOARD,
+  ],
+  batchSize: 1000,
 };
 
 const cliOptions = parseArgs();
@@ -80,11 +94,11 @@ const options = { ...defaultOptions, ...cliOptions };
 
 populateObjectIndex(options)
   .then(() => {
-    console.log('✅ Population complete');
+    console.log("✅ Population complete");
     process.exit(0);
   })
   .catch((error) => {
-    console.error('❌ Population failed:', error);
+    console.error("❌ Population failed:", error);
     process.exit(1);
   });
 

--- a/apps/api/src/services/competition-manager.service.ts
+++ b/apps/api/src/services/competition-manager.service.ts
@@ -1090,15 +1090,27 @@ export class CompetitionManager {
         return;
       }
 
+      // Check if agent is already in the competition
+      const isAlreadyInCompetition = await this.isAgentInCompetition(
+        activeCompetition.id,
+        agentId,
+      );
+      if (isAlreadyInCompetition) {
+        console.log(
+          `[CompetitionManager] Agent ${agentId} is already in competition ${activeCompetition.id}, skipping auto-join`,
+        );
+        return;
+      }
+
       console.log(
         `[CompetitionManager] Auto-joining agent ${agentId} to active competition ${activeCompetition.id}`,
       );
 
+      // Reset the agent's balances to starting values (consistent with startCompetition order)
+      await this.balanceManager.resetAgentBalances(agentId);
+
       // Add the agent to the competition
       await addAgentToCompetition(activeCompetition.id, agentId);
-
-      // Reset the agent's balances to starting values
-      await this.balanceManager.resetAgentBalances(agentId);
 
       // Take a portfolio snapshot for this specific agent
       await this.portfolioSnapshotter.takeAgentPortfolioSnapshot(

--- a/apps/api/src/services/object-index.service.ts
+++ b/apps/api/src/services/object-index.service.ts
@@ -1,29 +1,32 @@
 import { v4 as uuidv4 } from "uuid";
-import { objectIndexRepository } from "@/database/repositories/object-index.repository.js";
-import * as tradeRepository from "@/database/repositories/trade-repository.js";
+
 import * as agentRankRepository from "@/database/repositories/agentrank-repository.js";
 import * as competitionRepository from "@/database/repositories/competition-repository.js";
+import { objectIndexRepository } from "@/database/repositories/object-index.repository.js";
+import * as tradeRepository from "@/database/repositories/trade-repository.js";
 
 export class ObjectIndexService {
   /**
    * Populate object_index with trade data
    */
   async populateTrades(competitionId?: string) {
-    console.log(`Populating trades${competitionId ? ` for competition ${competitionId}` : ''}`);
-    
+    console.log(
+      `Populating trades${competitionId ? ` for competition ${competitionId}` : ""}`,
+    );
+
     // Use trade repository to fetch trades
     const tradesToSync = await tradeRepository.getAllTrades(competitionId);
-    
+
     if (tradesToSync.length === 0) {
-      console.log('No trades to sync');
+      console.log("No trades to sync");
       return;
     }
 
-    const entries = tradesToSync.map(trade => ({
+    const entries = tradesToSync.map((trade) => ({
       id: uuidv4(),
       competitionId: trade.competitionId,
       agentId: trade.agentId,
-      dataType: 'trade' as const,
+      dataType: "trade" as const,
       data: JSON.stringify(trade),
       sizeBytes: Buffer.byteLength(JSON.stringify(trade)),
       metadata: {
@@ -32,11 +35,11 @@ export class ObjectIndexService {
         hasReason: !!trade.reason,
         chains: {
           from: trade.fromChain,
-          to: trade.toChain
-        }
+          to: trade.toChain,
+        },
       },
       eventTimestamp: trade.timestamp || new Date(),
-      createdAt: new Date()
+      createdAt: new Date(),
     }));
 
     await objectIndexRepository.insertObjectIndexEntries(entries);
@@ -47,30 +50,33 @@ export class ObjectIndexService {
    * Populate object_index with agent rank history
    */
   async populateAgentRankHistory(competitionId?: string) {
-    console.log(`Populating agent rank history${competitionId ? ` for competition ${competitionId}` : ''}`);
-    
+    console.log(
+      `Populating agent rank history${competitionId ? ` for competition ${competitionId}` : ""}`,
+    );
+
     // Use agent rank repository to fetch history
-    const rankHistory = await agentRankRepository.getAllAgentRankHistory(competitionId);
-    
+    const rankHistory =
+      await agentRankRepository.getAllAgentRankHistory(competitionId);
+
     if (rankHistory.length === 0) {
-      console.log('No agent rank history to sync');
+      console.log("No agent rank history to sync");
       return;
     }
 
-    const entries = rankHistory.map(rank => ({
+    const entries = rankHistory.map((rank) => ({
       id: uuidv4(),
       competitionId: rank.competitionId,
       agentId: rank.agentId,
-      dataType: 'agent_rank_history' as const,
+      dataType: "agent_rank_history" as const,
       data: JSON.stringify(rank),
       sizeBytes: Buffer.byteLength(JSON.stringify(rank)),
       metadata: {
         mu: rank.mu,
         sigma: rank.sigma,
-        ordinal: rank.ordinal
+        ordinal: rank.ordinal,
       },
       eventTimestamp: rank.createdAt,
-      createdAt: new Date()
+      createdAt: new Date(),
     }));
 
     await objectIndexRepository.insertObjectIndexEntries(entries);
@@ -81,29 +87,32 @@ export class ObjectIndexService {
    * Populate object_index with competitions leaderboard
    */
   async populateCompetitionsLeaderboard(competitionId?: string) {
-    console.log(`Populating competitions leaderboard${competitionId ? ` for competition ${competitionId}` : ''}`);
-    
+    console.log(
+      `Populating competitions leaderboard${competitionId ? ` for competition ${competitionId}` : ""}`,
+    );
+
     // Use competition repository to fetch leaderboard
-    const leaderboard = await competitionRepository.getAllCompetitionsLeaderboard(competitionId);
-    
+    const leaderboard =
+      await competitionRepository.getAllCompetitionsLeaderboard(competitionId);
+
     if (leaderboard.length === 0) {
-      console.log('No leaderboard entries to sync');
+      console.log("No leaderboard entries to sync");
       return;
     }
 
-    const entries = leaderboard.map(entry => ({
+    const entries = leaderboard.map((entry) => ({
       id: uuidv4(),
       competitionId: entry.competitionId,
       agentId: entry.agentId,
-      dataType: 'competitions_leaderboard' as const,
+      dataType: "competitions_leaderboard" as const,
       data: JSON.stringify(entry),
       sizeBytes: Buffer.byteLength(JSON.stringify(entry)),
       metadata: {
         rank: entry.rank,
-        score: entry.score
+        score: entry.score,
       },
       eventTimestamp: entry.createdAt,
-      createdAt: new Date()
+      createdAt: new Date(),
     }));
 
     await objectIndexRepository.insertObjectIndexEntries(entries);
@@ -114,50 +123,57 @@ export class ObjectIndexService {
    * Populate object_index with portfolio snapshots
    */
   async populatePortfolioSnapshots(competitionId?: string) {
-    console.log(`Populating portfolio snapshots${competitionId ? ` for competition ${competitionId}` : ''}`);
-    
+    console.log(
+      `Populating portfolio snapshots${competitionId ? ` for competition ${competitionId}` : ""}`,
+    );
+
     // Use competition repository to fetch snapshots
-    const snapshots = await competitionRepository.getAllPortfolioSnapshots(competitionId);
-    
+    const snapshots =
+      await competitionRepository.getAllPortfolioSnapshots(competitionId);
+
     if (snapshots.length === 0) {
-      console.log('No portfolio snapshots to sync');
+      console.log("No portfolio snapshots to sync");
       return;
     }
 
     // Fetch token values for all snapshots using the new batch method
-    const snapshotIds = snapshots.map(s => s.id);
-    const allTokenValues = await competitionRepository.getPortfolioTokenValuesByIds(snapshotIds);
-    
-    // Group token values by snapshot ID
-    const tokenValuesBySnapshot = allTokenValues.reduce((acc, tv) => {
-      if (!acc[tv.portfolioSnapshotId]) {
-        acc[tv.portfolioSnapshotId] = [];
-      }
-      acc[tv.portfolioSnapshotId]!.push(tv);
-      return acc;
-    }, {} as Record<number, typeof allTokenValues>);
+    const snapshotIds = snapshots.map((s) => s.id);
+    const allTokenValues =
+      await competitionRepository.getPortfolioTokenValuesByIds(snapshotIds);
 
-    const entries = snapshots.map(snapshot => {
+    // Group token values by snapshot ID
+    const tokenValuesBySnapshot = allTokenValues.reduce(
+      (acc, tv) => {
+        if (!acc[tv.portfolioSnapshotId]) {
+          acc[tv.portfolioSnapshotId] = [];
+        }
+        acc[tv.portfolioSnapshotId]!.push(tv);
+        return acc;
+      },
+      {} as Record<number, typeof allTokenValues>,
+    );
+
+    const entries = snapshots.map((snapshot) => {
       const tokenValues = tokenValuesBySnapshot[snapshot.id] || [];
       const snapshotData = {
         ...snapshot,
-        tokenValues
+        tokenValues,
       };
 
       return {
         id: uuidv4(),
         competitionId: snapshot.competitionId,
         agentId: snapshot.agentId,
-        dataType: 'portfolio_snapshot' as const,
+        dataType: "portfolio_snapshot" as const,
         data: JSON.stringify(snapshotData),
         sizeBytes: Buffer.byteLength(JSON.stringify(snapshotData)),
         metadata: {
           totalValue: snapshot.totalValue,
           tokenCount: tokenValues.length,
-          snapshotId: snapshot.id
+          snapshotId: snapshot.id,
         },
         eventTimestamp: snapshot.timestamp || new Date(),
-        createdAt: new Date()
+        createdAt: new Date(),
       };
     });
 
@@ -169,30 +185,30 @@ export class ObjectIndexService {
    * Populate object_index with current agent ranks
    */
   async populateAgentRank() {
-    console.log('Populating current agent ranks');
-    
+    console.log("Populating current agent ranks");
+
     // Use agent rank repository to fetch raw ranks
     const ranks = await agentRankRepository.getAllRawAgentRanks();
-    
+
     if (ranks.length === 0) {
-      console.log('No agent ranks to sync');
+      console.log("No agent ranks to sync");
       return;
     }
 
-    const entries = ranks.map(rank => ({
+    const entries = ranks.map((rank) => ({
       id: uuidv4(),
       competitionId: null, // No competition association
       agentId: rank.agentId,
-      dataType: 'agent_rank' as const,
+      dataType: "agent_rank" as const,
       data: JSON.stringify(rank),
       sizeBytes: Buffer.byteLength(JSON.stringify(rank)),
       metadata: {
         mu: rank.mu,
         sigma: rank.sigma,
-        ordinal: rank.ordinal
+        ordinal: rank.ordinal,
       },
       eventTimestamp: rank.updatedAt,
-      createdAt: new Date()
+      createdAt: new Date(),
     }));
 
     await objectIndexRepository.insertObjectIndexEntries(entries);
@@ -220,7 +236,7 @@ export class ObjectIndexService {
       id: uuidv4(),
       competitionId: trade.competitionId as string | null,
       agentId: trade.agentId as string,
-      dataType: 'trade' as const,
+      dataType: "trade" as const,
       data: JSON.stringify(trade),
       sizeBytes: Buffer.byteLength(JSON.stringify(trade)),
       metadata: {
@@ -229,11 +245,11 @@ export class ObjectIndexService {
         hasReason: !!trade.reason,
         chains: {
           from: trade.fromChain,
-          to: trade.toChain
-        }
+          to: trade.toChain,
+        },
       },
       eventTimestamp: (trade.timestamp || new Date()) as Date,
-      createdAt: new Date()
+      createdAt: new Date(),
     };
 
     await objectIndexRepository.insertObjectIndexEntry(entry);
@@ -254,16 +270,16 @@ export class ObjectIndexService {
       id: uuidv4(),
       competitionId: null,
       agentId: rank.agentId as string,
-      dataType: 'agent_rank' as const,
+      dataType: "agent_rank" as const,
       data: JSON.stringify(rank),
       sizeBytes: Buffer.byteLength(JSON.stringify(rank)),
       metadata: {
         mu: rank.mu,
         sigma: rank.sigma,
-        ordinal: rank.ordinal
+        ordinal: rank.ordinal,
       },
       eventTimestamp: (rank.updatedAt || new Date()) as Date,
-      createdAt: new Date()
+      createdAt: new Date(),
     };
 
     await objectIndexRepository.insertObjectIndexEntry(entry);

--- a/apps/api/src/services/portfolio-snapshotter.service.ts
+++ b/apps/api/src/services/portfolio-snapshotter.service.ts
@@ -211,6 +211,161 @@ export class PortfolioSnapshotter {
   }
 
   /**
+   * Take a portfolio snapshot for a specific agent in a competition
+   * Used for sandbox mode when auto-joining agents to avoid snapshotting all agents
+   * @param competitionId The competition ID
+   * @param agentId The specific agent ID to snapshot
+   */
+  async takeAgentPortfolioSnapshot(
+    competitionId: string,
+    agentId: string,
+  ): Promise<void> {
+    console.log(
+      `[PortfolioSnapshotter] Taking portfolio snapshot for agent ${agentId} in competition ${competitionId}`,
+    );
+
+    const startTime = Date.now();
+    const timestamp = new Date();
+    let priceLookupCount = 0;
+    let dbPriceHitCount = 0;
+    let reusedPriceCount = 0;
+
+    const balances = await this.balanceManager.getAllBalances(agentId);
+    const valuesByToken: Record<
+      string,
+      {
+        amount: number;
+        valueUsd: number;
+        price: number;
+        symbol: string;
+        specificChain: string | null;
+      }
+    > = {};
+    let totalValue = 0;
+
+    for (const balance of balances) {
+      priceLookupCount++;
+
+      // First try to get latest price record from the database to reuse chain information
+      const latestPriceRecord = await getLatestPrice(
+        balance.tokenAddress,
+        balance.specificChain as SpecificChain,
+      );
+
+      let specificChain: string | null;
+      let priceResult;
+
+      if (
+        latestPriceRecord &&
+        latestPriceRecord.timestamp &&
+        latestPriceRecord.chain &&
+        latestPriceRecord.specificChain
+      ) {
+        dbPriceHitCount++;
+        specificChain = latestPriceRecord.specificChain;
+
+        // If price is recent enough (less than 10 minutes old), use it directly
+        const priceAge = Date.now() - latestPriceRecord.timestamp.getTime();
+        const isFreshPrice = priceAge < config.portfolio.priceFreshnessMs;
+
+        if (isFreshPrice) {
+          // Use the existing price if it's fresh
+          priceResult = {
+            price: latestPriceRecord.price,
+            symbol: latestPriceRecord.symbol,
+            timestamp: latestPriceRecord.timestamp,
+            // TODO: Implement typing for these as Drizzle enums or custom types
+            chain: latestPriceRecord.chain as BlockchainType,
+            specificChain: latestPriceRecord.specificChain as SpecificChain,
+            token: latestPriceRecord.token,
+          };
+          reusedPriceCount++;
+          console.log(
+            `[PortfolioSnapshotter] Using fresh price for ${balance.tokenAddress} from DB: $${priceResult.price} (${specificChain}) - age ${Math.round(priceAge / 1000)}s, threshold ${Math.round(config.portfolio.priceFreshnessMs / 1000)}s`,
+          );
+        } else if (specificChain && latestPriceRecord.chain) {
+          // Use specific chain information to avoid chain detection when fetching a new price
+          console.log(
+            `[PortfolioSnapshotter] Using specific chain info from DB for ${balance.tokenAddress}: ${specificChain}`,
+          );
+
+          // Pass both chain type and specific chain to getPrice to bypass chain detection
+          const result = await this.priceTracker.getPrice(
+            balance.tokenAddress,
+            latestPriceRecord.chain as BlockchainType,
+            specificChain as SpecificChain,
+          );
+          if (result !== null) {
+            priceResult = result;
+          }
+        } else {
+          // Fallback to regular price lookup
+          const result = await this.priceTracker.getPrice(balance.tokenAddress);
+          if (result !== null) {
+            priceResult = result;
+          }
+        }
+      } else {
+        // No price record found, do regular price lookup
+        const result = await this.priceTracker.getPrice(balance.tokenAddress);
+        if (result !== null) {
+          priceResult = result;
+        }
+      }
+
+      if (priceResult) {
+        const valueUsd = balance.amount * priceResult.price;
+        valuesByToken[balance.tokenAddress] = {
+          amount: balance.amount,
+          valueUsd,
+          price: priceResult.price,
+          symbol: priceResult.symbol,
+          specificChain: priceResult.specificChain,
+        };
+        totalValue += valueUsd;
+      } else {
+        console.warn(
+          `[PortfolioSnapshotter] No price available for token ${balance.tokenAddress}, excluding from portfolio snapshot`,
+        );
+      }
+    }
+
+    // Create portfolio snapshot in database
+    const snapshot = await createPortfolioSnapshot({
+      agentId,
+      competitionId,
+      timestamp,
+      totalValue,
+    });
+
+    // Store token values
+    for (const [token, data] of Object.entries(valuesByToken)) {
+      await createPortfolioTokenValue({
+        portfolioSnapshotId: snapshot.id,
+        tokenAddress: token,
+        amount: data.amount,
+        valueUsd: data.valueUsd,
+        price: data.price,
+        symbol: data.symbol,
+        specificChain: data.specificChain,
+      });
+    }
+
+    const endTime = Date.now();
+    const duration = endTime - startTime;
+
+    console.log(
+      `[PortfolioSnapshotter] Completed portfolio snapshot for agent ${agentId} in ${duration}ms`,
+    );
+    console.log(
+      `[PortfolioSnapshotter] Price lookup stats: Total: ${priceLookupCount}, DB hits: ${dbPriceHitCount}, Hit rate: ${((dbPriceHitCount / priceLookupCount) * 100).toFixed(2)}%`,
+    );
+    console.log(
+      `[PortfolioSnapshotter] Reused existing prices: ${reusedPriceCount}/${priceLookupCount} (${((reusedPriceCount / priceLookupCount) * 100).toFixed(2)}%)`,
+    );
+  }
+
+  /**
    * Check if Portfolio Snapshotter is healthy
    * For system health check use
    */

--- a/apps/api/src/types/index.ts
+++ b/apps/api/src/types/index.ts
@@ -606,7 +606,7 @@ export const SYNC_DATA_TYPE_VALUES = [
   "agent_rank_history",
   "agent_rank",
   "competitions_leaderboard",
-  "portfolio_snapshot"
+  "portfolio_snapshot",
 ] as const;
 
 /**
@@ -617,7 +617,7 @@ export const SYNC_DATA_TYPE = {
   AGENT_RANK_HISTORY: "agent_rank_history",
   AGENT_RANK: "agent_rank",
   COMPETITIONS_LEADERBOARD: "competitions_leaderboard",
-  PORTFOLIO_SNAPSHOT: "portfolio_snapshot"
+  PORTFOLIO_SNAPSHOT: "portfolio_snapshot",
 } as const;
 
 /**

--- a/apps/api/turbo.json
+++ b/apps/api/turbo.json
@@ -35,6 +35,7 @@
         "INITIAL_SVM_USDT_BALANCE",
         "MAX_TRADE_PERCENTAGE",
         "NODE_ENV",
+        "SANDBOX",
         "NOVES_API_KEY",
         "API_PREFIX",
         "PORTFOLIO_PRICE_FRESHNESS_MS",


### PR DESCRIPTION
# Overview
Implemented sandbox mode feature that automatically joins newly registered agents to active competitions when `SANDBOX=true` environment variable is set.

### Key Changes
- **Configuration**: Added `sandbox` boolean to config object from `SANDBOX` environment variable
- **Service Layer**: 
  - Added `CompetitionManager.autoJoinAgentToActiveCompetition()` method
  - Added `PortfolioSnapshotter.takeAgentPortfolioSnapshot()` for single-agent snapshots
- **Controller Layer**: Modified `AdminController.registerAgent()` to check sandbox mode and auto-join agents
- **Testing**: E2E test cases in `sandbox.test.ts` covering all scenarios
- **Documentation**: Added sandbox mode section to API README with usage examples

### Technical Implementation
- Preserves existing architectural patterns (controllers → services → repositories)
- Graceful error handling: agent registration succeeds even if auto-join fails
- Auto-join process: resets balances, adds to competition, takes portfolio snapshot
- Only affects agent registration via `/admin/agents` POST endpoint
- No breaking changes to existing API contracts