### PR TITLE
fix: attempt to resolve registration signing on mobile with forced reload

### DIFF
--- a/apps/registration/components/mobile-sign-helper.tsx
+++ b/apps/registration/components/mobile-sign-helper.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useAccount } from "wagmi";
+
+import { useUserSession } from "@/hooks/useAuth";
+import { isMobileDevice } from "@/lib/mobile-utils";
+
+/**
+ * Component that provides mobile-specific signing guidance
+ */
+export function MobileSignHelper() {
+  const { isConnected } = useAccount();
+  const userSession = useUserSession();
+  const [showMobileHelp, setShowMobileHelp] = useState(false);
+
+  useEffect(() => {
+    // Only show on mobile when user is connected but not authenticated
+    const isAuthenticating =
+      isConnected && userSession.isInitialized && !userSession.isAuthenticated;
+
+    if (isMobileDevice() && isAuthenticating) {
+      setShowMobileHelp(true);
+
+      // Hide after 15 seconds or when auth completes
+      const timer = setTimeout(() => {
+        setShowMobileHelp(false);
+      }, 15000);
+
+      return () => clearTimeout(timer);
+    } else {
+      setShowMobileHelp(false);
+    }
+  }, [isConnected, userSession]);
+
+  const handleRetrySign = () => {
+    // Trigger the RainbowKit authentication modal again
+    // This is safer than auto-triggering signMessage
+    window.location.reload();
+  };
+
+  if (!showMobileHelp) return null;
+
+  return (
+    <div className="fixed bottom-4 left-4 right-4 z-50 rounded-lg bg-blue-600 p-4 text-white shadow-lg">
+      <div className="flex items-start space-x-3">
+        <div className="flex-shrink-0">
+          <svg className="h-5 w-5" fill="currentColor" viewBox="0 0 20 20">
+            <path
+              fillRule="evenodd"
+              d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z"
+              clipRule="evenodd"
+            />
+          </svg>
+        </div>
+        <div className="flex-1">
+          <h3 className="text-sm font-medium">Signing Message</h3>
+          <p className="mt-1 text-xs">
+            If your wallet app doesn&apos;t open automatically, please return to
+            it manually to complete signing.
+          </p>
+          <button
+            onClick={handleRetrySign}
+            className="mt-2 rounded bg-blue-700 px-3 py-1 text-xs font-medium text-white hover:bg-blue-800"
+          >
+            Retry Signing
+          </button>
+        </div>
+        <button
+          onClick={() => setShowMobileHelp(false)}
+          className="flex-shrink-0 text-white hover:text-gray-200"
+        >
+          <svg
+            className="h-4 w-4"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M6 18L18 6M6 6l12 12"
+            />
+          </svg>
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/registration/components/mobile-wallet-enhancer.tsx
+++ b/apps/registration/components/mobile-wallet-enhancer.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useAccount } from "wagmi";
+
+import { isMobileDevice } from "@/lib/mobile-utils";
+
+/**
+ * Component that enhances mobile wallet behavior
+ * Handles mobile-specific WalletConnect issues by reloading after connection
+ */
+export function MobileWalletEnhancer() {
+  const { isConnected, address } = useAccount();
+  const prevConnected = useRef(false);
+
+  useEffect(() => {
+    // Only apply mobile enhancements on mobile devices
+    if (!isMobileDevice()) return;
+
+    // Detect precise false → true transition to avoid flickering issues
+    const justConnected = !prevConnected.current && isConnected && address;
+    prevConnected.current = isConnected;
+
+    const hasReloadedForWallet = sessionStorage.getItem("wallet-mobile-reload");
+
+    if (justConnected && !hasReloadedForWallet) {
+      // Mark that we're about to reload for wallet connection
+      sessionStorage.setItem("wallet-mobile-reload", "true");
+
+      // Increased delay to ensure connection state is fully established
+      setTimeout(() => {
+        window.location.reload();
+      }, 1000);
+    }
+
+    // Clear the reload flag after successful connection and page load
+    if (justConnected && hasReloadedForWallet) {
+      // Clear the flag after a short delay to allow for signing
+      setTimeout(() => {
+        sessionStorage.removeItem("wallet-mobile-reload");
+      }, 3000);
+    }
+  }, [isConnected, address]);
+
+  // This component doesn't render anything
+  return null;
+}

--- a/apps/registration/components/providers.tsx
+++ b/apps/registration/components/providers.tsx
@@ -19,6 +19,9 @@ import { ThemeProvider } from "@recallnet/ui/components/theme-provider";
 import { useLogin, useLogout, useNonce } from "@/hooks/useAuth";
 import { clientConfig } from "@/wagmi-config";
 
+import { MobileSignHelper } from "./mobile-sign-helper";
+import { MobileWalletEnhancer } from "./mobile-wallet-enhancer";
+
 const AUTHENTICATION_STATUS: AuthenticationStatus = "unauthenticated";
 const CONFIG = clientConfig();
 
@@ -73,6 +76,8 @@ function WalletProvider(props: { children: ReactNode }) {
         status={AUTHENTICATION_STATUS}
       >
         <RainbowKitProvider theme={darkTheme()}>
+          <MobileWalletEnhancer />
+          <MobileSignHelper />
           {props.children}
         </RainbowKitProvider>
       </RainbowKitAuthenticationProvider>

--- a/apps/registration/lib/mobile-utils.ts
+++ b/apps/registration/lib/mobile-utils.ts
@@ -1,0 +1,35 @@
+/**
+ * Utility functions for mobile device detection and behavior
+ */
+
+/**
+ * Detects if the current device is a mobile device
+ * @returns true if the device is mobile, false otherwise
+ */
+export function isMobileDevice(): boolean {
+  if (typeof window === "undefined") return false;
+
+  return /Mobi|Android|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
+    navigator.userAgent,
+  );
+}
+
+/**
+ * Detects if the current device is iOS
+ * @returns true if the device is iOS, false otherwise
+ */
+export function isIOSDevice(): boolean {
+  if (typeof window === "undefined") return false;
+
+  return /iPad|iPhone|iPod/.test(navigator.userAgent);
+}
+
+/**
+ * Detects if the current device is Android
+ * @returns true if the device is Android, false otherwise
+ */
+export function isAndroidDevice(): boolean {
+  if (typeof window === "undefined") return false;
+
+  return /Android/.test(navigator.userAgent);
+}


### PR DESCRIPTION
# Summary

Implemented mobile-specific enhancements to address WalletConnect deep linking issues that prevent mobile wallet apps from properly opening for SIWE (Sign-In with Ethereum) authentication.

## Problem Statement
- Mobile users could connect their wallets successfully
- However, clicking "Sign Message" would not trigger the mobile wallet app to open
- This is a known limitation with WalletConnect v2 on mobile browsers
- Users experienced a "dead-end" where the sign button appeared but did nothing

### 1. Mobile Detection Utilities (`lib/mobile-utils.ts`)
- **Purpose**: Reliable mobile device detection for conditional behavior
- **Features**: 
  - SSR-safe implementation with `typeof window` checks
  - Comprehensive mobile device regex patterns
  - Separate iOS and Android detection functions

### 2. Mobile Wallet Enhancer (`components/mobile-wallet-enhancer.tsx`)
- **Purpose**: Automatically reload page after wallet connection to prime WalletConnect deep links
- **Key Features**:
  - **Precise connection detection**: Uses `useRef` to track `false → true` transitions, preventing flickering issues
  - **Mobile-only behavior**: Only affects mobile devices, desktop unchanged
  - **Session storage safeguards**: Prevents infinite reload loops
  - **Optimized timing**: 1000ms delay for stable connection establishment
  - **Automatic cleanup**: Removes session flags after 3 seconds

### 3. Mobile Sign Helper (`components/mobile-sign-helper.tsx`)
- **Purpose**: Provide user guidance and retry options during mobile authentication
- **Key Features**:
  - **Smart visibility**: Only appears on mobile during authentication attempts
  - **User guidance**: Clear instructions for manual wallet app navigation
  - **Retry functionality**: "Retry Signing" button for failed attempts
  - **Auto-dismiss**: Disappears after 15 seconds or successful authentication
  - **Non-intrusive**: Positioned as overlay notification