### PR TITLE
fix(comps): build errors with experimental mode

### DIFF
--- a/apps/comps/components/agent-profile/index.tsx
+++ b/apps/comps/components/agent-profile/index.tsx
@@ -200,7 +200,7 @@ export default function AgentProfile({
             <span className="text-secondary-foreground w-full text-left">
               {agent.stats?.bestPlacement
                 ? `🥇 ${agent.stats.bestPlacement.rank} of ${agent.stats.bestPlacement.totalAgents}`
-                : "No completed yet"}
+                : "No completed competitions yet"}
             </span>
           </div>
           <div className="flex w-full">

--- a/apps/comps/components/user-agents/agents-summary.tsx
+++ b/apps/comps/components/user-agents/agents-summary.tsx
@@ -6,7 +6,7 @@ import { cn } from "@recallnet/ui2/lib/utils";
 
 import BigNumberDisplay from "@/components/bignumber";
 import { useCompetition } from "@/hooks";
-import { Agent } from "@/types";
+import { Agent, Competition } from "@/types";
 import { toOrdinal } from "@/utils/format";
 
 export const AgentsSummary: React.FunctionComponent<{
@@ -16,7 +16,81 @@ export const AgentsSummary: React.FunctionComponent<{
   completedComps: number;
   highest: number | null;
 }> = ({ bestPlacement, nAgents = 0, completedComps, highest, className }) => {
-  const { data: competition } = useCompetition(bestPlacement?.competitionId);
+  const competitionId = bestPlacement?.competitionId;
+
+  // If we have a competition ID, render the component that fetches competition data
+  if (competitionId) {
+    return (
+      <AgentsSummaryWithCompetition
+        bestPlacement={bestPlacement}
+        nAgents={nAgents}
+        completedComps={completedComps}
+        highest={highest}
+        className={className}
+        competitionId={competitionId}
+      />
+    );
+  }
+
+  // Otherwise render without competition data
+  return (
+    <AgentsSummaryContent
+      bestPlacement={bestPlacement}
+      nAgents={nAgents}
+      completedComps={completedComps}
+      highest={highest}
+      className={className}
+      competition={null}
+    />
+  );
+};
+
+// Component that always calls the `useCompetition` hook
+const AgentsSummaryWithCompetition: React.FunctionComponent<{
+  className?: string;
+  nAgents: number;
+  bestPlacement?: NonNullable<Agent["stats"]>["bestPlacement"];
+  completedComps: number;
+  highest: number | null;
+  competitionId: string;
+}> = ({
+  bestPlacement,
+  nAgents,
+  completedComps,
+  highest,
+  className,
+  competitionId,
+}) => {
+  const { data: competition } = useCompetition(competitionId);
+
+  return (
+    <AgentsSummaryContent
+      bestPlacement={bestPlacement}
+      nAgents={nAgents}
+      completedComps={completedComps}
+      highest={highest}
+      className={className}
+      competition={competition}
+    />
+  );
+};
+
+// The actual content component without any hooks
+const AgentsSummaryContent: React.FunctionComponent<{
+  className?: string;
+  nAgents: number;
+  bestPlacement?: NonNullable<Agent["stats"]>["bestPlacement"];
+  completedComps: number;
+  highest: number | null;
+  competition: Competition | null;
+}> = ({
+  bestPlacement,
+  nAgents,
+  completedComps,
+  highest,
+  className,
+  competition,
+}) => {
   const borderRules =
     nAgents >= 4 ? "xs:border-r-1 border-b-1" : "border-b-1 xs:border-r-1";
 

--- a/apps/comps/lib/api-client.ts
+++ b/apps/comps/lib/api-client.ts
@@ -31,7 +31,19 @@ import {
   VotingStateResponse,
 } from "@/types";
 
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || "/api";
+/**
+ * Get the base URL for the API
+ * @returns The base URL for the API
+ */
+const getApiBaseUrl = () => {
+  const baseUrl = process.env.NEXT_PUBLIC_API_BASE_URL;
+  if (!baseUrl) {
+    throw new Error("NEXT_PUBLIC_API_BASE_URL is not set");
+  }
+  return baseUrl;
+};
+
+const API_BASE_URL = getApiBaseUrl();
 
 /**
  * Base HTTP error class with status code support

--- a/apps/comps/lib/api-client.ts
+++ b/apps/comps/lib/api-client.ts
@@ -31,19 +31,8 @@ import {
   VotingStateResponse,
 } from "@/types";
 
-/**
- * Get the base URL for the API
- * @returns The base URL for the API
- */
-const getApiBaseUrl = () => {
-  const baseUrl = process.env.NEXT_PUBLIC_API_BASE_URL;
-  if (!baseUrl) {
-    throw new Error("NEXT_PUBLIC_API_BASE_URL is not set");
-  }
-  return baseUrl;
-};
-
-const API_BASE_URL = getApiBaseUrl();
+const API_BASE_URL =
+  process.env.NEXT_PUBLIC_API_BASE_URL?.trim() || "http://localhost:3000/api";
 
 /**
  * Base HTTP error class with status code support

--- a/apps/comps/package.json
+++ b/apps/comps/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack --port 3001",
-    "build": "next build --experimental-build-mode compile",
+    "build": "next build",
     "start": "next start",
     "lint": "next lint --max-warnings 0",
     "format": "prettier --write . --ignore-path=../../.prettierignore",

--- a/apps/comps/turbo.json
+++ b/apps/comps/turbo.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "build": {
+      "env": ["NEXT_PUBLIC_API_BASE_URL"]
+    }
+  }
+}


### PR DESCRIPTION
The staging app is unable to load data from the backend API. This is because the build script's `--experimental-build-mode compile` will prevent the app from reading the `NEXT_PUBLIC_API_BASE_URL` env var, so then all API calls fail. i.e., the API client defaults to the internal `/api` if the env var isn't present (see the logs below).

This PR fixes the errors by reverting the experimental build mode, and it also removes the internal `/api` fallback (legacy for when we had to mock data).

Also, the `AgentsSummary` card was throwing an error on build because the `bestPlacement.competitionId` is nullable, so we have to use the component composition pattern to conditionally render it.

Reference:
<img width="1015" alt="Screenshot 2025-06-26 at 6 09 24 PM" src="https://github.com/user-attachments/assets/2e573292-9a83-448e-9abc-9f7d3f4ef31e" />