### PR TITLE
feat: adds email verification

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -78,3 +78,8 @@ API_DOMAIN=http://localhost:3000
 
 # Optional: API prefix (e.g., API_PREFIX=development -> /development/api/...)
 API_PREFIX=
+
+# Loops API Key
+LOOPS_API_KEY=email_loops_api_key
+# Loops email template id
+LOOPS_TRANSACTIONAL_ID=email_loops_transactional_id

--- a/apps/api/drizzle/0018_opposite_marrow.sql
+++ b/apps/api/drizzle/0018_opposite_marrow.sql
@@ -2,7 +2,7 @@ CREATE TABLE "email_verification_tokens" (
 	"id" uuid PRIMARY KEY NOT NULL,
 	"user_id" uuid,
 	"agent_id" uuid,
-	"token" varchar(255) NOT NULL,
+	"token" char(36) NOT NULL,
 	"expires_at" timestamp with time zone NOT NULL,
 	"used" boolean DEFAULT false,
 	"created_at" timestamp with time zone DEFAULT now() NOT NULL,

--- a/apps/api/drizzle/0018_oval_lady_ursula.sql
+++ b/apps/api/drizzle/0018_oval_lady_ursula.sql
@@ -1,0 +1,18 @@
+CREATE TABLE "email_verification_tokens" (
+	"id" uuid PRIMARY KEY NOT NULL,
+	"user_id" uuid,
+	"agent_id" uuid,
+	"token" varchar(255) NOT NULL,
+	"expires_at" timestamp with time zone NOT NULL,
+	"used" boolean DEFAULT false,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "email_verification_tokens_token_unique" UNIQUE("token"),
+	CONSTRAINT "email_verification_tokens_token_key" UNIQUE("token")
+);
+--> statement-breakpoint
+ALTER TABLE "agents" ADD COLUMN "is_email_verified" boolean DEFAULT false;--> statement-breakpoint
+ALTER TABLE "users" ADD COLUMN "is_email_verified" boolean DEFAULT false;--> statement-breakpoint
+ALTER TABLE "email_verification_tokens" ADD CONSTRAINT "email_verification_tokens_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "email_verification_tokens" ADD CONSTRAINT "email_verification_tokens_agent_id_fkey" FOREIGN KEY ("agent_id") REFERENCES "public"."agents"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "idx_email_verification_tokens_user_id_token" ON "email_verification_tokens" USING btree ("user_id","token");--> statement-breakpoint
+CREATE INDEX "idx_email_verification_tokens_agent_id_token" ON "email_verification_tokens" USING btree ("agent_id","token");

--- a/apps/api/drizzle/meta/0018_snapshot.json
+++ b/apps/api/drizzle/meta/0018_snapshot.json
@@ -1,0 +1,3318 @@
+{
+  "id": "9f9f6547-643c-403a-b2eb-b4353dc9ecab",
+  "prevId": "fbdbfd5e-a44b-44e9-a87e-ea32a35d42be",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.admins": {
+      "name": "admins",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "varchar(400)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "actor_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "last_login_at": {
+          "name": "last_login_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_admins_username": {
+          "name": "idx_admins_username",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_admins_email": {
+          "name": "idx_admins_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_admins_api_key": {
+          "name": "idx_admins_api_key",
+          "columns": [
+            {
+              "expression": "api_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_admins_status": {
+          "name": "idx_admins_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "admins_username_unique": {
+          "name": "admins_username_unique",
+          "nullsNotDistinct": false,
+          "columns": ["username"]
+        },
+        "admins_email_unique": {
+          "name": "admins_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        },
+        "admins_api_key_unique": {
+          "name": "admins_api_key_unique",
+          "nullsNotDistinct": false,
+          "columns": ["api_key"]
+        },
+        "admins_username_key": {
+          "name": "admins_username_key",
+          "nullsNotDistinct": false,
+          "columns": ["username"]
+        },
+        "admins_email_key": {
+          "name": "admins_email_key",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        },
+        "admins_api_key_key": {
+          "name": "admins_api_key_key",
+          "nullsNotDistinct": false,
+          "columns": ["api_key"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_nonces": {
+      "name": "agent_nonces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nonce": {
+          "name": "nonce",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_agent_nonces_agent_id": {
+          "name": "idx_agent_nonces_agent_id",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_nonces_nonce": {
+          "name": "idx_agent_nonces_nonce",
+          "columns": [
+            {
+              "expression": "nonce",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_nonces_expires_at": {
+          "name": "idx_agent_nonces_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_nonces_agent_id_fkey": {
+          "name": "agent_nonces_agent_id_fkey",
+          "tableFrom": "agent_nonces",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agent_nonces_nonce_unique": {
+          "name": "agent_nonces_nonce_unique",
+          "nullsNotDistinct": false,
+          "columns": ["nonce"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wallet_address": {
+          "name": "wallet_address",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "varchar(400)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_email_verified": {
+          "name": "is_email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "actor_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "deactivation_reason": {
+          "name": "deactivation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deactivation_date": {
+          "name": "deactivation_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agents_owner_id": {
+          "name": "idx_agents_owner_id",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agents_status": {
+          "name": "idx_agents_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agents_wallet_address": {
+          "name": "idx_agents_wallet_address",
+          "columns": [
+            {
+              "expression": "wallet_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agents_api_key": {
+          "name": "idx_agents_api_key",
+          "columns": [
+            {
+              "expression": "api_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agents_owner_id_fkey": {
+          "name": "agents_owner_id_fkey",
+          "tableFrom": "agents",
+          "tableTo": "users",
+          "columnsFrom": ["owner_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agents_wallet_address_unique": {
+          "name": "agents_wallet_address_unique",
+          "nullsNotDistinct": false,
+          "columns": ["wallet_address"]
+        },
+        "agents_email_unique": {
+          "name": "agents_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        },
+        "agents_owner_id_name_key": {
+          "name": "agents_owner_id_name_key",
+          "nullsNotDistinct": false,
+          "columns": ["owner_id", "name"]
+        },
+        "agents_api_key_key": {
+          "name": "agents_api_key_key",
+          "nullsNotDistinct": false,
+          "columns": ["api_key"]
+        },
+        "agents_wallet_address_key": {
+          "name": "agents_wallet_address_key",
+          "nullsNotDistinct": false,
+          "columns": ["wallet_address"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.competition_agents": {
+      "name": "competition_agents",
+      "schema": "",
+      "columns": {
+        "competition_id": {
+          "name": "competition_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "competition_agent_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "deactivation_reason": {
+          "name": "deactivation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deactivated_at": {
+          "name": "deactivated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_competition_agents_status": {
+          "name": "idx_competition_agents_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_competition_agents_competition_id": {
+          "name": "idx_competition_agents_competition_id",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_competition_agents_agent_id": {
+          "name": "idx_competition_agents_agent_id",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_competition_agents_deactivated_at": {
+          "name": "idx_competition_agents_deactivated_at",
+          "columns": [
+            {
+              "expression": "deactivated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "competition_agents_competition_id_fkey": {
+          "name": "competition_agents_competition_id_fkey",
+          "tableFrom": "competition_agents",
+          "tableTo": "competitions",
+          "columnsFrom": ["competition_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "competition_agents_agent_id_fkey": {
+          "name": "competition_agents_agent_id_fkey",
+          "tableFrom": "competition_agents",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "competition_agents_pkey": {
+          "name": "competition_agents_pkey",
+          "columns": ["competition_id", "agent_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.competitions": {
+      "name": "competitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "competition_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'trading'"
+        },
+        "external_url": {
+          "name": "external_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "voting_start_date": {
+          "name": "voting_start_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "voting_end_date": {
+          "name": "voting_end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "competition_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sandbox_mode": {
+          "name": "sandbox_mode",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_competitions_status": {
+          "name": "idx_competitions_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.competitions_leaderboard": {
+      "name": "competitions_leaderboard",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "numeric(30, 15)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_competitions_leaderboard_agent_id": {
+          "name": "idx_competitions_leaderboard_agent_id",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_competitions_leaderboard_competition_id": {
+          "name": "idx_competitions_leaderboard_competition_id",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_competitions_leaderboard_agent_competition": {
+          "name": "idx_competitions_leaderboard_agent_competition",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "competitions_leaderboard_agent_id_fkey": {
+          "name": "competitions_leaderboard_agent_id_fkey",
+          "tableFrom": "competitions_leaderboard",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "competitions_leaderboard_competition_id_fkey": {
+          "name": "competitions_leaderboard_competition_id_fkey",
+          "tableFrom": "competitions_leaderboard",
+          "tableTo": "competitions",
+          "columnsFrom": ["competition_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_verification_tokens": {
+      "name": "email_verification_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used": {
+          "name": "used",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_email_verification_tokens_user_id_token": {
+          "name": "idx_email_verification_tokens_user_id_token",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_email_verification_tokens_agent_id_token": {
+          "name": "idx_email_verification_tokens_agent_id_token",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_verification_tokens_user_id_fkey": {
+          "name": "email_verification_tokens_user_id_fkey",
+          "tableFrom": "email_verification_tokens",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_verification_tokens_agent_id_fkey": {
+          "name": "email_verification_tokens_agent_id_fkey",
+          "tableFrom": "email_verification_tokens",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "email_verification_tokens_token_unique": {
+          "name": "email_verification_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        },
+        "email_verification_tokens_token_key": {
+          "name": "email_verification_tokens_token_key",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "wallet_address": {
+          "name": "wallet_address",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_email_verified": {
+          "name": "is_email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "actor_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_users_wallet_address": {
+          "name": "idx_users_wallet_address",
+          "columns": [
+            {
+              "expression": "wallet_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_status": {
+          "name": "idx_users_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_wallet_address_unique": {
+          "name": "users_wallet_address_unique",
+          "nullsNotDistinct": false,
+          "columns": ["wallet_address"]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        },
+        "users_wallet_address_key": {
+          "name": "users_wallet_address_key",
+          "nullsNotDistinct": false,
+          "columns": ["wallet_address"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.votes": {
+      "name": "votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_votes_competition_id": {
+          "name": "idx_votes_competition_id",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_votes_agent_competition": {
+          "name": "idx_votes_agent_competition",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_votes_user_competition": {
+          "name": "idx_votes_user_competition",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "votes_user_id_fkey": {
+          "name": "votes_user_id_fkey",
+          "tableFrom": "votes",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "votes_agent_id_fkey": {
+          "name": "votes_agent_id_fkey",
+          "tableFrom": "votes",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "votes_competition_id_fkey": {
+          "name": "votes_competition_id_fkey",
+          "tableFrom": "votes",
+          "tableTo": "competitions",
+          "columnsFrom": ["competition_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "votes_user_agent_competition_key": {
+          "name": "votes_user_agent_competition_key",
+          "nullsNotDistinct": false,
+          "columns": ["user_id", "agent_id", "competition_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_rank": {
+      "name": "agent_rank",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mu": {
+          "name": "mu",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sigma": {
+          "name": "sigma",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ordinal": {
+          "name": "ordinal",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_rank_agent_id": {
+          "name": "idx_agent_rank_agent_id",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_rank_agent_id_fkey": {
+          "name": "agent_rank_agent_id_fkey",
+          "tableFrom": "agent_rank",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_agent_rank_agent_id": {
+          "name": "unique_agent_rank_agent_id",
+          "nullsNotDistinct": false,
+          "columns": ["agent_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_rank_history": {
+      "name": "agent_rank_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mu": {
+          "name": "mu",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sigma": {
+          "name": "sigma",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ordinal": {
+          "name": "ordinal",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_rank_history_agent_id": {
+          "name": "idx_agent_rank_history_agent_id",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_rank_history_competition_id": {
+          "name": "idx_agent_rank_history_competition_id",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_rank_history_agent_competition": {
+          "name": "idx_agent_rank_history_agent_competition",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_rank_history_agent_id_fkey": {
+          "name": "agent_rank_history_agent_id_fkey",
+          "tableFrom": "agent_rank_history",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_rank_history_competition_id_fkey": {
+          "name": "agent_rank_history_competition_id_fkey",
+          "tableFrom": "agent_rank_history",
+          "tableTo": "competitions",
+          "columnsFrom": ["competition_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.object_index": {
+      "name": "object_index",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data_type": {
+          "name": "data_type",
+          "type": "sync_data_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_timestamp": {
+          "name": "event_timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_object_index_competition_id": {
+          "name": "idx_object_index_competition_id",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_object_index_agent_id": {
+          "name": "idx_object_index_agent_id",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_object_index_data_type": {
+          "name": "idx_object_index_data_type",
+          "columns": [
+            {
+              "expression": "data_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_object_index_competition_agent": {
+          "name": "idx_object_index_competition_agent",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_object_index_created_at": {
+          "name": "idx_object_index_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "object_index_competition_id_fkey": {
+          "name": "object_index_competition_id_fkey",
+          "tableFrom": "object_index",
+          "tableTo": "competitions",
+          "columnsFrom": ["competition_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "object_index_agent_id_fkey": {
+          "name": "object_index_agent_id_fkey",
+          "tableFrom": "object_index",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "trading_comps.balances": {
+      "name": "balances",
+      "schema": "trading_comps",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_address": {
+          "name": "token_address",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "specific_chain": {
+          "name": "specific_chain",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_balances_specific_chain": {
+          "name": "idx_balances_specific_chain",
+          "columns": [
+            {
+              "expression": "specific_chain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_balances_agent_id": {
+          "name": "idx_balances_agent_id",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "balances_agent_id_fkey": {
+          "name": "balances_agent_id_fkey",
+          "tableFrom": "balances",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "balances_agent_id_token_address_key": {
+          "name": "balances_agent_id_token_address_key",
+          "nullsNotDistinct": false,
+          "columns": ["agent_id", "token_address"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "trading_comps.portfolio_snapshots": {
+      "name": "portfolio_snapshots",
+      "schema": "trading_comps",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "total_value": {
+          "name": "total_value",
+          "type": "numeric(30, 15)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_portfolio_snapshots_agent_competition": {
+          "name": "idx_portfolio_snapshots_agent_competition",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_portfolio_snapshots_timestamp": {
+          "name": "idx_portfolio_snapshots_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "portfolio_snapshots_agent_id_fkey": {
+          "name": "portfolio_snapshots_agent_id_fkey",
+          "tableFrom": "portfolio_snapshots",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "portfolio_snapshots_competition_id_fkey": {
+          "name": "portfolio_snapshots_competition_id_fkey",
+          "tableFrom": "portfolio_snapshots",
+          "tableTo": "competitions",
+          "columnsFrom": ["competition_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "trading_comps.portfolio_token_values": {
+      "name": "portfolio_token_values",
+      "schema": "trading_comps",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "portfolio_snapshot_id": {
+          "name": "portfolio_snapshot_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_address": {
+          "name": "token_address",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_usd": {
+          "name": "value_usd",
+          "type": "numeric(30, 15)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "specific_chain": {
+          "name": "specific_chain",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_portfolio_token_values_snapshot_id": {
+          "name": "idx_portfolio_token_values_snapshot_id",
+          "columns": [
+            {
+              "expression": "portfolio_snapshot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_portfolio_token_values_specific_chain": {
+          "name": "idx_portfolio_token_values_specific_chain",
+          "columns": [
+            {
+              "expression": "specific_chain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "portfolio_token_values_portfolio_snapshot_id_fkey": {
+          "name": "portfolio_token_values_portfolio_snapshot_id_fkey",
+          "tableFrom": "portfolio_token_values",
+          "tableTo": "portfolio_snapshots",
+          "schemaTo": "trading_comps",
+          "columnsFrom": ["portfolio_snapshot_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "trading_comps.prices": {
+      "name": "prices",
+      "schema": "trading_comps",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "chain": {
+          "name": "chain",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "specific_chain": {
+          "name": "specific_chain",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_prices_chain": {
+          "name": "idx_prices_chain",
+          "columns": [
+            {
+              "expression": "chain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_prices_specific_chain": {
+          "name": "idx_prices_specific_chain",
+          "columns": [
+            {
+              "expression": "specific_chain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_prices_timestamp": {
+          "name": "idx_prices_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_prices_token": {
+          "name": "idx_prices_token",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_prices_token_chain": {
+          "name": "idx_prices_token_chain",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_prices_token_specific_chain": {
+          "name": "idx_prices_token_specific_chain",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "specific_chain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_prices_token_timestamp": {
+          "name": "idx_prices_token_timestamp",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "trading_comps.trades": {
+      "name": "trades",
+      "schema": "trading_comps",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_token": {
+          "name": "from_token",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_token": {
+          "name": "to_token",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_amount": {
+          "name": "from_amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_amount": {
+          "name": "to_amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trade_amount_usd": {
+          "name": "trade_amount_usd",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_token_symbol": {
+          "name": "to_token_symbol",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_token_symbol": {
+          "name": "from_token_symbol",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "from_chain": {
+          "name": "from_chain",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_chain": {
+          "name": "to_chain",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_specific_chain": {
+          "name": "from_specific_chain",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_specific_chain": {
+          "name": "to_specific_chain",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_trades_competition_id": {
+          "name": "idx_trades_competition_id",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_trades_from_chain": {
+          "name": "idx_trades_from_chain",
+          "columns": [
+            {
+              "expression": "from_chain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_trades_from_specific_chain": {
+          "name": "idx_trades_from_specific_chain",
+          "columns": [
+            {
+              "expression": "from_specific_chain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_trades_agent_id": {
+          "name": "idx_trades_agent_id",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_trades_timestamp": {
+          "name": "idx_trades_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_trades_to_chain": {
+          "name": "idx_trades_to_chain",
+          "columns": [
+            {
+              "expression": "to_chain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_trades_to_specific_chain": {
+          "name": "idx_trades_to_specific_chain",
+          "columns": [
+            {
+              "expression": "to_specific_chain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trades_agent_id_fkey": {
+          "name": "trades_agent_id_fkey",
+          "tableFrom": "trades",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "trades_competition_id_fkey": {
+          "name": "trades_competition_id_fkey",
+          "tableFrom": "trades",
+          "tableTo": "competitions",
+          "columnsFrom": ["competition_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "trading_comps.trading_competitions": {
+      "name": "trading_competitions",
+      "schema": "trading_comps",
+      "columns": {
+        "competitionId": {
+          "name": "competitionId",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cross_chain_trading_type": {
+          "name": "cross_chain_trading_type",
+          "type": "cross_chain_trading_type",
+          "typeSchema": "trading_comps",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'disallowAll'"
+        }
+      },
+      "indexes": {
+        "idx_competitions_cross_chain_trading": {
+          "name": "idx_competitions_cross_chain_trading",
+          "columns": [
+            {
+              "expression": "cross_chain_trading_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trading_competitions_competitionId_competitions_id_fk": {
+          "name": "trading_competitions_competitionId_competitions_id_fk",
+          "tableFrom": "trading_competitions",
+          "tableTo": "competitions",
+          "columnsFrom": ["competitionId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.epochs": {
+      "name": "epochs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "epochs_number_unique": {
+          "name": "epochs_number_unique",
+          "nullsNotDistinct": false,
+          "columns": ["number"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rewards": {
+      "name": "rewards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "epoch": {
+          "name": "epoch",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(78, 0)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "leaf_hash": {
+          "name": "leaf_hash",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimed": {
+          "name": "claimed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_rewards_epoch": {
+          "name": "idx_rewards_epoch",
+          "columns": [
+            {
+              "expression": "epoch",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_rewards_address": {
+          "name": "idx_rewards_address",
+          "columns": [
+            {
+              "expression": "address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rewards_epoch_epochs_id_fk": {
+          "name": "rewards_epoch_epochs_id_fk",
+          "tableFrom": "rewards",
+          "tableTo": "epochs",
+          "columnsFrom": ["epoch"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rewards_roots": {
+      "name": "rewards_roots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "epoch": {
+          "name": "epoch",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root_hash": {
+          "name": "root_hash",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tx": {
+          "name": "tx",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_rewards_roots_epoch": {
+          "name": "uq_rewards_roots_epoch",
+          "columns": [
+            {
+              "expression": "epoch",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rewards_roots_epoch_epochs_id_fk": {
+          "name": "rewards_roots_epoch_epochs_id_fk",
+          "tableFrom": "rewards_roots",
+          "tableTo": "epochs",
+          "columnsFrom": ["epoch"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rewards_tree": {
+      "name": "rewards_tree",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "epoch": {
+          "name": "epoch",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idx": {
+          "name": "idx",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_rewards_tree_epoch_level_idx": {
+          "name": "idx_rewards_tree_epoch_level_idx",
+          "columns": [
+            {
+              "expression": "epoch",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "level",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idx",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_rewards_tree_level_hash": {
+          "name": "idx_rewards_tree_level_hash",
+          "columns": [
+            {
+              "expression": "level",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_rewards_tree_level_idx": {
+          "name": "idx_rewards_tree_level_idx",
+          "columns": [
+            {
+              "expression": "level",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idx",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rewards_tree_epoch_epochs_id_fk": {
+          "name": "rewards_tree_epoch_epochs_id_fk",
+          "tableFrom": "rewards_tree",
+          "tableTo": "epochs",
+          "columnsFrom": ["epoch"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stakes": {
+      "name": "stakes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token_id": {
+          "name": "token_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(78, 0)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "epoch_created": {
+          "name": "epoch_created",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "staked_at": {
+          "name": "staked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "can_unstake_after": {
+          "name": "can_unstake_after",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unstaked_at": {
+          "name": "unstaked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "can_withdraw_after": {
+          "name": "can_withdraw_after",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "withdrawn_at": {
+          "name": "withdrawn_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "relocked_at": {
+          "name": "relocked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_stakes_address": {
+          "name": "idx_stakes_address",
+          "columns": [
+            {
+              "expression": "address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stakes_user_id_users_id_fk": {
+          "name": "stakes_user_id_users_id_fk",
+          "tableFrom": "stakes",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "stakes_epoch_created_epochs_id_fk": {
+          "name": "stakes_epoch_created_epochs_id_fk",
+          "tableFrom": "stakes",
+          "tableTo": "epochs",
+          "columnsFrom": ["epoch_created"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vote_assignments": {
+      "name": "vote_assignments",
+      "schema": "",
+      "columns": {
+        "stake_id": {
+          "name": "stake_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "epoch": {
+          "name": "epoch",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(78, 0)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_vote_assignments_user_epoch": {
+          "name": "idx_vote_assignments_user_epoch",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "epoch",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_vote_assignments_epoch": {
+          "name": "idx_vote_assignments_epoch",
+          "columns": [
+            {
+              "expression": "epoch",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vote_assignments_stake_id_stakes_id_fk": {
+          "name": "vote_assignments_stake_id_stakes_id_fk",
+          "tableFrom": "vote_assignments",
+          "tableTo": "stakes",
+          "columnsFrom": ["stake_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vote_assignments_user_id_users_id_fk": {
+          "name": "vote_assignments_user_id_users_id_fk",
+          "tableFrom": "vote_assignments",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vote_assignments_epoch_epochs_id_fk": {
+          "name": "vote_assignments_epoch_epochs_id_fk",
+          "tableFrom": "vote_assignments",
+          "tableTo": "epochs",
+          "columnsFrom": ["epoch"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "vote_assignments_pkey": {
+          "name": "vote_assignments_pkey",
+          "columns": ["stake_id", "user_id", "epoch"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.votes_available": {
+      "name": "votes_available",
+      "schema": "",
+      "columns": {
+        "address": {
+          "name": "address",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "epoch": {
+          "name": "epoch",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(78, 0)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_number": {
+          "name": "block_number",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transaction_hash": {
+          "name": "transaction_hash",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "log_index": {
+          "name": "log_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "votes_available_epoch_epochs_id_fk": {
+          "name": "votes_available_epoch_epochs_id_fk",
+          "tableFrom": "votes_available",
+          "tableTo": "epochs",
+          "columnsFrom": ["epoch"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "votes_available_pkey": {
+          "name": "votes_available_pkey",
+          "columns": ["address", "epoch"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.votes_performed": {
+      "name": "votes_performed",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "epoch": {
+          "name": "epoch",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(78, 0)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_votes_performed_agent_epoch": {
+          "name": "idx_votes_performed_agent_epoch",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "epoch",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_votes_performed_epoch": {
+          "name": "idx_votes_performed_epoch",
+          "columns": [
+            {
+              "expression": "epoch",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "votes_performed_user_id_users_id_fk": {
+          "name": "votes_performed_user_id_users_id_fk",
+          "tableFrom": "votes_performed",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "votes_performed_agent_id_agents_id_fk": {
+          "name": "votes_performed_agent_id_agents_id_fk",
+          "tableFrom": "votes_performed",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "votes_performed_epoch_epochs_id_fk": {
+          "name": "votes_performed_epoch_epochs_id_fk",
+          "tableFrom": "votes_performed",
+          "tableTo": "epochs",
+          "columnsFrom": ["epoch"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "votes_performed_pkey": {
+          "name": "votes_performed_pkey",
+          "columns": ["user_id", "agent_id", "epoch"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.actor_status": {
+      "name": "actor_status",
+      "schema": "public",
+      "values": ["active", "inactive", "suspended", "deleted"]
+    },
+    "public.competition_agent_status": {
+      "name": "competition_agent_status",
+      "schema": "public",
+      "values": ["active", "withdrawn", "disqualified"]
+    },
+    "public.competition_status": {
+      "name": "competition_status",
+      "schema": "public",
+      "values": ["pending", "active", "ended"]
+    },
+    "public.competition_type": {
+      "name": "competition_type",
+      "schema": "public",
+      "values": ["trading"]
+    },
+    "public.sync_data_type": {
+      "name": "sync_data_type",
+      "schema": "public",
+      "values": [
+        "trade",
+        "agent_rank_history",
+        "agent_rank",
+        "competitions_leaderboard",
+        "portfolio_snapshot"
+      ]
+    },
+    "trading_comps.cross_chain_trading_type": {
+      "name": "cross_chain_trading_type",
+      "schema": "trading_comps",
+      "values": ["disallowAll", "disallowXParent", "allow"]
+    }
+  },
+  "schemas": {
+    "trading_comps": "trading_comps"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/meta/0018_snapshot.json
+++ b/apps/api/drizzle/meta/0018_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "id": "9f9f6547-643c-403a-b2eb-b4353dc9ecab",
+  "id": "a7ef592a-848a-4646-ab37-a911345d4762",
   "prevId": "fbdbfd5e-a44b-44e9-a87e-ea32a35d42be",
   "version": "7",
   "dialect": "postgresql",
@@ -910,7 +910,7 @@
         },
         "token": {
           "name": "token",
-          "type": "varchar(255)",
+          "type": "char(36)",
           "primaryKey": false,
           "notNull": true
         },

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -127,6 +127,13 @@
       "when": 1750863370674,
       "tag": "0017_luxuriant_silver_surfer",
       "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "7",
+      "when": 1750874105473,
+      "tag": "0018_oval_lady_ursula",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -131,8 +131,8 @@
     {
       "idx": 18,
       "version": "7",
-      "when": 1750874105473,
-      "tag": "0018_oval_lady_ursula",
+      "when": 1751310102025,
+      "tag": "0018_opposite_marrow",
       "breakpoints": true
     }
   ]

--- a/apps/api/e2e/tests/email-verification.test.ts
+++ b/apps/api/e2e/tests/email-verification.test.ts
@@ -1,0 +1,462 @@
+import axios from "axios";
+import { eq } from "drizzle-orm";
+import { v4 as uuidv4 } from "uuid";
+import { beforeEach, describe, expect, test } from "vitest";
+
+import { config } from "@/config/index.js";
+import { db } from "@/database/db.js";
+import { findById as findAgentById } from "@/database/repositories/agent-repository.js";
+import {
+  createEmailVerificationToken,
+  markTokenAsUsed,
+} from "@/database/repositories/email-verification-repository.js";
+import { findById as findUserById } from "@/database/repositories/user-repository.js";
+import { emailVerificationTokens } from "@/database/schema/core/defs.js";
+import { getBaseUrl } from "@/e2e/utils/server.js";
+import {
+  ADMIN_EMAIL,
+  ADMIN_PASSWORD,
+  ADMIN_USERNAME,
+  cleanupTestState,
+  registerUserAndAgentAndGetClient,
+} from "@/e2e/utils/test-helpers.js";
+import { ServiceRegistry } from "@/services/index.js";
+
+describe("Email Verification API", () => {
+  let adminApiKey: string;
+
+  beforeEach(async () => {
+    await cleanupTestState();
+
+    // Create admin account directly using the setup endpoint
+    const response = await axios.post(`${getBaseUrl()}/api/admin/setup`, {
+      username: ADMIN_USERNAME,
+      password: ADMIN_PASSWORD,
+      email: ADMIN_EMAIL,
+    });
+
+    // Store the admin API key for authentication
+    adminApiKey = response.data.admin.apiKey;
+    expect(adminApiKey).toBeDefined();
+  });
+
+  test("should verify a valid token for a user", async () => {
+    // Register a user with email
+    const userEmail = `user-${Date.now()}@example.com`;
+    const { user } = await registerUserAndAgentAndGetClient({
+      adminApiKey,
+      userEmail,
+    });
+
+    // Ensure user's email is not verified initially
+    const initialUser = await findUserById(user.id);
+    expect(initialUser?.isEmailVerified).toBe(false);
+
+    // Get token by user id
+    const tokens = await db
+      .select()
+      .from(emailVerificationTokens)
+      .where(eq(emailVerificationTokens.userId, user.id))
+      .limit(1);
+
+    const token = tokens[0]?.token;
+    expect(token).toBeDefined();
+
+    // Verify the token
+    const verifyResponse = await axios.get(
+      `${getBaseUrl()}/api/verify-email?token=${token}`,
+      {
+        maxRedirects: 0,
+        validateStatus: null,
+      },
+    );
+
+    // Should redirect to profile page with success message
+    expect(verifyResponse.status).toBe(302);
+    expect(verifyResponse.headers["location"]).toContain(
+      `${config.app.url}/profile?success=true`,
+    );
+    expect(verifyResponse.headers["location"]).toContain(
+      "message=Email%20verified%20successfully",
+    );
+
+    // Check that user's email is now verified
+    const updatedUser = await findUserById(user.id);
+    expect(updatedUser?.isEmailVerified).toBe(true);
+  });
+
+  test("should verify a valid token for an agent", async () => {
+    // Register a user and agent
+    const { agent } = await registerUserAndAgentAndGetClient({
+      adminApiKey,
+    });
+
+    // Set agent email using agent manager service
+    const agentEmail = `agent-${Date.now()}@example.com`;
+    const agentManager = ServiceRegistry.getInstance().agentManager;
+
+    const secondAgent = await agentManager.createAgent({
+      ownerId: agent.ownerId,
+      name: "Second Agent",
+      email: agentEmail,
+    });
+
+    // Ensure agent's email is not verified initially
+    expect(secondAgent.isEmailVerified).toBe(false);
+
+    const tokens = await db
+      .select()
+      .from(emailVerificationTokens)
+      .where(eq(emailVerificationTokens.agentId, secondAgent.id))
+      .limit(1);
+
+    const token = tokens[0]?.token;
+    expect(token).toBeDefined();
+
+    // Verify the token
+    const verifyResponse = await axios.get(
+      `${getBaseUrl()}/api/verify-email?token=${token}`,
+      {
+        maxRedirects: 0,
+        validateStatus: null,
+      },
+    );
+
+    // Should redirect to profile page with success message
+    expect(verifyResponse.status).toBe(302);
+    expect(verifyResponse.headers["location"]).toContain(
+      `${config.app.url}/profile?success=true`,
+    );
+    expect(verifyResponse.headers["location"]).toContain(
+      "message=Email%20verified%20successfully",
+    );
+
+    // Check that agent's email is now verified
+    const updatedAgent = await findAgentById(secondAgent.id);
+    expect(updatedAgent?.isEmailVerified).toBe(true);
+  });
+
+  test("should handle invalid tokens", async () => {
+    // Try to verify a non-existent token
+    const invalidToken = "non-existent-token";
+    const verifyResponse = await axios.get(
+      `${getBaseUrl()}/api/verify-email?token=${invalidToken}`,
+      {
+        maxRedirects: 0,
+        validateStatus: null,
+      },
+    );
+
+    // Should redirect to profile page with error message
+    expect(verifyResponse.status).toBe(302);
+    expect(verifyResponse.headers["location"]).toContain(
+      `${config.app.url}/profile?success=false`,
+    );
+    expect(verifyResponse.headers["location"]).toContain(
+      "message=Invalid%20verification%20token",
+    );
+  });
+
+  test("should handle expired tokens", async () => {
+    // Register a user with email
+    const userEmail = `expired-${Date.now()}@example.com`;
+    const { user } = await registerUserAndAgentAndGetClient({
+      adminApiKey,
+      userEmail,
+    });
+
+    // Create an expired verification token
+    const token = uuidv4();
+    const expiresAt = new Date();
+    expiresAt.setHours(expiresAt.getHours() - 1); // 1 hour in the past
+
+    await createEmailVerificationToken({
+      id: uuidv4(),
+      userId: user.id,
+      token,
+      expiresAt,
+    });
+
+    // Try to verify the expired token
+    const verifyResponse = await axios.get(
+      `${getBaseUrl()}/api/verify-email?token=${token}`,
+      {
+        maxRedirects: 0,
+        validateStatus: null,
+      },
+    );
+
+    // Should redirect to profile page with error message
+    expect(verifyResponse.status).toBe(302);
+    expect(verifyResponse.headers["location"]).toContain(
+      `${config.app.url}/profile?success=false`,
+    );
+    expect(verifyResponse.headers["location"]).toContain(
+      "message=Token%20has%20expired",
+    );
+
+    // Check that user's email is still not verified
+    const updatedUser = await findUserById(user.id);
+    expect(updatedUser?.isEmailVerified).toBe(false);
+  });
+
+  test("should handle already used tokens", async () => {
+    // Register a user with email
+    const userEmail = `used-token-${Date.now()}@example.com`;
+    const { user } = await registerUserAndAgentAndGetClient({
+      adminApiKey,
+      userEmail,
+    });
+
+    // Get token by user id
+    const tokens = await db
+      .select()
+      .from(emailVerificationTokens)
+      .where(eq(emailVerificationTokens.userId, user.id))
+      .limit(1);
+
+    // Mark the token as used
+    await markTokenAsUsed(tokens[0]!.id);
+
+    // Try to verify the used token
+    const verifyResponse = await axios.get(
+      `${getBaseUrl()}/api/verify-email?token=${tokens[0]!.token}`,
+      {
+        maxRedirects: 0,
+        validateStatus: null,
+      },
+    );
+
+    // Should redirect to profile page with error message
+    expect(verifyResponse.status).toBe(302);
+    expect(verifyResponse.headers["location"]).toContain(
+      `${config.app.url}/profile?success=false`,
+    );
+    expect(verifyResponse.headers["location"]).toContain(
+      "message=Token%20has%20already%20been%20used",
+    );
+
+    // Check that user's email is still not verified
+    const updatedUser = await findUserById(user.id);
+    expect(updatedUser?.isEmailVerified).toBe(false);
+  });
+
+  test("should handle token with no association", async () => {
+    // Create a token with neither userId nor agentId
+    const token = uuidv4();
+    const expiresAt = new Date();
+    expiresAt.setHours(expiresAt.getHours() + 24); // 24 hours from now
+
+    await createEmailVerificationToken({
+      id: uuidv4(),
+      token,
+      expiresAt,
+    });
+
+    // Try to verify the token
+    const verifyResponse = await axios.get(
+      `${getBaseUrl()}/api/verify-email?token=${token}`,
+      {
+        maxRedirects: 0,
+        validateStatus: null,
+      },
+    );
+
+    // Should redirect to profile page with error message
+    expect(verifyResponse.status).toBe(302);
+    expect(verifyResponse.headers["location"]).toContain(
+      `${config.app.url}/profile?success=false`,
+    );
+    expect(verifyResponse.headers["location"]).toContain(
+      "message=Token%20is%20not%20associated%20with%20a%20user%20or%20agent",
+    );
+  });
+
+  test("should handle missing token parameter", async () => {
+    // Try to verify without providing a token
+    const verifyResponse = await axios.get(`${getBaseUrl()}/api/verify-email`, {
+      maxRedirects: 0,
+      validateStatus: null,
+    });
+
+    // Should redirect to profile page with error message
+    expect(verifyResponse.status).toBe(302);
+    expect(verifyResponse.headers["location"]).toContain(
+      `${config.app.url}/profile?success=false`,
+    );
+    expect(verifyResponse.headers["location"]).toContain(
+      "message=Token%20is%20required",
+    );
+  });
+
+  test("should send new verification email when user email is updated", async () => {
+    // Register a user with initial email
+    const initialEmail = `initial-${Date.now()}@example.com`;
+    const { user } = await registerUserAndAgentAndGetClient({
+      adminApiKey,
+      userEmail: initialEmail,
+    });
+
+    // Verify the initial email
+    const initialTokens = await db
+      .select()
+      .from(emailVerificationTokens)
+      .where(eq(emailVerificationTokens.userId, user.id))
+      .limit(1);
+
+    const initialToken = initialTokens[0]?.token;
+    expect(initialToken).toBeDefined();
+
+    // Verify the initial token
+    await axios.get(`${getBaseUrl()}/api/verify-email?token=${initialToken}`, {
+      maxRedirects: 0,
+      validateStatus: null,
+    });
+
+    // Check that user's email is now verified
+    let updatedUser = await findUserById(user.id);
+    expect(updatedUser?.isEmailVerified).toBe(true);
+
+    // Update the user's email
+    const newEmail = `updated-${Date.now()}@example.com`;
+    const userManager = ServiceRegistry.getInstance().userManager;
+
+    await userManager.updateUser({
+      id: user.id,
+      email: newEmail,
+    });
+
+    // Check that user's email verification status is reset
+    updatedUser = await findUserById(user.id);
+    expect(updatedUser?.email).toBe(newEmail);
+    expect(updatedUser?.isEmailVerified).toBe(false);
+
+    // Check that a new verification token was created
+    const allTokens = await db
+      .select()
+      .from(emailVerificationTokens)
+      .where(eq(emailVerificationTokens.userId, user.id));
+
+    // Sort tokens by createdAt in descending order and get the most recent one
+    const sortedTokens = [...allTokens].sort(
+      (a, b) =>
+        new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+    );
+
+    const newToken = sortedTokens[0]?.token;
+    expect(newToken).toBeDefined();
+    expect(newToken).not.toBe(initialToken);
+
+    // Verify the new token
+    const verifyResponse = await axios.get(
+      `${getBaseUrl()}/api/verify-email?token=${newToken}`,
+      {
+        maxRedirects: 0,
+        validateStatus: null,
+      },
+    );
+
+    // Should redirect to profile page with success message
+    expect(verifyResponse.status).toBe(302);
+    expect(verifyResponse.headers["location"]).toContain(
+      `${config.app.url}/profile?success=true`,
+    );
+    expect(verifyResponse.headers["location"]).toContain(
+      "message=Email%20verified%20successfully",
+    );
+
+    // Check that user's email is verified again
+    updatedUser = await findUserById(user.id);
+    expect(updatedUser?.isEmailVerified).toBe(true);
+  });
+
+  test("should send new verification email when agent email is updated", async () => {
+    // Register a user and agent
+    const { agent } = await registerUserAndAgentAndGetClient({
+      adminApiKey,
+    });
+
+    // Set agent email using agent manager service
+    const initialEmail = `agent-initial-${Date.now()}@example.com`;
+    const agentManager = ServiceRegistry.getInstance().agentManager;
+
+    const testAgent = await agentManager.createAgent({
+      ownerId: agent.ownerId,
+      name: "Test Agent For Email Update",
+      email: initialEmail,
+    });
+
+    // Ensure agent's email is not verified initially
+    expect(testAgent.isEmailVerified).toBe(false);
+
+    // Get initial verification token
+    const initialTokens = await db
+      .select()
+      .from(emailVerificationTokens)
+      .where(eq(emailVerificationTokens.agentId, testAgent.id))
+      .limit(1);
+
+    const initialToken = initialTokens[0]?.token;
+    expect(initialToken).toBeDefined();
+
+    // Verify the initial token
+    await axios.get(`${getBaseUrl()}/api/verify-email?token=${initialToken}`, {
+      maxRedirects: 0,
+      validateStatus: null,
+    });
+
+    // Check that agent's email is now verified
+    let updatedAgent = await findAgentById(testAgent.id);
+    expect(updatedAgent?.isEmailVerified).toBe(true);
+
+    // Update the agent's email
+    const newEmail = `agent-updated-${Date.now()}@example.com`;
+    await agentManager.updateAgent({
+      ...testAgent,
+      email: newEmail,
+    });
+
+    // Check that agent's email verification status is reset
+    updatedAgent = await findAgentById(testAgent.id);
+    expect(updatedAgent?.email).toBe(newEmail);
+    expect(updatedAgent?.isEmailVerified).toBe(false);
+
+    // Check that a new verification token was created
+    const allTokens = await db
+      .select()
+      .from(emailVerificationTokens)
+      .where(eq(emailVerificationTokens.agentId, testAgent.id));
+
+    // Sort tokens by createdAt in descending order and get the most recent one
+    const sortedTokens = [...allTokens].sort(
+      (a, b) =>
+        new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+    );
+
+    const newToken = sortedTokens[0]?.token;
+    expect(newToken).toBeDefined();
+    expect(newToken).not.toBe(initialToken);
+
+    // Verify the new token
+    const verifyResponse = await axios.get(
+      `${getBaseUrl()}/api/verify-email?token=${newToken}`,
+      {
+        maxRedirects: 0,
+        validateStatus: null,
+      },
+    );
+
+    // Should redirect to profile page with success message
+    expect(verifyResponse.status).toBe(302);
+    expect(verifyResponse.headers["location"]).toContain(
+      `${config.app.url}/profile?success=true`,
+    );
+    expect(verifyResponse.headers["location"]).toContain(
+      "message=Email%20verified%20successfully",
+    );
+
+    // Check that agent's email is verified again
+    updatedAgent = await findAgentById(testAgent.id);
+    expect(updatedAgent?.isEmailVerified).toBe(true);
+  });
+});

--- a/apps/api/openapi/API.md
+++ b/apps/api/openapi/API.md
@@ -1345,6 +1345,32 @@ while preserving historical participation data. Note: Cannot leave competitions 
 | --------------- | ------ |
 | BearerAuth      |        |
 
+### /api/verify-email
+
+#### GET
+
+##### Summary:
+
+Verify an email verification token
+
+##### Description:
+
+Verifies an email verification token sent to a user or agent's email address.
+This endpoint is typically accessed via a link in the verification email.
+
+##### Parameters
+
+| Name  | Located in | Description                           | Required | Schema |
+| ----- | ---------- | ------------------------------------- | -------- | ------ |
+| token | query      | The verification token from the email | Yes      | string |
+
+##### Responses
+
+| Code | Description                             |
+| ---- | --------------------------------------- |
+| 302  | Redirects to frontend user profile page |
+| 500  | Internal server error                   |
+
 ### /api/health
 
 #### GET

--- a/apps/api/openapi/openapi.json
+++ b/apps/api/openapi/openapi.json
@@ -5295,6 +5295,60 @@
         }
       }
     },
+    "/api/verify-email": {
+      "get": {
+        "summary": "Verify an email verification token",
+        "description": "Verifies an email verification token sent to a user or agent's email address.\nThis endpoint is typically accessed via a link in the verification email.\n",
+        "tags": ["Email Verification"],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "token",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The verification token from the email"
+          }
+        ],
+        "responses": {
+          "302": {
+            "description": "Redirects to frontend user profile page",
+            "headers": {
+              "Location": {
+                "schema": {
+                  "type": "string"
+                },
+                "description": "URL to the frontend user profile page with query parameters",
+                "example": "http://localhost:3001/profile?success=true&message=Email%20verified%20successfully%20for%20user"
+              }
+            },
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/health": {
       "get": {
         "tags": ["Health"],

--- a/apps/api/src/config/index.ts
+++ b/apps/api/src/config/index.ts
@@ -149,6 +149,10 @@ export const config = {
     apiPrefix: process.env.API_PREFIX || "",
     sandboxUrl: "https://api.sandbox.competitions.recall.network",
   },
+  email: {
+    apiKey: process.env.LOOPS_API_KEY || "",
+    transactionalId: process.env.LOOPS_TRANSACTIONAL_ID || "",
+  },
   // Frontend app configuration for interfacing with the server
   app: {
     url: process.env.FRONTEND_URL || "http://localhost:3001", // TODO: resolve frontend/backend default ports

--- a/apps/api/src/controllers/email-verification.controller.ts
+++ b/apps/api/src/controllers/email-verification.controller.ts
@@ -1,0 +1,75 @@
+import { NextFunction, Request, Response } from "express";
+
+import { config } from "@/config/index.js";
+import { ServiceRegistry } from "@/services/index.js";
+
+export function makeEmailVerificationController(services: ServiceRegistry) {
+  /**
+   * Email Verification Controller
+   * Handles email verification endpoints
+   */
+  return {
+    /**
+     * Verify an email verification token
+     * @param req Request object
+     * @param res Response object
+     * @param next Next function
+     */
+    async verifyEmail(req: Request, res: Response, next: NextFunction) {
+      try {
+        const { token } = req.query;
+
+        if (!token || typeof token !== "string") {
+          return res.redirect(
+            `${config.app.url}/profile?success=false&message=${encodeURIComponent("Token is required")}`,
+          );
+        }
+
+        const result =
+          await services.emailVerificationService.verifyToken(token);
+
+        if (!result.success) {
+          let message = "Verification failed";
+
+          switch (result.error.type) {
+            case "InvalidToken":
+              message = "Invalid verification token";
+              break;
+            case "TokenHasBeenUsed":
+              message = "Token has already been used";
+              break;
+            case "TokenHasExpired":
+              message = "Token has expired";
+              break;
+            case "UserNotFound":
+              message = "User not found";
+              break;
+            case "AgentNotFound":
+              message = "Agent not found";
+              break;
+            case "NoAssociation":
+              message = "Token is not associated with a user or agent";
+              break;
+            case "SystemError":
+              message = result.error.message;
+              break;
+          }
+
+          return res.redirect(
+            `${config.app.url}/profile?success=false&message=${encodeURIComponent(message)}`,
+          );
+        }
+
+        return res.redirect(
+          `${config.app.url}/profile?success=true&message=${encodeURIComponent(result.value.message)}`,
+        );
+      } catch (error) {
+        next(error);
+      }
+    },
+  };
+}
+
+export type EmailVerificationController = ReturnType<
+  typeof makeEmailVerificationController
+>;

--- a/apps/api/src/controllers/email-verification.controller.ts
+++ b/apps/api/src/controllers/email-verification.controller.ts
@@ -41,12 +41,6 @@ export function makeEmailVerificationController(services: ServiceRegistry) {
             case "TokenHasExpired":
               message = "Token has expired";
               break;
-            case "UserNotFound":
-              message = "User not found";
-              break;
-            case "AgentNotFound":
-              message = "Agent not found";
-              break;
             case "NoAssociation":
               message = "Token is not associated with a user or agent";
               break;

--- a/apps/api/src/database/repositories/email-verification-repository.ts
+++ b/apps/api/src/database/repositories/email-verification-repository.ts
@@ -2,19 +2,19 @@ import { eq } from "drizzle-orm";
 
 import { db } from "@/database/db.js";
 import { emailVerificationTokens } from "@/database/schema/core/defs.js";
+import {
+  InsertEmailVerificationToken,
+  SelectEmailVerificationToken,
+} from "@/database/schema/core/types.js";
 
 /**
  * Creates a new email verification token
  * @param token The token data to insert
  * @returns The inserted token
  */
-export async function createEmailVerificationToken(token: {
-  id: string;
-  userId?: string;
-  agentId?: string;
-  token: string;
-  expiresAt: Date;
-}): Promise<typeof emailVerificationTokens.$inferSelect> {
+export async function createEmailVerificationToken(
+  token: InsertEmailVerificationToken,
+): Promise<SelectEmailVerificationToken> {
   const [insertedToken] = await db
     .insert(emailVerificationTokens)
     .values(token)
@@ -34,7 +34,7 @@ export async function createEmailVerificationToken(token: {
  */
 export async function findEmailVerificationTokenByToken(
   tokenString: string,
-): Promise<typeof emailVerificationTokens.$inferSelect | undefined> {
+): Promise<SelectEmailVerificationToken | undefined> {
   const tokens = await db
     .select()
     .from(emailVerificationTokens)
@@ -51,7 +51,7 @@ export async function findEmailVerificationTokenByToken(
  */
 export async function markTokenAsUsed(
   tokenId: string,
-): Promise<typeof emailVerificationTokens.$inferSelect | undefined> {
+): Promise<SelectEmailVerificationToken | undefined> {
   const [updatedToken] = await db
     .update(emailVerificationTokens)
     .set({ used: true })

--- a/apps/api/src/database/repositories/email-verification-repository.ts
+++ b/apps/api/src/database/repositories/email-verification-repository.ts
@@ -1,0 +1,62 @@
+import { eq } from "drizzle-orm";
+
+import { db } from "@/database/db.js";
+import { emailVerificationTokens } from "@/database/schema/core/defs.js";
+
+/**
+ * Creates a new email verification token
+ * @param token The token data to insert
+ * @returns The inserted token
+ */
+export async function createEmailVerificationToken(token: {
+  id: string;
+  userId?: string;
+  agentId?: string;
+  token: string;
+  expiresAt: Date;
+}): Promise<typeof emailVerificationTokens.$inferSelect> {
+  const [insertedToken] = await db
+    .insert(emailVerificationTokens)
+    .values(token)
+    .returning();
+
+  if (!insertedToken) {
+    throw new Error("Failed to create email verification token");
+  }
+
+  return insertedToken;
+}
+
+/**
+ * Finds an email verification token by its token string
+ * @param tokenString The token string to search for
+ * @returns The token if found, undefined otherwise
+ */
+export async function findEmailVerificationTokenByToken(
+  tokenString: string,
+): Promise<typeof emailVerificationTokens.$inferSelect | undefined> {
+  const tokens = await db
+    .select()
+    .from(emailVerificationTokens)
+    .where(eq(emailVerificationTokens.token, tokenString))
+    .limit(1);
+
+  return tokens[0];
+}
+
+/**
+ * Marks a token as used
+ * @param tokenId The ID of the token to mark as used
+ * @returns The updated token
+ */
+export async function markTokenAsUsed(
+  tokenId: string,
+): Promise<typeof emailVerificationTokens.$inferSelect | undefined> {
+  const [updatedToken] = await db
+    .update(emailVerificationTokens)
+    .set({ used: true })
+    .where(eq(emailVerificationTokens.id, tokenId))
+    .returning();
+
+  return updatedToken;
+}

--- a/apps/api/src/database/schema/core/defs.ts
+++ b/apps/api/src/database/schema/core/defs.ts
@@ -63,6 +63,7 @@ export const users = pgTable(
     email: varchar({ length: 100 }).unique(),
     imageUrl: text("image_url"),
     metadata: jsonb(),
+    isEmailVerified: boolean("is_email_verified").default(false),
     status: actorStatus("status").default("active").notNull(),
     createdAt: timestamp("created_at", {
       withTimezone: true,
@@ -97,6 +98,7 @@ export const agents = pgTable(
     imageUrl: text("image_url"),
     apiKey: varchar("api_key", { length: 400 }).notNull(),
     metadata: jsonb(),
+    isEmailVerified: boolean("is_email_verified").default(false),
     status: actorStatus("status").default("active").notNull(),
     deactivationReason: text("deactivation_reason"),
     deactivationDate: timestamp("deactivation_date", {
@@ -347,5 +349,49 @@ export const competitionsLeaderboard = pgTable(
       foreignColumns: [competitions.id],
       name: "competitions_leaderboard_competition_id_fkey",
     }).onDelete("cascade"),
+  ],
+);
+
+/**
+ * Email verification tokens for users and agents
+ */
+export const emailVerificationTokens = pgTable(
+  "email_verification_tokens",
+  {
+    id: uuid().primaryKey().notNull(),
+    userId: uuid("user_id"),
+    agentId: uuid("agent_id"),
+    token: varchar("token", { length: 255 }).notNull().unique(),
+    expiresAt: timestamp("expires_at", { withTimezone: true }).notNull(),
+    used: boolean("used").default(false),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => [
+    // Indexes for performance
+    index("idx_email_verification_tokens_user_id_token").on(
+      table.userId,
+      table.token,
+    ),
+    index("idx_email_verification_tokens_agent_id_token").on(
+      table.agentId,
+      table.token,
+    ),
+
+    // Foreign key constraints
+    foreignKey({
+      columns: [table.userId],
+      foreignColumns: [users.id],
+      name: "email_verification_tokens_user_id_fkey",
+    }).onDelete("cascade"),
+    foreignKey({
+      columns: [table.agentId],
+      foreignColumns: [agents.id],
+      name: "email_verification_tokens_agent_id_fkey",
+    }).onDelete("cascade"),
+
+    // Unique constraint on token
+    unique("email_verification_tokens_token_key").on(table.token),
   ],
 );

--- a/apps/api/src/database/schema/core/defs.ts
+++ b/apps/api/src/database/schema/core/defs.ts
@@ -1,5 +1,6 @@
 import {
   boolean,
+  char,
   foreignKey,
   index,
   integer,
@@ -361,7 +362,7 @@ export const emailVerificationTokens = pgTable(
     id: uuid().primaryKey().notNull(),
     userId: uuid("user_id"),
     agentId: uuid("agent_id"),
-    token: varchar("token", { length: 255 }).notNull().unique(),
+    token: char("token", { length: 36 }).notNull().unique(),
     expiresAt: timestamp("expires_at", { withTimezone: true }).notNull(),
     used: boolean("used").default(false),
     createdAt: timestamp("created_at", { withTimezone: true })

--- a/apps/api/src/database/schema/core/types.ts
+++ b/apps/api/src/database/schema/core/types.ts
@@ -27,3 +27,8 @@ export type SelectCompetitionsLeaderboard =
   typeof defs.competitionsLeaderboard.$inferSelect;
 export type InsertCompetitionsLeaderboard =
   typeof defs.competitionsLeaderboard.$inferInsert;
+
+export type SelectEmailVerificationToken =
+  typeof defs.emailVerificationTokens.$inferSelect;
+export type InsertEmailVerificationToken =
+  typeof defs.emailVerificationTokens.$inferInsert;

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -7,6 +7,7 @@ import { makeAgentController } from "@/controllers/agent.controller.js";
 import { makeAuthController } from "@/controllers/auth.controller.js";
 import { makeCompetitionController } from "@/controllers/competition.controller.js";
 import { makeDocsController } from "@/controllers/docs.controller.js";
+import { makeEmailVerificationController } from "@/controllers/email-verification.controller.js";
 import { makeHealthController } from "@/controllers/health.controller.js";
 import { makeLeaderboardController } from "@/controllers/leaderboard.controller.js";
 import { makePriceController } from "@/controllers/price.controller.js";
@@ -27,6 +28,7 @@ import { configureAgentsRoutes } from "@/routes/agents.routes.js";
 import { configureAuthRoutes } from "@/routes/auth.routes.js";
 import { configureCompetitionsRoutes } from "@/routes/competitions.routes.js";
 import { configureDocsRoutes } from "@/routes/docs.routes.js";
+import { configureEmailVerificationRoutes } from "@/routes/email-verification.routes.js";
 import { configureHealthRoutes } from "@/routes/health.routes.js";
 import { configurePriceRoutes } from "@/routes/price.routes.js";
 import { configureTradeRoutes } from "@/routes/trade.routes.js";
@@ -140,6 +142,7 @@ const adminController = makeAdminController(services);
 const authController = makeAuthController(services);
 const competitionController = makeCompetitionController(services);
 const docsController = makeDocsController();
+const emailVerificationController = makeEmailVerificationController(services);
 const healthController = makeHealthController();
 const priceController = makePriceController(services);
 const tradeController = makeTradeController(services);
@@ -173,6 +176,9 @@ const competitionsRoutes = configureCompetitionsRoutes(
 );
 const docsRoutes = configureDocsRoutes(docsController);
 const healthRoutes = configureHealthRoutes(healthController);
+const emailVerificationRoutes = configureEmailVerificationRoutes(
+  emailVerificationController,
+);
 const priceRoutes = configurePriceRoutes(priceController);
 const tradeRoutes = configureTradeRoutes(tradeController);
 const userRoutes = configureUserRoutes(userController, voteController);
@@ -182,6 +188,7 @@ const leaderboardRoutes = configureLeaderboardRoutes(leaderboardController);
 
 // Apply routes to the API router
 apiRouter.use("/auth", authRoutes);
+apiRouter.use("/verify-email", emailVerificationRoutes);
 apiRouter.use("/trade", tradeRoutes);
 apiRouter.use("/price", priceRoutes);
 apiRouter.use("/competitions", competitionsRoutes);

--- a/apps/api/src/routes/email-verification.routes.ts
+++ b/apps/api/src/routes/email-verification.routes.ts
@@ -1,0 +1,52 @@
+import { Router } from "express";
+
+import { EmailVerificationController } from "@/controllers/email-verification.controller.js";
+
+export function configureEmailVerificationRoutes(
+  controller: EmailVerificationController,
+) {
+  const router = Router();
+
+  /**
+   * @openapi
+   * /api/verify-email:
+   *   get:
+   *     summary: Verify an email verification token
+   *     description: |
+   *       Verifies an email verification token sent to a user or agent's email address.
+   *       This endpoint is typically accessed via a link in the verification email.
+   *     tags: [Email Verification]
+   *     parameters:
+   *       - in: query
+   *         name: token
+   *         required: true
+   *         schema:
+   *           type: string
+   *         description: The verification token from the email
+   *     responses:
+   *       302:
+   *         description: Redirects to frontend user profile page
+   *         headers:
+   *           Location:
+   *             schema:
+   *               type: string
+   *             description: URL to the frontend user profile page with query parameters
+   *             example: "http://localhost:3001/profile?success=true&message=Email%20verified%20successfully%20for%20user"
+   *         content:
+   *           text/html:
+   *             schema:
+   *               type: string
+   *       500:
+   *         description: Internal server error
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   *               properties:
+   *                 error:
+   *                   type: string
+   */
+  router.get("/", controller.verifyEmail);
+
+  return router;
+}

--- a/apps/api/src/services/agent-manager.service.ts
+++ b/apps/api/src/services/agent-manager.service.ts
@@ -75,10 +75,10 @@ export class AgentManager {
   // Email service for sending verification emails
   private emailService: EmailService;
 
-  constructor() {
+  constructor(emailService: EmailService) {
     this.apiKeyCache = new Map();
     this.inactiveAgentsCache = new Map();
-    this.emailService = new EmailService();
+    this.emailService = emailService;
   }
 
   /**

--- a/apps/api/src/services/agent-manager.service.ts
+++ b/apps/api/src/services/agent-manager.service.ts
@@ -33,6 +33,7 @@ import {
   getAgentPortfolioSnapshots,
   getBulkAgentCompetitionRankings,
 } from "@/database/repositories/competition-repository.js";
+import { createEmailVerificationToken } from "@/database/repositories/email-verification-repository.js";
 import { getBulkAgentMetrics } from "@/database/repositories/leaderboard-repository.js";
 import {
   countAgentTrades,
@@ -46,6 +47,7 @@ import {
   SelectCompetition,
 } from "@/database/schema/core/types.js";
 import { ApiError } from "@/middleware/errorHandler.js";
+import { EmailService } from "@/services/email.service.js";
 import {
   ACTOR_STATUS,
   AgentCompetitionsParams,
@@ -70,10 +72,13 @@ export class AgentManager {
   private apiKeyCache: Map<string, ApiAuth>;
   // Cache for inactive agents to avoid repeated database lookups
   private inactiveAgentsCache: Map<string, { reason: string; date: Date }>;
+  // Email service for sending verification emails
+  private emailService: EmailService;
 
   constructor() {
     this.apiKeyCache = new Map();
     this.inactiveAgentsCache = new Map();
+    this.emailService = new EmailService();
   }
 
   /**
@@ -144,6 +149,10 @@ export class AgentManager {
         agentId: id,
         key: apiKey,
       });
+
+      if (email) {
+        await this.sendEmailVerification(savedAgent);
+      }
 
       console.log(
         `[AgentManager] Created agent: ${name} (${id}) for owner ${ownerId}`,
@@ -637,6 +646,12 @@ export class AgentManager {
         return undefined;
       }
 
+      // Check if email has changed and needs verification
+      const emailChanged = agent.email && agent.email !== existingAgent.email;
+      if (emailChanged) {
+        agent.isEmailVerified = false;
+      }
+
       // Always set updated timestamp
       agent.updatedAt = new Date();
 
@@ -645,6 +660,11 @@ export class AgentManager {
       if (!updatedAgent) {
         console.log(`[AgentManager] Failed to update agent: ${agent.id}`);
         return undefined;
+      }
+
+      // Send verification email if email has changed
+      if (emailChanged && updatedAgent.email) {
+        await this.sendEmailVerification(updatedAgent);
       }
 
       console.log(
@@ -1863,6 +1883,112 @@ export class AgentManager {
     } catch (error) {
       console.error("[AgentManager] Error cleaning up expired nonces:", error);
       return 0;
+    }
+  }
+
+  /**
+   * Create a new email verification token for an agent
+   * @param agentId The ID of the agent to create a token for
+   * @param expiresInHours How many hours until the token expires (default: 24)
+   * @returns The created token string
+   */
+  private async createEmailVerificationToken(
+    agentId: string,
+    expiresInHours: number = 24,
+  ): Promise<string> {
+    try {
+      const token = uuidv4();
+      const expiresAt = new Date();
+      expiresAt.setHours(expiresAt.getHours() + expiresInHours);
+
+      await createEmailVerificationToken({
+        id: uuidv4(),
+        agentId,
+        token,
+        expiresAt,
+      });
+
+      console.log(
+        `[AgentManager] Created email verification token for agent ${agentId}`,
+      );
+      return token;
+    } catch (error) {
+      console.error(
+        `[AgentManager] Error creating email verification token for agent ${agentId}:`,
+        error,
+      );
+      throw new Error(
+        `Failed to create email verification token: ${error instanceof Error ? error.message : error}`,
+      );
+    }
+  }
+
+  /**
+   * Send an email verification link to an agent
+   * @param agent The agent to send the verification email to
+   * @returns The created email verification token
+   */
+  private async sendEmailVerification(agent: SelectAgent): Promise<void> {
+    try {
+      if (!agent.email) {
+        console.warn(
+          `[AgentManager] Cannot send verification email: Agent ${agent.id} has no email address`,
+        );
+        return;
+      }
+
+      const tokenString = await this.createEmailVerificationToken(agent.id, 24);
+
+      await this.emailService.sendTransactionalEmail(agent.email, tokenString);
+
+      console.log(
+        `[AgentManager] Sent verification email to ${agent.email} for agent ${agent.id}`,
+      );
+    } catch (error) {
+      console.error(
+        `[AgentManager] Error sending verification email to agent ${agent.id}:`,
+        error,
+      );
+      // We don't throw here to prevent registration failure if email sending fails
+    }
+  }
+
+  /**
+   * Mark an agent's email as verified
+   * @param agentId The ID of the agent to update
+   * @returns The updated agent or undefined if not found
+   */
+  async markEmailAsVerified(agentId: string): Promise<SelectAgent | undefined> {
+    try {
+      console.log(
+        `[AgentManager] Marking email as verified for agent ${agentId}`,
+      );
+
+      // Update the agent with email verified flag
+      const updatedAgent = await update({
+        id: agentId,
+        isEmailVerified: true,
+      });
+
+      if (!updatedAgent) {
+        console.log(
+          `[AgentManager] Failed to update email verification status for agent: ${agentId}`,
+        );
+        return undefined;
+      }
+
+      console.log(
+        `[AgentManager] Successfully marked email as verified for agent: ${agentId}`,
+      );
+      return updatedAgent;
+    } catch (error) {
+      console.error(
+        `[AgentManager] Error marking email as verified for agent ${agentId}:`,
+        error,
+      );
+      throw new Error(
+        `Failed to mark email as verified: ${error instanceof Error ? error.message : error}`,
+      );
     }
   }
 }

--- a/apps/api/src/services/email-verification.service.ts
+++ b/apps/api/src/services/email-verification.service.ts
@@ -1,0 +1,201 @@
+import axios from "axios";
+
+import { config } from "@/config/index.js";
+import { findById as findAgentById } from "@/database/repositories/agent-repository.js";
+import {
+  findEmailVerificationTokenByToken,
+  markTokenAsUsed,
+} from "@/database/repositories/email-verification-repository.js";
+import { findById as findUserById } from "@/database/repositories/user-repository.js";
+import { AgentManager } from "@/services/agent-manager.service.js";
+import { UserManager } from "@/services/user-manager.service.js";
+
+type Result<Ok, Err> =
+  | { success: true; value: Ok }
+  | { success: false; error: Err };
+
+/**
+ * Domain-specific error types for email verification
+ */
+type VerifyEmailError =
+  | { type: "InvalidToken"; token: string }
+  | { type: "TokenHasBeenUsed"; token: string }
+  | { type: "TokenHasExpired"; token: string }
+  | { type: "UserNotFound"; userId: string }
+  | { type: "AgentNotFound"; agentId: string }
+  | { type: "NoAssociation"; token: string }
+  | { type: "SystemError"; message: string; originalError?: unknown };
+
+/**
+ * Email Verification Service
+ * Handles email verification token creation and validation
+ */
+export class EmailVerificationService {
+  private userManager: UserManager;
+  private agentManager: AgentManager;
+
+  constructor() {
+    this.userManager = new UserManager();
+    this.agentManager = new AgentManager();
+  }
+
+  /**
+   * Verify an email verification token
+   * @param token The token to verify
+   * @returns Result object with verification outcome or specific error
+   */
+  async verifyToken(
+    token: string,
+  ): Promise<
+    Result<
+      { message: string; userId?: string; agentId?: string },
+      VerifyEmailError
+    >
+  > {
+    try {
+      const tokenRecord = await findEmailVerificationTokenByToken(token);
+      if (!tokenRecord) {
+        return {
+          success: false,
+          error: {
+            type: "InvalidToken",
+            token,
+          },
+        };
+      }
+
+      if (tokenRecord.used) {
+        return {
+          success: false,
+          error: {
+            type: "TokenHasBeenUsed",
+            token,
+          },
+        };
+      }
+
+      if (new Date() > tokenRecord.expiresAt) {
+        return {
+          success: false,
+          error: {
+            type: "TokenHasExpired",
+            token,
+          },
+        };
+      }
+
+      await markTokenAsUsed(tokenRecord.id);
+
+      // Check if it's associated with user
+      if (tokenRecord.userId) {
+        const user = await findUserById(tokenRecord.userId);
+        await this.userManager.markEmailAsVerified(tokenRecord.userId);
+
+        // Update Loops with "Verified" userGroup if user exists
+        if (user && user.email && user.name) {
+          await this.updateLoopsWithVerifiedStatus(user.email, user.name);
+        }
+
+        return {
+          success: true,
+          value: {
+            message: "Email verified successfully for user",
+            userId: tokenRecord.userId,
+          },
+        };
+      }
+
+      // Check if it's associated with agent
+      if (tokenRecord.agentId) {
+        const agent = await findAgentById(tokenRecord.agentId);
+        await this.agentManager.markEmailAsVerified(tokenRecord.agentId);
+
+        // Update Loops with "Verified" userGroup if agent exists
+        if (agent && agent.email && agent.name) {
+          await this.updateLoopsWithVerifiedStatus(agent.email, agent.name);
+        }
+
+        return {
+          success: true,
+          value: {
+            message: "Email verified successfully for agent",
+            agentId: tokenRecord.agentId,
+          },
+        };
+      }
+
+      return {
+        success: false,
+        error: {
+          type: "NoAssociation",
+          token,
+        },
+      };
+    } catch (error) {
+      console.error("[EmailVerificationService] Error verifying token:", error);
+      return {
+        success: false,
+        error: {
+          type: "SystemError",
+          message: "Error verifying token",
+          originalError: error,
+        },
+      };
+    }
+  }
+
+  /**
+   * Update Loops with "Verified" userGroup status
+   * @param email The email address to update
+   * @param name The name to update
+   * @returns Promise resolving to the API response, or null if API key is missing
+   */
+  private async updateLoopsWithVerifiedStatus(
+    email: string,
+    name: string,
+  ): Promise<void> {
+    try {
+      // Get the Loops API key from environment variables
+      const loopsApiKey = config.email.apiKey;
+      if (!loopsApiKey) {
+        console.error(
+          "[EmailVerificationService] Missing LOOPS_API_KEY in environment variables",
+        );
+        return;
+      }
+
+      // Prepare the payload for Loops API
+      const loopsPayload = {
+        email: email,
+        firstName: name,
+        userGroup: "Verified",
+      };
+
+      // Send request to Loops API
+      const response = await axios.put(
+        "https://app.loops.so/api/v1/contacts/update",
+        loopsPayload,
+        {
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${loopsApiKey}`,
+          },
+        },
+      );
+
+      if (response.status !== 200) {
+        console.error(
+          "[EmailVerificationService] Loops API error:",
+          response.data,
+        );
+      } else {
+        console.log(
+          `[EmailVerificationService] Successfully updated Loops with Verified status for ${email}`,
+        );
+      }
+    } catch (error) {
+      console.error("[EmailVerificationService] Error updating Loops:", error);
+      // Don't throw error to prevent blocking the verification flow
+    }
+  }
+}

--- a/apps/api/src/services/email-verification.service.ts
+++ b/apps/api/src/services/email-verification.service.ts
@@ -32,9 +32,9 @@ export class EmailVerificationService {
   private userManager: UserManager;
   private agentManager: AgentManager;
 
-  constructor() {
-    this.userManager = new UserManager();
-    this.agentManager = new AgentManager();
+  constructor(userManager: UserManager, agentManager: AgentManager) {
+    this.userManager = userManager;
+    this.agentManager = agentManager;
   }
 
   /**

--- a/apps/api/src/services/email-verification.service.ts
+++ b/apps/api/src/services/email-verification.service.ts
@@ -21,8 +21,6 @@ type VerifyEmailError =
   | { type: "InvalidToken"; token: string }
   | { type: "TokenHasBeenUsed"; token: string }
   | { type: "TokenHasExpired"; token: string }
-  | { type: "UserNotFound"; userId: string }
-  | { type: "AgentNotFound"; agentId: string }
   | { type: "NoAssociation"; token: string }
   | { type: "SystemError"; message: string; originalError?: unknown };
 

--- a/apps/api/src/services/email.service.ts
+++ b/apps/api/src/services/email.service.ts
@@ -1,0 +1,127 @@
+import axios from "axios";
+
+import { config } from "@/config/index.js";
+
+const EMAIL_VERIFICATION_PATH = "api/verify-email";
+
+/**
+ * Interface for verification email payload
+ */
+interface Payload {
+  transactionalId: string;
+  email: string;
+  dataVariables: {
+    verification_link: string;
+  };
+}
+
+/**
+ * Email Service
+ * Handles sending emails through the Loops API
+ */
+export class EmailService {
+  private readonly apiKey: string;
+  private readonly baseUrl: string =
+    "https://app.loops.so/api/v1/transactional";
+  private readonly apiDomain: string;
+  private readonly transactionalId: string;
+
+  /**
+   * Creates a new instance of the EmailService
+   */
+  constructor() {
+    this.apiKey = config.email.apiKey;
+    this.apiDomain = config.api.domain.endsWith("/")
+      ? config.api.domain
+      : `${config.api.domain}/`;
+    this.transactionalId = config.email.transactionalId;
+
+    if (!this.apiKey) {
+      console.warn(
+        "[EmailService] No API key provided for email service. Email functionality will be disabled.",
+      );
+    }
+
+    if (!this.transactionalId) {
+      console.warn("[EmailService] No transactional id provided");
+    }
+  }
+
+  /**
+   * Sends a transactional email using a template
+   * @param to The recipient email address
+   * @param token The verification token to include in the link
+   * @returns Promise resolving to the API response, or null if email functionality is disabled
+   * @throws Error if the API request fails
+   */
+  async sendTransactionalEmail(
+    to: string,
+    token: string,
+  ): Promise<unknown | null> {
+    if (!this.isEmailEnabled()) {
+      console.log(
+        "[EmailService] Email sending skipped - API key or transactional ID not provided",
+      );
+      return null;
+    }
+
+    const verificationLink = this.formatVerificationLink(token);
+
+    const payload: Payload = {
+      email: to,
+      transactionalId: this.transactionalId,
+      dataVariables: {
+        verification_link: verificationLink,
+      },
+    };
+    return this.sendEmail(payload);
+  }
+
+  /**
+   * Sends an email using the Loops API
+   * @param options Email options including recipients, subject, and content
+   * @returns Promise resolving to the API response
+   * @throws Error if the API request fails
+   */
+  private async sendEmail(payload: Payload): Promise<unknown> {
+    try {
+      const response = await axios.post(`${this.baseUrl}`, payload, {
+        headers: {
+          Authorization: `Bearer ${this.apiKey}`,
+          "Content-Type": "application/json",
+        },
+      });
+
+      console.log(`[EmailService] Email sent successfully`);
+      return response.data;
+    } catch (error) {
+      console.error("[EmailService] Error sending email:", error);
+
+      if (axios.isAxiosError(error)) {
+        console.error("[EmailService] API response:", error.response?.data);
+        throw new Error(
+          `Failed to send email: ${error.response?.data?.message || error.message}`,
+        );
+      }
+
+      throw new Error(`Failed to send email: ${error}`);
+    }
+  }
+
+  /**
+   * Checks if email functionality is enabled
+   * @returns True if both API key and transactional ID are provided, false otherwise
+   */
+  private isEmailEnabled(): boolean {
+    return Boolean(this.apiKey && this.transactionalId);
+  }
+
+  /**
+   * Creates a verification link using the API domain from config
+   * @param token The verification token to include in the link
+   * @returns A properly formatted verification URL
+   */
+  private formatVerificationLink(token: string): string {
+    return `${this.apiDomain}${EMAIL_VERIFICATION_PATH}?token=${token}`;
+  }
+}

--- a/apps/api/src/services/email.service.ts
+++ b/apps/api/src/services/email.service.ts
@@ -11,7 +11,7 @@ interface Payload {
   transactionalId: string;
   email: string;
   dataVariables: {
-    verification_link: string;
+    verificationLink: string;
   };
 }
 
@@ -71,7 +71,7 @@ export class EmailService {
       email: to,
       transactionalId: this.transactionalId,
       dataVariables: {
-        verification_link: verificationLink,
+        verificationLink: verificationLink,
       },
     };
     return this.sendEmail(payload);

--- a/apps/api/src/services/index.ts
+++ b/apps/api/src/services/index.ts
@@ -56,11 +56,6 @@ class ServiceRegistry {
       this._portfolioSnapshotter,
     );
 
-    // Initialize user and agent managers (new architecture)
-    this._userManager = new UserManager();
-    this._agentManager = new AgentManager();
-    this._adminManager = new AdminManager();
-
     // Initialize auth service (no dependencies needed)
     this._authService = new AuthService();
 
@@ -79,8 +74,16 @@ class ServiceRegistry {
     // Initialize email service (no dependencies)
     this._emailService = new EmailService();
 
-    // Initialize email verification service (no dependencies)
-    this._emailVerificationService = new EmailVerificationService();
+    // Initialize user and agent managers (require email service)
+    this._userManager = new UserManager(this._emailService);
+    this._agentManager = new AgentManager(this._emailService);
+    this._adminManager = new AdminManager();
+
+    // Initialize email verification service (requires user and agent managers)
+    this._emailVerificationService = new EmailVerificationService(
+      this._userManager,
+      this._agentManager,
+    );
 
     this._competitionManager = new CompetitionManager(
       this._balanceManager,

--- a/apps/api/src/services/index.ts
+++ b/apps/api/src/services/index.ts
@@ -5,6 +5,8 @@ import { AuthService } from "@/services/auth.service.js";
 import { BalanceManager } from "@/services/balance-manager.service.js";
 import { CompetitionManager } from "@/services/competition-manager.service.js";
 import { ConfigurationService } from "@/services/configuration.service.js";
+import { EmailVerificationService } from "@/services/email-verification.service.js";
+import { EmailService } from "@/services/email.service.js";
 import { LeaderboardService } from "@/services/leaderboard.service.js";
 import { ObjectIndexService } from "@/services/object-index.service.js";
 import { PortfolioSnapshotter } from "@/services/portfolio-snapshotter.service.js";
@@ -37,6 +39,8 @@ class ServiceRegistry {
   private _voteManager: VoteManager;
   private _agentRankService: AgentRankService;
   private _objectIndexService: ObjectIndexService;
+  private _emailService: EmailService;
+  private _emailVerificationService: EmailVerificationService;
 
   constructor() {
     // Initialize services in dependency order
@@ -71,6 +75,12 @@ class ServiceRegistry {
 
     // Initialize object index service (no dependencies)
     this._objectIndexService = new ObjectIndexService();
+
+    // Initialize email service (no dependencies)
+    this._emailService = new EmailService();
+
+    // Initialize email verification service (no dependencies)
+    this._emailVerificationService = new EmailVerificationService();
 
     this._competitionManager = new CompetitionManager(
       this._balanceManager,
@@ -161,6 +171,14 @@ class ServiceRegistry {
   get objectIndexService(): ObjectIndexService {
     return this._objectIndexService;
   }
+
+  get emailService(): EmailService {
+    return this._emailService;
+  }
+
+  get emailVerificationService(): EmailVerificationService {
+    return this._emailVerificationService;
+  }
 }
 
 // Export service types for convenience
@@ -172,6 +190,8 @@ export {
   BalanceManager,
   CompetitionManager,
   ConfigurationService,
+  EmailService,
+  EmailVerificationService,
   LeaderboardService,
   ObjectIndexService,
   PortfolioSnapshotter,

--- a/apps/api/src/services/user-manager.service.ts
+++ b/apps/api/src/services/user-manager.service.ts
@@ -202,12 +202,17 @@ export class UserManager {
 
       // Check if email was updated to a new value
       const emailChanged = user.email && currentUser.email !== user.email;
+      if (emailChanged) {
+        user = {
+          ...user,
+          isEmailVerified: false,
+        };
+      }
 
       const now = new Date();
       const updatedUser = await update({
         ...user,
         updatedAt: now,
-        isEmailVerified: !emailChanged, // we must set IsEmailVerified to false if emailChanged is true
       });
 
       // Update cache

--- a/apps/api/src/services/user-manager.service.ts
+++ b/apps/api/src/services/user-manager.service.ts
@@ -28,10 +28,10 @@ export class UserManager {
   // Email service for sending verification emails
   private emailService: EmailService;
 
-  constructor() {
+  constructor(emailService: EmailService) {
     this.userWalletCache = new Map();
     this.userProfileCache = new Map();
-    this.emailService = new EmailService();
+    this.emailService = emailService;
   }
 
   /**

--- a/apps/api/src/services/user-manager.service.ts
+++ b/apps/api/src/services/user-manager.service.ts
@@ -1,5 +1,6 @@
 import { v4 as uuidv4 } from "uuid";
 
+import { createEmailVerificationToken } from "@/database/repositories/email-verification-repository.js";
 import {
   count,
   create,
@@ -12,6 +13,7 @@ import {
   update,
 } from "@/database/repositories/user-repository.js";
 import { InsertUser, SelectUser } from "@/database/schema/core/types.js";
+import { EmailService } from "@/services/email.service.js";
 import { UserMetadata, UserSearchParams } from "@/types/index.js";
 
 /**
@@ -23,10 +25,13 @@ export class UserManager {
   private userWalletCache: Map<string, string>; // walletAddress -> userId
   // Cache for user profiles by ID
   private userProfileCache: Map<string, SelectUser>; // userId -> user profile
+  // Email service for sending verification emails
+  private emailService: EmailService;
 
   constructor() {
     this.userWalletCache = new Map();
     this.userProfileCache = new Map();
+    this.emailService = new EmailService();
   }
 
   /**
@@ -108,6 +113,11 @@ export class UserManager {
       this.userWalletCache.set(normalizedWalletAddress, id);
       this.userProfileCache.set(id, savedUser);
 
+      // Send email verification if email is provided
+      if (email) {
+        await this.sendEmailVerification(savedUser);
+      }
+
       console.log(
         `[UserManager] Registered user: ${name || "Unknown"} (${id}) with wallet ${normalizedWalletAddress}`,
       );
@@ -184,16 +194,31 @@ export class UserManager {
     user: Partial<InsertUser> & { id: string },
   ): Promise<SelectUser> {
     try {
+      // Get the current user data to check if email is being changed
+      const currentUser = await this.getUser(user.id);
+      if (!currentUser) {
+        throw new Error(`User with ID ${user.id} not found`);
+      }
+
+      // Check if email was updated to a new value
+      const emailChanged = user.email && currentUser.email !== user.email;
+
       const now = new Date();
       const updatedUser = await update({
         ...user,
         updatedAt: now,
+        isEmailVerified: !emailChanged, // we must set IsEmailVerified to false if emailChanged is true
       });
 
       // Update cache
       this.userProfileCache.set(user.id, updatedUser);
       if (updatedUser.walletAddress) {
         this.userWalletCache.set(updatedUser.walletAddress, user.id);
+      }
+
+      // Send verification email if email has changed
+      if (emailChanged && updatedUser.email) {
+        await this.sendEmailVerification(updatedUser);
       }
 
       console.log(`[UserManager] Updated user: ${user.id}`);
@@ -360,5 +385,95 @@ export class UserManager {
       walletCacheSize: this.userWalletCache.size,
       profileCacheSize: this.userProfileCache.size,
     };
+  }
+
+  /**
+   * Create a new email verification token for a user
+   * @param userId The ID of the user to create a token for
+   * @param expiresInHours How many hours until the token expires (default: 24)
+   * @returns The created token string
+   */
+  private async createEmailVerificationToken(
+    userId: string,
+    expiresInHours: number = 24,
+  ): Promise<string> {
+    try {
+      const token = uuidv4();
+      const expiresAt = new Date();
+      expiresAt.setHours(expiresAt.getHours() + expiresInHours);
+
+      await createEmailVerificationToken({
+        id: uuidv4(),
+        userId,
+        token,
+        expiresAt,
+      });
+
+      console.log(
+        `[UserManager] Created email verification token for user ${userId}`,
+      );
+      return token;
+    } catch (error) {
+      console.error(
+        `[UserManager] Error creating email verification token for user ${userId}:`,
+        error,
+      );
+      throw new Error(
+        `Failed to create email verification token: ${error instanceof Error ? error.message : error}`,
+      );
+    }
+  }
+
+  /**
+   * Send an email verification link to a user
+   * @param user The user to send the verification email to
+   * @returns The created email verification token
+   */
+  private async sendEmailVerification(user: SelectUser): Promise<void> {
+    try {
+      if (!user.email) {
+        console.warn(
+          `[UserManager] Cannot send verification email: User ${user.id} has no email address`,
+        );
+        return;
+      }
+
+      const tokenString = await this.createEmailVerificationToken(user.id, 24);
+
+      await this.emailService.sendTransactionalEmail(user.email, tokenString);
+
+      console.log(
+        `[UserManager] Sent verification email to ${user.email} for user ${user.id}`,
+      );
+    } catch (error) {
+      console.error(
+        `[UserManager] Error sending verification email to user ${user.id}:`,
+        error,
+      );
+      // We don't throw here to prevent registration failure if email sending fails
+    }
+  }
+
+  /**
+   * Mark a user's email as verified
+   * @param userId The ID of the user whose email should be marked as verified
+   * @returns The updated user or null if the user was not found
+   */
+  async markEmailAsVerified(userId: string): Promise<SelectUser | null> {
+    try {
+      const updatedUser = await this.updateUser({
+        id: userId,
+        isEmailVerified: true,
+      });
+
+      console.log(`[UserManager] Marked email as verified for user ${userId}`);
+      return updatedUser;
+    } catch (error) {
+      console.error(
+        `[UserManager] Error marking email as verified for user ${userId}:`,
+        error,
+      );
+      return null;
+    }
   }
 }

--- a/apps/api/turbo.json
+++ b/apps/api/turbo.json
@@ -51,7 +51,9 @@
         "TEST_PORT",
         "TEST_SOL_TOKEN_ADDRESS",
         "npm_package_version",
-        "API_DOMAIN"
+        "API_DOMAIN",
+        "LOOPS_API_KEY",
+        "LOOPS_TRANSACTIONAL_ID"
       ]
     }
   }


### PR DESCRIPTION
## Summary
Closes #437 
Closes #416 

## Implementation

- When a user is registered or updated, we check for the email and send a verification email
- When an agent is created or updated, we check for the email and send a verification email
- A token is stored on a new table called `email_verification_tokens`
- A new endpoint is created `GET /verify-email?token=${token}` for verifying the user (or agent)
- The user (or agent) is marked as verified (flag `is_email_verified` is set to `true`)
- That information is sent to Loops

## Implement details
- Two new envs are added: `LOOPS_API_KEY` and `LOOPS_TRANSACTIONAL_ID`. `LOOPS_TRANSACTIONAL_ID` is the id of the email template created on Loops web app
- A migration for  `email_verification_tokens` table and `is_email_verified` flag is added
- `EmailVerificationService` is responsible for verifying the user (or agent) token
- `EmailService` is responsible for sending transactional emails

## Notes
- Before deploying, we must create a transaction email on Loops and set `LOOPS_API_KEY` and `LOOPS_TRANSACTIONAL_ID`
- This was tested with automated tests (`email-verification.test.ts`) that ignores Loops by not setting the envs
- This was also manually tested by using the scripts `register:user` and `register:agent`