### PR TITLE
fix(comps): The agent profile page competition table shows data and can be sorted.

### DIFF
--- a/apps/comps/components/agent-profile/comps-table.tsx
+++ b/apps/comps/components/agent-profile/comps-table.tsx
@@ -51,8 +51,7 @@ export function CompetitionTable({
                 Competition
               </SortableTableHeader>
               {
-                //some fields have sorted removed until they are supported by the api
-                // id, name, description, startDate, endDate, createdAt, updatedAt, portfolioValue, pnl, totalTrades, rank
+                // some fields have sorted removed until they are supported by the api, specifically Trophies and Skills
               }
               <TableHead>Skills</TableHead>
               <SortableTableHeader
@@ -61,7 +60,12 @@ export function CompetitionTable({
               >
                 Portfolio
               </SortableTableHeader>
-              <TableHead className="w-30 flex justify-end">P&L</TableHead>
+              <SortableTableHeader
+                onToggleSort={() => handleSortChange("pnl")}
+                sortState={sortState["pnl"]}
+              >
+                P&L
+              </SortableTableHeader>
               <SortableTableHeader
                 onToggleSort={() => handleSortChange("totalTrades")}
                 sortState={sortState["totalTrades"]}
@@ -130,7 +134,7 @@ export function CompetitionTable({
                     </TableCell>
                     <TableCell className="w-30 flex items-center justify-center font-medium">
                       <span className="text-secondary-foreground flex flex-col">
-                        {comp.pnlPercent
+                        {typeof comp.pnlPercent === "number"
                           ? `${Math.round(comp.pnlPercent)}%`
                           : "n/a"}
                       </span>

--- a/apps/comps/components/agent-profile/comps-table.tsx
+++ b/apps/comps/components/agent-profile/comps-table.tsx
@@ -123,18 +123,24 @@ export function CompetitionTable({
                       {/* Future skills mapping */}
                     </TableCell>
                     <TableCell className="text-md text-secondary-foreground flex items-center font-medium">
-                      $0<span className="ml-2 text-xs">USDC</span>
+                      {typeof comp.portfolioValue === "number"
+                        ? `$${comp.portfolioValue.toFixed(2)}`
+                        : "n/a"}
+                      <span className="ml-2 text-xs">USDC</span>
                     </TableCell>
                     <TableCell className="w-30 flex items-center justify-center font-medium">
                       <span className="text-secondary-foreground flex flex-col">
-                        0$
+                        {comp.pnlPercent
+                          ? `${Math.round(comp.pnlPercent)}%`
+                          : "n/a"}
                       </span>
                     </TableCell>
                     <TableCell className="w-30 text-md fond-semibold text-secondary-foreground flex items-center text-center">
-                      0
+                      {comp.totalTrades}
                     </TableCell>
                     <TableCell className="w-30 text-secondary-foreground flex items-center text-center">
-                      0/0
+                      {comp.bestPlacement &&
+                        `${comp.bestPlacement.rank}/${comp.bestPlacement.totalAgents}`}
                     </TableCell>
                     <TableCell className="align-center h-25 flex items-center gap-2">
                       <Hexagon className="h-8 w-8 bg-blue-500" />

--- a/apps/comps/components/agent-profile/comps-table.tsx
+++ b/apps/comps/components/agent-profile/comps-table.tsx
@@ -52,12 +52,28 @@ export function CompetitionTable({
               </SortableTableHeader>
               {
                 //some fields have sorted removed until they are supported by the api
+                // id, name, description, startDate, endDate, createdAt, updatedAt, portfolioValue, pnl, totalTrades, rank
               }
               <TableHead>Skills</TableHead>
-              <TableHead>Portfolio</TableHead>
+              <SortableTableHeader
+                onToggleSort={() => handleSortChange("portfolioValue")}
+                sortState={sortState["portfolioValue"]}
+              >
+                Portfolio
+              </SortableTableHeader>
               <TableHead className="w-30 flex justify-end">P&L</TableHead>
-              <TableHead>Trades</TableHead>
-              <TableHead>Placement</TableHead>
+              <SortableTableHeader
+                onToggleSort={() => handleSortChange("totalTrades")}
+                sortState={sortState["totalTrades"]}
+              >
+                Trades
+              </SortableTableHeader>
+              <SortableTableHeader
+                onToggleSort={() => handleSortChange("rank")}
+                sortState={sortState["rank"]}
+              >
+                Placement
+              </SortableTableHeader>
               <TableHead>Trophies</TableHead>
               {canClaim && <TableHead className="text-left">Reward</TableHead>}
             </TableRow>

--- a/apps/comps/components/agent-profile/comps-table.tsx
+++ b/apps/comps/components/agent-profile/comps-table.tsx
@@ -143,7 +143,8 @@ export function CompetitionTable({
                       {comp.totalTrades}
                     </TableCell>
                     <TableCell className="w-30 text-secondary-foreground flex items-center text-center">
-                      {comp.bestPlacement &&
+                      {comp.bestPlacement?.rank &&
+                        comp.bestPlacement?.totalAgents &&
                         `${comp.bestPlacement.rank}/${comp.bestPlacement.totalAgents}`}
                     </TableCell>
                     <TableCell className="align-center h-25 flex items-center gap-2">

--- a/apps/comps/types/competition.ts
+++ b/apps/comps/types/competition.ts
@@ -68,6 +68,14 @@ export interface Competition {
       votedAt?: string;
     };
   };
+  portfolioValue?: number;
+  pnl?: number;
+  pnlPercent?: number;
+  totalTrades?: number;
+  bestPlacement?: {
+    rank?: number;
+    totalAgents?: number;
+  };
 }
 
 export interface CompetitionResponse {


### PR DESCRIPTION
part of: https://github.com/recallnet/js-recall/issues/637

Connect front end agent profile page competitions table to the parts of the api that are supported currently