### PR TITLE
fix: resolve nonce generation in registration siwe process

### DIFF
--- a/apps/registration/components/providers.tsx
+++ b/apps/registration/components/providers.tsx
@@ -23,7 +23,7 @@ const AUTHENTICATION_STATUS: AuthenticationStatus = "unauthenticated";
 const CONFIG = clientConfig();
 
 function WalletProvider(props: { children: ReactNode }) {
-  const { data: nonceData, refetch: refetchNonce } = useNonce();
+  const { refetch: refetchNonce } = useNonce();
   const { mutateAsync: login } = useLogin();
   const { mutateAsync: logout } = useLogout();
 
@@ -64,7 +64,7 @@ function WalletProvider(props: { children: ReactNode }) {
         await logout();
       },
     });
-  }, [nonceData, refetchNonce, login, logout]);
+  }, [refetchNonce, login, logout]);
 
   return (
     <WagmiProvider config={CONFIG}>

--- a/apps/registration/components/providers.tsx
+++ b/apps/registration/components/providers.tsx
@@ -30,12 +30,10 @@ function WalletProvider(props: { children: ReactNode }) {
   const authAdapter = React.useMemo(() => {
     return createAuthenticationAdapter({
       getNonce: async () => {
-        // If we don't have nonce data, refetch it
-        if (!nonceData?.nonce) {
-          const result = await refetchNonce();
-          return result.data?.nonce ?? "";
-        }
-        return nonceData.nonce;
+        // Always fetch a fresh nonce for each SIWE attempt
+        // This prevents nonce reuse issues that cause first-attempt failures
+        const result = await refetchNonce();
+        return result.data?.nonce ?? "";
       },
       createMessage: ({ nonce, address, chainId }) => {
         return createSiweMessage({

--- a/apps/registration/hooks/useAuth.ts
+++ b/apps/registration/hooks/useAuth.ts
@@ -23,6 +23,9 @@ export const useNonce = () => {
     queryFn: async () => {
       return apiClient.getNonce();
     },
+    // Don't cache nonces for too long - they should be fresh for each auth attempt
+    staleTime: 0, // Always consider stale
+    gcTime: 1000 * 60, // Keep in cache for 1 minute but mark as stale immediately
   });
 };
 
@@ -48,6 +51,13 @@ export const useLogin = () => {
 
       // Trigger competitions refetch
       queryClient.invalidateQueries({ queryKey: ["competitions"] });
+
+      // Invalidate nonce cache after successful login
+      queryClient.invalidateQueries({ queryKey: ["nonce"] });
+    },
+    onError: () => {
+      // Invalidate nonce cache after failed login to ensure fresh nonce on retry
+      queryClient.invalidateQueries({ queryKey: ["nonce"] });
     },
   });
 };


### PR DESCRIPTION
# Summary

- React Query caching behavior was caching nonces (single-use authentication tokens) between login attempts
- First attempt would fail due to nonce validation issues on the backend
- Second attempt would succeed because the same cached nonce was still valid within its time window
- The useNonce() hook was designed to reuse cached nonces instead of fetching fresh ones for each attempt

## Solution Implemented

- Always fetch fresh nonces: Modified the authentication adapter to call refetchNonce() on every SIWE attempt instead of using cached data
- Disabled nonce caching: Set staleTime: 0 on the nonce query to prevent React Query from serving stale cached nonces
- Added cache invalidation: Implemented nonce cache cleanup after both successful and failed login attempts
- Improved error handling: Enhanced the login mutation to properly handle failures and ensure clean state