### PR TITLE
fix (api): edit autoJoin method to target the agent when taking portfolio snapshots

### DIFF
--- a/apps/api/e2e/tests/sandbox-mode.test.ts
+++ b/apps/api/e2e/tests/sandbox-mode.test.ts
@@ -6,6 +6,7 @@ import {
   AdminAgentResponse,
   CompetitionAgentsResponse,
   CompetitionStatusResponse,
+  SnapshotResponse,
   StartCompetitionResponse,
   UserRegistrationResponse,
 } from "@/e2e/utils/api-types.js";
@@ -540,5 +541,113 @@ describe("Sandbox Mode", () => {
     expect(status.competition?.id).toBe(competition1.id);
     expect(status.competition?.status).toBe("active");
     expect(status.competition?.sandboxMode).toBe(true);
+  });
+
+  test("should verify that only the auto-joined agent gets a portfolio snapshot", async () => {
+    // First create a dummy user+agent to start the competition with (to avoid "no agents provided" error)
+    const dummyUserResponse = await adminClient.registerUser({
+      walletAddress: generateRandomEthAddress(),
+      name: "Dummy User",
+      email: "dummy@example.com",
+      agentName: "Dummy Agent",
+      agentDescription: "Dummy agent for competition startup",
+      agentWalletAddress: generateRandomEthAddress(),
+    });
+    expect(dummyUserResponse.success).toBe(true);
+    const dummyAgent = (dummyUserResponse as UserRegistrationResponse).agent;
+    expect(dummyAgent).toBeDefined();
+
+    // Create and start a sandbox competition with the dummy agent
+    const competitionName = `Sandbox Test Competition ${Date.now()}`;
+    const competitionResponse = await startTestCompetition(
+      adminClient,
+      competitionName,
+      [dummyAgent!.id],
+      true, // sandboxMode = true
+    );
+    expect(competitionResponse.success).toBe(true);
+    const competition = competitionResponse.competition;
+    expect(competition.sandboxMode).toBe(true);
+
+    // Verify competition is active and in sandbox mode
+    const statusResponse = await adminClient.getCompetitionStatus();
+    expect(statusResponse.success).toBe(true);
+    const status = statusResponse as CompetitionStatusResponse;
+    expect(status.competition?.id).toBe(competition.id);
+    expect(status.competition?.status).toBe("active");
+    expect(status.competition?.sandboxMode).toBe(true);
+
+    // First register a user without an agent
+    const newUserResponse = await adminClient.registerUser({
+      walletAddress: generateRandomEthAddress(),
+      name: "New Sandbox User",
+      email: "new-sandbox@example.com",
+    });
+    expect(newUserResponse.success).toBe(true);
+    const newUser = (newUserResponse as UserRegistrationResponse).user;
+
+    // Now register an agent for this user using the registerAgent route (which has auto-join logic)
+    const newAgentResponse = await adminClient.registerAgent({
+      user: {
+        walletAddress: newUser.walletAddress,
+      },
+      agent: {
+        name: "New Sandbox Agent",
+        description: "Agent that should auto-join sandbox competition",
+        walletAddress: generateRandomEthAddress(),
+      },
+    });
+    expect(newAgentResponse.success).toBe(true);
+    const newAgent = (newAgentResponse as AdminAgentResponse).agent;
+
+    // Wait a moment for auto-join processing
+    await wait(100);
+
+    // Check that the new agent was automatically added to the competition
+    const competitionAgentsResponse = await adminClient.getCompetitionAgents(
+      competition.id,
+    );
+    expect(competitionAgentsResponse.success).toBe(true);
+    const competitionAgents =
+      competitionAgentsResponse as CompetitionAgentsResponse;
+
+    // Should have both the dummy agent and the newly registered agent
+    expect(competitionAgents.agents.length).toBe(2);
+    const agentIds = competitionAgents.agents.map((agent) => agent.id);
+    expect(agentIds).toContain(dummyAgent!.id);
+    expect(agentIds).toContain(newAgent!.id);
+
+    // Verify the new agent has active status in the competition
+    const newAgentInCompetition = competitionAgents.agents.find(
+      (agent) => agent.id === newAgent!.id,
+    );
+    expect(newAgentInCompetition?.active).toBe(true);
+
+    // Verify that a portfolio snapshot was created for the newly auto-joined agent
+    // Get snapshots for this specific agent
+    const snapshotsResponse = await adminClient.request(
+      "get",
+      `/api/admin/competition/${competition.id}/snapshots?agentId=${newAgent!.id}`,
+    );
+    const typedResponse = snapshotsResponse as SnapshotResponse;
+    expect(typedResponse.success).toBe(true);
+    expect(typedResponse.snapshots).toBeDefined();
+    expect(typedResponse.snapshots.length).toBeGreaterThan(0);
+
+    // Verify the snapshot has the correct agent ID and competition ID
+    const latestSnapshot =
+      typedResponse.snapshots[typedResponse.snapshots.length - 1];
+    expect(latestSnapshot?.agentId).toBe(newAgent!.id);
+    expect(latestSnapshot?.competitionId).toBe(competition.id);
+
+    // Verify the snapshot has token values (confirming it's a complete snapshot)
+    expect(latestSnapshot?.valuesByToken).toBeDefined();
+    expect(Object.keys(latestSnapshot!.valuesByToken).length).toBeGreaterThan(
+      0,
+    );
+
+    console.log(
+      `[Test] Auto-joined agent ${newAgent!.id} successfully got portfolio snapshot with total value: $${latestSnapshot?.totalValue}`,
+    );
   });
 });

--- a/apps/api/src/services/competition-manager.service.ts
+++ b/apps/api/src/services/competition-manager.service.ts
@@ -1131,9 +1131,10 @@ export class CompetitionManager {
       // Add the agent to the competition
       await addAgentToCompetition(activeCompetition.id, agentId);
 
-      // Take a portfolio snapshot for all agents in the competition (includes the newly joined agent)
-      await this.portfolioSnapshotter.takePortfolioSnapshots(
+      // Take a portfolio snapshot for the newly joined agent
+      await this.portfolioSnapshotter.takePortfolioSnapshotForAgent(
         activeCompetition.id,
+        agentId,
       );
 
       console.log(

--- a/apps/api/src/services/portfolio-snapshotter.service.ts
+++ b/apps/api/src/services/portfolio-snapshotter.service.ts
@@ -25,6 +25,163 @@ export class PortfolioSnapshotter {
   }
 
   /**
+   * Take a portfolio snapshot for a specific agent in a competition
+   * @param competitionId The competition ID
+   * @param agentId The agent ID
+   * @param timestamp Optional timestamp for the snapshot (defaults to current time)
+   * @returns Object with snapshot statistics
+   */
+  async takePortfolioSnapshotForAgent(
+    competitionId: string,
+    agentId: string,
+    timestamp: Date = new Date(),
+  ): Promise<{
+    priceLookupCount: number;
+    dbPriceHitCount: number;
+    reusedPriceCount: number;
+    totalValue: number;
+  }> {
+    console.log(
+      `[PortfolioSnapshotter] Taking portfolio snapshot for agent ${agentId} in competition ${competitionId}`,
+    );
+
+    const balances = await this.balanceManager.getAllBalances(agentId);
+    const valuesByToken: Record<
+      string,
+      {
+        amount: number;
+        valueUsd: number;
+        price: number;
+        symbol: string;
+        specificChain: string | null;
+      }
+    > = {};
+    let totalValue = 0;
+    let priceLookupCount = 0;
+    let dbPriceHitCount = 0;
+    let reusedPriceCount = 0;
+
+    for (const balance of balances) {
+      priceLookupCount++;
+
+      // First try to get latest price record from the database to reuse chain information
+      const latestPriceRecord = await getLatestPrice(
+        balance.tokenAddress,
+        balance.specificChain as SpecificChain,
+      );
+
+      let specificChain: string | null;
+      let priceResult;
+
+      if (
+        latestPriceRecord &&
+        latestPriceRecord.timestamp &&
+        latestPriceRecord.chain &&
+        latestPriceRecord.specificChain
+      ) {
+        dbPriceHitCount++;
+        specificChain = latestPriceRecord.specificChain;
+
+        // If price is recent enough (less than 10 minutes old), use it directly
+        const priceAge = Date.now() - latestPriceRecord.timestamp.getTime();
+        const isFreshPrice = priceAge < config.portfolio.priceFreshnessMs;
+
+        if (isFreshPrice) {
+          // Use the existing price if it's fresh
+          priceResult = {
+            price: latestPriceRecord.price,
+            symbol: latestPriceRecord.symbol,
+            timestamp: latestPriceRecord.timestamp,
+            // TODO: Implement typing for these as Drizzle enums or custom types
+            chain: latestPriceRecord.chain as BlockchainType,
+            specificChain: latestPriceRecord.specificChain as SpecificChain,
+            token: latestPriceRecord.token,
+          };
+          reusedPriceCount++;
+          console.log(
+            `[PortfolioSnapshotter] Using fresh price for ${balance.tokenAddress} from DB: $${priceResult.price} (${specificChain}) - age ${Math.round(priceAge / 1000)}s, threshold ${Math.round(config.portfolio.priceFreshnessMs / 1000)}s`,
+          );
+        } else if (specificChain && latestPriceRecord.chain) {
+          // Use specific chain information to avoid chain detection when fetching a new price
+          console.log(
+            `[PortfolioSnapshotter] Using specific chain info from DB for ${balance.tokenAddress}: ${specificChain}`,
+          );
+
+          // Pass both chain type and specific chain to getPrice to bypass chain detection
+          const result = await this.priceTracker.getPrice(
+            balance.tokenAddress,
+            latestPriceRecord.chain as BlockchainType,
+            specificChain as SpecificChain,
+          );
+          if (result !== null) {
+            priceResult = result;
+          }
+        } else {
+          // Fallback to regular price lookup
+          const result = await this.priceTracker.getPrice(balance.tokenAddress);
+          if (result !== null) {
+            priceResult = result;
+          }
+        }
+      } else {
+        // No price record found, do regular price lookup
+        const result = await this.priceTracker.getPrice(balance.tokenAddress);
+        if (result !== null) {
+          priceResult = result;
+        }
+      }
+
+      if (priceResult) {
+        const valueUsd = balance.amount * priceResult.price;
+        valuesByToken[balance.tokenAddress] = {
+          amount: balance.amount,
+          valueUsd,
+          price: priceResult.price,
+          symbol: priceResult.symbol,
+          specificChain: priceResult.specificChain,
+        };
+        totalValue += valueUsd;
+      } else {
+        console.warn(
+          `[PortfolioSnapshotter] No price available for token ${balance.tokenAddress}, excluding from portfolio snapshot`,
+        );
+      }
+    }
+
+    // Create portfolio snapshot in database
+    const snapshot = await createPortfolioSnapshot({
+      agentId,
+      competitionId,
+      timestamp,
+      totalValue,
+    });
+
+    // Store token values
+    for (const [token, data] of Object.entries(valuesByToken)) {
+      await createPortfolioTokenValue({
+        portfolioSnapshotId: snapshot.id,
+        tokenAddress: token,
+        amount: data.amount,
+        valueUsd: data.valueUsd,
+        price: data.price,
+        symbol: data.symbol,
+        specificChain: data.specificChain,
+      });
+    }
+
+    console.log(
+      `[PortfolioSnapshotter] Completed portfolio snapshot for agent ${agentId} - Total value: $${totalValue.toFixed(2)}`,
+    );
+
+    return {
+      priceLookupCount,
+      dbPriceHitCount,
+      reusedPriceCount,
+      totalValue,
+    };
+  }
+
+  /**
    * Take portfolio snapshots for all agents in a competition
    * @param competitionId The competition ID
    */
@@ -36,133 +193,19 @@ export class PortfolioSnapshotter {
     const startTime = Date.now();
     const agents = await getCompetitionAgents(competitionId);
     const timestamp = new Date();
-    let priceLookupCount = 0;
-    let dbPriceHitCount = 0;
-    let reusedPriceCount = 0;
+    let totalPriceLookupCount = 0;
+    let totalDbPriceHitCount = 0;
+    let totalReusedPriceCount = 0;
 
     for (const agentId of agents) {
-      const balances = await this.balanceManager.getAllBalances(agentId);
-      const valuesByToken: Record<
-        string,
-        {
-          amount: number;
-          valueUsd: number;
-          price: number;
-          symbol: string;
-          specificChain: string | null;
-        }
-      > = {};
-      let totalValue = 0;
-
-      for (const balance of balances) {
-        priceLookupCount++;
-
-        // First try to get latest price record from the database to reuse chain information
-        const latestPriceRecord = await getLatestPrice(
-          balance.tokenAddress,
-          balance.specificChain as SpecificChain,
-        );
-
-        let specificChain: string | null;
-        let priceResult;
-
-        if (
-          latestPriceRecord &&
-          latestPriceRecord.timestamp &&
-          latestPriceRecord.chain &&
-          latestPriceRecord.specificChain
-        ) {
-          dbPriceHitCount++;
-          specificChain = latestPriceRecord.specificChain;
-
-          // If price is recent enough (less than 10 minutes old), use it directly
-          const priceAge = Date.now() - latestPriceRecord.timestamp.getTime();
-          const isFreshPrice = priceAge < config.portfolio.priceFreshnessMs;
-
-          if (isFreshPrice) {
-            // Use the existing price if it's fresh
-            priceResult = {
-              price: latestPriceRecord.price,
-              symbol: latestPriceRecord.symbol,
-              timestamp: latestPriceRecord.timestamp,
-              // TODO: Implement typing for these as Drizzle enums or custom types
-              chain: latestPriceRecord.chain as BlockchainType,
-              specificChain: latestPriceRecord.specificChain as SpecificChain,
-              token: latestPriceRecord.token,
-            };
-            reusedPriceCount++;
-            console.log(
-              `[PortfolioSnapshotter] Using fresh price for ${balance.tokenAddress} from DB: $${priceResult.price} (${specificChain}) - age ${Math.round(priceAge / 1000)}s, threshold ${Math.round(config.portfolio.priceFreshnessMs / 1000)}s`,
-            );
-          } else if (specificChain && latestPriceRecord.chain) {
-            // Use specific chain information to avoid chain detection when fetching a new price
-            console.log(
-              `[PortfolioSnapshotter] Using specific chain info from DB for ${balance.tokenAddress}: ${specificChain}`,
-            );
-
-            // Pass both chain type and specific chain to getPrice to bypass chain detection
-            const result = await this.priceTracker.getPrice(
-              balance.tokenAddress,
-              latestPriceRecord.chain as BlockchainType,
-              specificChain as SpecificChain,
-            );
-            if (result !== null) {
-              priceResult = result;
-            }
-          } else {
-            // Fallback to regular price lookup
-            const result = await this.priceTracker.getPrice(
-              balance.tokenAddress,
-            );
-            if (result !== null) {
-              priceResult = result;
-            }
-          }
-        } else {
-          // No price record found, do regular price lookup
-          const result = await this.priceTracker.getPrice(balance.tokenAddress);
-          if (result !== null) {
-            priceResult = result;
-          }
-        }
-
-        if (priceResult) {
-          const valueUsd = balance.amount * priceResult.price;
-          valuesByToken[balance.tokenAddress] = {
-            amount: balance.amount,
-            valueUsd,
-            price: priceResult.price,
-            symbol: priceResult.symbol,
-            specificChain: priceResult.specificChain,
-          };
-          totalValue += valueUsd;
-        } else {
-          console.warn(
-            `[PortfolioSnapshotter] No price available for token ${balance.tokenAddress}, excluding from portfolio snapshot`,
-          );
-        }
-      }
-
-      // Create portfolio snapshot in database
-      const snapshot = await createPortfolioSnapshot({
-        agentId,
+      const stats = await this.takePortfolioSnapshotForAgent(
         competitionId,
+        agentId,
         timestamp,
-        totalValue,
-      });
-
-      // Store token values
-      for (const [token, data] of Object.entries(valuesByToken)) {
-        await createPortfolioTokenValue({
-          portfolioSnapshotId: snapshot.id,
-          tokenAddress: token,
-          amount: data.amount,
-          valueUsd: data.valueUsd,
-          price: data.price,
-          symbol: data.symbol,
-          specificChain: data.specificChain,
-        });
-      }
+      );
+      totalPriceLookupCount += stats.priceLookupCount;
+      totalDbPriceHitCount += stats.dbPriceHitCount;
+      totalReusedPriceCount += stats.reusedPriceCount;
     }
 
     const endTime = Date.now();
@@ -172,10 +215,10 @@ export class PortfolioSnapshotter {
       `[PortfolioSnapshotter] Completed portfolio snapshots for ${agents.length} agents in ${duration}ms`,
     );
     console.log(
-      `[PortfolioSnapshotter] Price lookup stats: Total: ${priceLookupCount}, DB hits: ${dbPriceHitCount}, Hit rate: ${((dbPriceHitCount / priceLookupCount) * 100).toFixed(2)}%`,
+      `[PortfolioSnapshotter] Price lookup stats: Total: ${totalPriceLookupCount}, DB hits: ${totalDbPriceHitCount}, Hit rate: ${((totalDbPriceHitCount / totalPriceLookupCount) * 100).toFixed(2)}%`,
     );
     console.log(
-      `[PortfolioSnapshotter] Reused existing prices: ${reusedPriceCount}/${priceLookupCount} (${((reusedPriceCount / priceLookupCount) * 100).toFixed(2)}%)`,
+      `[PortfolioSnapshotter] Reused existing prices: ${totalReusedPriceCount}/${totalPriceLookupCount} (${((totalReusedPriceCount / totalPriceLookupCount) * 100).toFixed(2)}%)`,
     );
   }
 


### PR DESCRIPTION
# Summary

- Previous version took portfolio snapshots for all agents in the sandbox, which is highly inefficient
- On autoJoin trigger, this change would incur only 1 portfolio snapshot run for the agent being registered 