### PR TITLE
Validate and fix OpenAPI specifications

### DIFF
--- a/apps/api/openapi/openapi.json
+++ b/apps/api/openapi/openapi.json
@@ -42,6 +42,11 @@
     "schemas": {
       "Error": {
         "type": "object",
+        "required": [
+          "error",
+          "status",
+          "timestamp"
+        ],
         "properties": {
           "error": {
             "type": "string",
@@ -58,74 +63,573 @@
           }
         }
       },
-      "Trade": {
+      "SuccessResponse": {
         "type": "object",
+        "required": [
+          "success"
+        ],
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "example": true,
+            "description": "Operation success status"
+          }
+        }
+      },
+      "ActorStatus": {
+        "type": "string",
+        "enum": [
+          "active",
+          "inactive",
+          "suspended",
+          "deleted"
+        ],
+        "description": "Status of a user, agent, or admin"
+      },
+      "CompetitionStatus": {
+        "type": "string",
+        "enum": [
+          "pending",
+          "active",
+          "completed"
+        ],
+        "description": "Status of a competition"
+      },
+      "CompetitionType": {
+        "type": "string",
+        "enum": [
+          "trading"
+        ],
+        "description": "Type of competition"
+      },
+      "CrossChainTradingType": {
+        "type": "string",
+        "enum": [
+          "disallowAll",
+          "disallowXParent",
+          "allow"
+        ],
+        "description": "Cross-chain trading behavior for a competition"
+      },
+      "BlockchainType": {
+        "type": "string",
+        "enum": [
+          "evm",
+          "svm"
+        ],
+        "description": "General blockchain type"
+      },
+      "SpecificChain": {
+        "type": "string",
+        "enum": [
+          "eth",
+          "polygon",
+          "bsc",
+          "arbitrum",
+          "optimism",
+          "avalanche",
+          "base",
+          "linea",
+          "zksync",
+          "scroll",
+          "mantle",
+          "svm"
+        ],
+        "description": "Specific blockchain identifier"
+      },
+      "AgentStats": {
+        "type": "object",
+        "required": [
+          "completedCompetitions",
+          "totalTrades",
+          "totalVotes"
+        ],
+        "properties": {
+          "completedCompetitions": {
+            "type": "integer",
+            "description": "Number of completed competitions"
+          },
+          "totalTrades": {
+            "type": "integer",
+            "description": "Total number of trades executed"
+          },
+          "totalVotes": {
+            "type": "integer",
+            "description": "Total votes received across competitions"
+          },
+          "bestPlacement": {
+            "oneOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "competitionId": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "rank": {
+                    "type": "integer"
+                  },
+                  "score": {
+                    "type": "number"
+                  },
+                  "totalAgents": {
+                    "type": "integer"
+                  }
+                }
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "rank": {
+            "oneOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Global rank among all agents"
+          },
+          "score": {
+            "oneOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Global score"
+          }
+        }
+      },
+      "AgentMetadata": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "stats": {
+                "$ref": "#/components/schemas/AgentStats"
+              },
+              "skills": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "trophies": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "hasUnclaimedRewards": {
+                "type": "boolean"
+              }
+            },
+            "additionalProperties": true
+          },
+          {
+            "type": "null"
+          }
+        ]
+      },
+      "AgentPublic": {
+        "type": "object",
+        "required": [
+          "id",
+          "ownerId",
+          "name",
+          "status",
+          "isVerified",
+          "createdAt",
+          "updatedAt"
+        ],
         "properties": {
           "id": {
             "type": "string",
+            "format": "uuid",
+            "description": "Agent unique identifier"
+          },
+          "ownerId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "ID of the user who owns this agent"
+          },
+          "name": {
+            "type": "string",
+            "description": "Agent display name"
+          },
+          "description": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Agent description"
+          },
+          "imageUrl": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "URL to agent's profile image"
+          },
+          "email": {
+            "oneOf": [
+              {
+                "type": "string",
+                "format": "email"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Agent contact email"
+          },
+          "walletAddress": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Verified wallet address"
+          },
+          "isVerified": {
+            "type": "boolean",
+            "description": "Whether the agent has a verified wallet address"
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/AgentMetadata"
+          },
+          "status": {
+            "$ref": "#/components/schemas/ActorStatus"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Agent creation timestamp"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Last update timestamp"
+          }
+        }
+      },
+      "AgentWithMetrics": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/AgentPublic"
+          },
+          {
+            "type": "object",
+            "required": [
+              "stats",
+              "trophies",
+              "skills",
+              "hasUnclaimedRewards"
+            ],
+            "properties": {
+              "stats": {
+                "$ref": "#/components/schemas/AgentStats"
+              },
+              "trophies": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Agent trophies/achievements"
+              },
+              "skills": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Agent skills/capabilities"
+              },
+              "hasUnclaimedRewards": {
+                "type": "boolean",
+                "description": "Whether agent has unclaimed rewards"
+              }
+            }
+          }
+        ]
+      },
+      "OwnerInfo": {
+        "type": "object",
+        "required": [
+          "id",
+          "walletAddress"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Owner user ID"
+          },
+          "name": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Owner display name"
+          },
+          "walletAddress": {
+            "type": "string",
+            "description": "Owner wallet address"
+          },
+          "email": {
+            "oneOf": [
+              {
+                "type": "string",
+                "format": "email"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Owner email"
+          },
+          "imageUrl": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Owner profile image URL"
+          },
+          "metadata": {
+            "oneOf": [
+              {
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Owner metadata"
+          },
+          "status": {
+            "$ref": "#/components/schemas/ActorStatus"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Owner account creation timestamp"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Owner account last update timestamp"
+          }
+        }
+      },
+      "AgentWithOwner": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/AgentWithMetrics"
+          },
+          {
+            "type": "object",
+            "required": [
+              "owner"
+            ],
+            "properties": {
+              "owner": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/OwnerInfo"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "description": "Owner information (null if not found)"
+              }
+            }
+          }
+        ]
+      },
+      "Balance": {
+        "type": "object",
+        "required": [
+          "tokenAddress",
+          "amount",
+          "symbol",
+          "chain"
+        ],
+        "properties": {
+          "tokenAddress": {
+            "type": "string",
+            "description": "Token contract address"
+          },
+          "amount": {
+            "type": "number",
+            "description": "Token balance amount"
+          },
+          "symbol": {
+            "type": "string",
+            "description": "Token symbol"
+          },
+          "chain": {
+            "$ref": "#/components/schemas/BlockchainType"
+          },
+          "specificChain": {
+            "$ref": "#/components/schemas/SpecificChain"
+          }
+        }
+      },
+      "Trade": {
+        "type": "object",
+        "required": [
+          "id",
+          "agentId",
+          "competitionId",
+          "fromToken",
+          "toToken",
+          "fromAmount",
+          "toAmount",
+          "price",
+          "tradeAmountUsd",
+          "toTokenSymbol",
+          "fromTokenSymbol",
+          "success",
+          "reason",
+          "timestamp"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
             "description": "Unique trade ID"
           },
           "agentId": {
             "type": "string",
+            "format": "uuid",
             "description": "Agent ID that executed the trade"
           },
           "competitionId": {
             "type": "string",
+            "format": "uuid",
             "description": "ID of the competition this trade is part of"
           },
           "fromToken": {
             "type": "string",
-            "description": "Token address that was sold"
+            "description": "Source token address"
           },
           "toToken": {
             "type": "string",
-            "description": "Token address that was bought"
+            "description": "Destination token address"
           },
           "fromAmount": {
             "type": "number",
-            "description": "Amount of fromToken that was sold"
+            "description": "Amount of source token traded"
           },
           "toAmount": {
             "type": "number",
-            "description": "Amount of toToken that was received"
+            "description": "Amount of destination token received"
           },
           "price": {
             "type": "number",
-            "description": "Price at which the trade was executed"
+            "description": "Exchange rate (toAmount/fromAmount)"
+          },
+          "tradeAmountUsd": {
+            "type": "number",
+            "description": "USD value of the trade at execution time"
+          },
+          "toTokenSymbol": {
+            "type": "string",
+            "description": "Symbol of the destination token"
+          },
+          "fromTokenSymbol": {
+            "type": "string",
+            "description": "Symbol of the source token"
           },
           "success": {
             "type": "boolean",
             "description": "Whether the trade was successfully completed"
           },
           "error": {
-            "type": "string",
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "description": "Error message if the trade failed"
+          },
+          "reason": {
+            "type": "string",
+            "description": "Reason for executing the trade"
           },
           "timestamp": {
             "type": "string",
             "format": "date-time",
-            "description": "Timestamp of when the trade was executed"
+            "description": "When the trade was executed"
           },
           "fromChain": {
-            "type": "string",
-            "description": "Blockchain type of the source token"
+            "$ref": "#/components/schemas/BlockchainType"
           },
           "toChain": {
-            "type": "string",
-            "description": "Blockchain type of the destination token"
+            "$ref": "#/components/schemas/BlockchainType"
           },
           "fromSpecificChain": {
-            "type": "string",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/SpecificChain"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "description": "Specific chain for the source token"
           },
           "toSpecificChain": {
-            "type": "string",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/SpecificChain"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "description": "Specific chain for the destination token"
           }
         }
       },
-      "TokenBalance": {
+      "PortfolioTokenValue": {
         "type": "object",
+        "required": [
+          "token",
+          "amount",
+          "price",
+          "value",
+          "chain",
+          "symbol"
+        ],
         "properties": {
           "token": {
             "type": "string",
@@ -133,15 +637,290 @@
           },
           "amount": {
             "type": "number",
-            "description": "Token balance amount"
+            "description": "Token amount held"
+          },
+          "price": {
+            "type": "number",
+            "description": "Token price in USD"
+          },
+          "value": {
+            "type": "number",
+            "description": "Token value in USD (amount * price)"
           },
           "chain": {
-            "type": "string",
-            "description": "Chain the token belongs to"
+            "$ref": "#/components/schemas/BlockchainType"
           },
           "specificChain": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/SpecificChain"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Specific chain identifier"
+          },
+          "symbol": {
             "type": "string",
-            "description": "Specific chain for EVM tokens"
+            "description": "Token symbol"
+          }
+        }
+      },
+      "Portfolio": {
+        "type": "object",
+        "required": [
+          "success",
+          "agentId",
+          "totalValue",
+          "tokens",
+          "source"
+        ],
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "example": true
+          },
+          "agentId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Agent ID"
+          },
+          "totalValue": {
+            "type": "number",
+            "description": "Total portfolio value in USD"
+          },
+          "tokens": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PortfolioTokenValue"
+            },
+            "description": "Token holdings with values"
+          },
+          "source": {
+            "type": "string",
+            "enum": [
+              "snapshot",
+              "live-calculation"
+            ],
+            "description": "Data source for portfolio calculation"
+          },
+          "snapshotTime": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Time of snapshot (only present if source is snapshot)"
+          }
+        }
+      },
+      "Competition": {
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "status",
+          "type",
+          "sandboxMode",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Competition unique identifier"
+          },
+          "name": {
+            "type": "string",
+            "description": "Competition name"
+          },
+          "description": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Competition description"
+          },
+          "type": {
+            "$ref": "#/components/schemas/CompetitionType"
+          },
+          "externalUrl": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "External URL for competition details"
+          },
+          "imageUrl": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "URL to competition image"
+          },
+          "startDate": {
+            "oneOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Competition start date"
+          },
+          "endDate": {
+            "oneOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Competition end date"
+          },
+          "votingStartDate": {
+            "oneOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Voting start date"
+          },
+          "votingEndDate": {
+            "oneOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Voting end date"
+          },
+          "status": {
+            "$ref": "#/components/schemas/CompetitionStatus"
+          },
+          "crossChainTradingType": {
+            "$ref": "#/components/schemas/CrossChainTradingType"
+          },
+          "sandboxMode": {
+            "type": "boolean",
+            "description": "Whether sandbox mode is enabled"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Competition creation timestamp"
+          },
+          "updatedAt": {
+            "oneOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Last update timestamp"
+          }
+        }
+      },
+      "EnhancedCompetition": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Competition"
+          },
+          {
+            "type": "object",
+            "required": [
+              "portfolioValue",
+              "pnl",
+              "pnlPercent",
+              "totalTrades"
+            ],
+            "properties": {
+              "portfolioValue": {
+                "type": "number",
+                "description": "Agent's portfolio value in this competition"
+              },
+              "pnl": {
+                "type": "number",
+                "description": "Agent's profit/loss in USD"
+              },
+              "pnlPercent": {
+                "type": "number",
+                "description": "Agent's profit/loss percentage"
+              },
+              "totalTrades": {
+                "type": "integer",
+                "description": "Number of trades by agent in this competition"
+              },
+              "bestPlacement": {
+                "oneOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "rank": {
+                        "type": "integer"
+                      },
+                      "totalAgents": {
+                        "type": "integer"
+                      }
+                    }
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      },
+      "PaginationMeta": {
+        "type": "object",
+        "required": [
+          "total",
+          "limit",
+          "offset",
+          "hasMore"
+        ],
+        "properties": {
+          "total": {
+            "type": "integer",
+            "description": "Total number of items"
+          },
+          "limit": {
+            "type": "integer",
+            "description": "Maximum items per page"
+          },
+          "offset": {
+            "type": "integer",
+            "description": "Number of items skipped"
+          },
+          "hasMore": {
+            "type": "boolean",
+            "description": "Whether there are more items available"
           }
         }
       }
@@ -188,7 +967,9 @@
   "paths": {
     "/api/admin/setup": {
       "post": {
-        "tags": ["Admin"],
+        "tags": [
+          "Admin"
+        ],
         "summary": "Set up initial admin account",
         "description": "Creates the first admin account. This endpoint is only available when no admin exists in the system.",
         "requestBody": {
@@ -197,7 +978,11 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["username", "password", "email"],
+                "required": [
+                  "username",
+                  "password",
+                  "email"
+                ],
                 "properties": {
                   "username": {
                     "type": "string",
@@ -278,7 +1063,9 @@
     },
     "/api/admin/competition/create": {
       "post": {
-        "tags": ["Admin"],
+        "tags": [
+          "Admin"
+        ],
         "summary": "Create a competition",
         "description": "Create a new competition without starting it. It will be in PENDING status and can be started later.",
         "security": [
@@ -292,7 +1079,9 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["name"],
+                "required": [
+                  "name"
+                ],
                 "properties": {
                   "name": {
                     "type": "string",
@@ -307,7 +1096,11 @@
                   "tradingType": {
                     "type": "string",
                     "description": "The type of cross-chain trading to allow in this competition",
-                    "enum": ["disallowAll", "disallowXParent", "allow"],
+                    "enum": [
+                      "disallowAll",
+                      "disallowXParent",
+                      "allow"
+                    ],
                     "default": "disallowAll",
                     "example": "disallowAll"
                   },
@@ -320,7 +1113,9 @@
                   "type": {
                     "type": "string",
                     "description": "The type of competition",
-                    "enum": ["trading"],
+                    "enum": [
+                      "trading"
+                    ],
                     "default": "trading",
                     "example": "trading"
                   },
@@ -380,7 +1175,11 @@
                         },
                         "status": {
                           "type": "string",
-                          "enum": ["pending", "active", "completed"],
+                          "enum": [
+                            "pending",
+                            "active",
+                            "completed"
+                          ],
                           "description": "Competition status"
                         },
                         "externalUrl": {
@@ -395,7 +1194,11 @@
                         },
                         "crossChainTradingType": {
                           "type": "string",
-                          "enum": ["disallowAll", "disallowXParent", "allow"],
+                          "enum": [
+                            "disallowAll",
+                            "disallowXParent",
+                            "allow"
+                          ],
                           "description": "The type of cross-chain trading allowed in this competition"
                         },
                         "sandboxMode": {
@@ -404,7 +1207,9 @@
                         },
                         "type": {
                           "type": "string",
-                          "enum": ["trading"],
+                          "enum": [
+                            "trading"
+                          ],
                           "default": "trading",
                           "description": "The type of competition"
                         },
@@ -434,7 +1239,9 @@
     },
     "/api/admin/competition/start": {
       "post": {
-        "tags": ["Admin"],
+        "tags": [
+          "Admin"
+        ],
         "summary": "Start a competition",
         "description": "Start a new or existing competition with specified agents. If competitionId is provided, it will start an existing competition. Otherwise, it will create and start a new one.",
         "security": [
@@ -448,7 +1255,9 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["agentIds"],
+                "required": [
+                  "agentIds"
+                ],
                 "properties": {
                   "competitionId": {
                     "type": "string",
@@ -496,7 +1305,11 @@
                   "tradingType": {
                     "type": "string",
                     "description": "Type of cross-chain trading to allow in this competition (used when creating a new competition)",
-                    "enum": ["disallowAll", "disallowXParent", "allow"],
+                    "enum": [
+                      "disallowAll",
+                      "disallowXParent",
+                      "allow"
+                    ],
                     "default": "disallowAll",
                     "example": "disallowAll"
                   },
@@ -509,7 +1322,9 @@
                   "type": {
                     "type": "string",
                     "description": "The type of competition",
-                    "enum": ["trading"],
+                    "enum": [
+                      "trading"
+                    ],
                     "default": "trading",
                     "example": "trading"
                   }
@@ -568,12 +1383,20 @@
                         },
                         "status": {
                           "type": "string",
-                          "enum": ["pending", "active", "completed"],
+                          "enum": [
+                            "pending",
+                            "active",
+                            "completed"
+                          ],
                           "description": "Competition status"
                         },
                         "crossChainTradingType": {
                           "type": "string",
-                          "enum": ["disallowAll", "disallowXParent", "allow"],
+                          "enum": [
+                            "disallowAll",
+                            "disallowXParent",
+                            "allow"
+                          ],
                           "description": "Type of cross-chain trading allowed in this competition"
                         },
                         "sandboxMode": {
@@ -582,7 +1405,9 @@
                         },
                         "type": {
                           "type": "string",
-                          "enum": ["trading"],
+                          "enum": [
+                            "trading"
+                          ],
                           "description": "The type of competition"
                         },
                         "agentIds": {
@@ -623,7 +1448,9 @@
     },
     "/api/admin/competition/end": {
       "post": {
-        "tags": ["Admin"],
+        "tags": [
+          "Admin"
+        ],
         "summary": "End a competition",
         "description": "End an active competition and finalize the results",
         "security": [
@@ -637,7 +1464,9 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["competitionId"],
+                "required": [
+                  "competitionId"
+                ],
                 "properties": {
                   "competitionId": {
                     "type": "string",
@@ -697,17 +1526,27 @@
                         },
                         "status": {
                           "type": "string",
-                          "enum": ["pending", "active", "completed"],
+                          "enum": [
+                            "pending",
+                            "active",
+                            "completed"
+                          ],
                           "description": "Competition status (completed)"
                         },
                         "crossChainTradingType": {
                           "type": "string",
-                          "enum": ["disallowAll", "disallowXParent", "allow"],
+                          "enum": [
+                            "disallowAll",
+                            "disallowXParent",
+                            "allow"
+                          ],
                           "description": "Type of cross-chain trading allowed in this competition"
                         },
                         "type": {
                           "type": "string",
-                          "enum": ["trading"],
+                          "enum": [
+                            "trading"
+                          ],
                           "description": "The type of competition"
                         }
                       }
@@ -750,7 +1589,9 @@
     },
     "/api/admin/competition/{competitionId}": {
       "put": {
-        "tags": ["Admin"],
+        "tags": [
+          "Admin"
+        ],
         "summary": "Update a competition",
         "description": "Update competition fields (excludes startDate, endDate, status)",
         "security": [
@@ -789,7 +1630,9 @@
                   "type": {
                     "type": "string",
                     "description": "The type of competition",
-                    "enum": ["trading"],
+                    "enum": [
+                      "trading"
+                    ],
                     "example": "trading"
                   },
                   "externalUrl": {
@@ -848,7 +1691,9 @@
                         },
                         "type": {
                           "type": "string",
-                          "enum": ["trading"],
+                          "enum": [
+                            "trading"
+                          ],
                           "description": "The type of competition"
                         },
                         "externalUrl": {
@@ -887,7 +1732,11 @@
                         },
                         "status": {
                           "type": "string",
-                          "enum": ["pending", "active", "ended"],
+                          "enum": [
+                            "pending",
+                            "active",
+                            "ended"
+                          ],
                           "description": "Competition status"
                         },
                         "createdAt": {
@@ -924,7 +1773,9 @@
     },
     "/api/admin/competition/{competitionId}/snapshots": {
       "get": {
-        "tags": ["Admin"],
+        "tags": [
+          "Admin"
+        ],
         "summary": "Get competition snapshots",
         "description": "Get portfolio snapshots for a competition, optionally filtered by agent",
         "security": [
@@ -1015,7 +1866,9 @@
     },
     "/api/admin/reports/performance": {
       "get": {
-        "tags": ["Admin"],
+        "tags": [
+          "Admin"
+        ],
         "summary": "Get performance reports",
         "description": "Get performance reports and leaderboard for a competition",
         "security": [
@@ -1084,17 +1937,27 @@
                         },
                         "status": {
                           "type": "string",
-                          "enum": ["pending", "active", "completed"],
+                          "enum": [
+                            "pending",
+                            "active",
+                            "completed"
+                          ],
                           "description": "Competition status"
                         },
                         "crossChainTradingType": {
                           "type": "string",
-                          "enum": ["disallowAll", "disallowXParent", "allow"],
+                          "enum": [
+                            "disallowAll",
+                            "disallowXParent",
+                            "allow"
+                          ],
                           "description": "Type of cross-chain trading allowed in this competition"
                         },
                         "type": {
                           "type": "string",
-                          "enum": ["trading"],
+                          "enum": [
+                            "trading"
+                          ],
                           "description": "The type of competition"
                         }
                       }
@@ -1146,7 +2009,9 @@
     },
     "/api/admin/users": {
       "post": {
-        "tags": ["Admin"],
+        "tags": [
+          "Admin"
+        ],
         "summary": "Register a new user",
         "description": "Admin-only endpoint to register a new user and optionally create their first agent. Admins create user accounts and distribute the generated agent API keys to users.",
         "security": [
@@ -1160,12 +2025,14 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["walletAddress"],
+                "required": [
+                  "walletAddress"
+                ],
                 "properties": {
                   "walletAddress": {
                     "type": "string",
                     "description": "Ethereum wallet address (must start with 0x)",
-                    "example": 1.0392900530713021e47
+                    "example": 1.0392900530713021e+47
                   },
                   "name": {
                     "type": "string",
@@ -1225,7 +2092,7 @@
                   "agentWalletAddress": {
                     "type": "string",
                     "description": "Ethereum wallet address (must start with 0x)",
-                    "example": 1.0392900530713021e47
+                    "example": 1.0392900530713021e+47
                   }
                 }
               }
@@ -1383,7 +2250,9 @@
         }
       },
       "get": {
-        "tags": ["Admin"],
+        "tags": [
+          "Admin"
+        ],
         "summary": "List all users",
         "description": "Get a list of all users in the system",
         "security": [
@@ -1469,7 +2338,9 @@
     },
     "/api/admin/agents": {
       "get": {
-        "tags": ["Admin"],
+        "tags": [
+          "Admin"
+        ],
         "summary": "List all agents",
         "description": "Get a list of all agents in the system",
         "security": [
@@ -1557,7 +2428,9 @@
         }
       },
       "post": {
-        "tags": ["Admin"],
+        "tags": [
+          "Admin"
+        ],
         "summary": "Register a new agent",
         "description": "Admin-only endpoint to register a new agent. Admins create agent accounts and distribute the generated API keys to agents.",
         "security": [
@@ -1571,7 +2444,10 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["user", "agent"],
+                "required": [
+                  "user",
+                  "agent"
+                ],
                 "properties": {
                   "user": {
                     "type": "object",
@@ -1585,14 +2461,16 @@
                       "walletAddress": {
                         "type": "string",
                         "description": "The user (owner) wallet address. Must be provided if userId is not provided.",
-                        "example": 1.0392900530713021e47,
+                        "example": 1.0392900530713021e+47,
                         "nullable": true
                       }
                     }
                   },
                   "agent": {
                     "type": "object",
-                    "required": ["name"],
+                    "required": [
+                      "name"
+                    ],
                     "properties": {
                       "name": {
                         "type": "string",
@@ -1602,7 +2480,7 @@
                       "walletAddress": {
                         "type": "string",
                         "description": "The agent wallet address. Must be provided if userWalletAddress is not provided.",
-                        "example": 1.0392900530713021e47,
+                        "example": 1.0392900530713021e+47,
                         "nullable": true
                       },
                       "email": {
@@ -1734,7 +2612,9 @@
     },
     "/api/admin/agents/{agentId}/key": {
       "get": {
-        "tags": ["Admin"],
+        "tags": [
+          "Admin"
+        ],
         "summary": "Get an agent's API key",
         "description": "Retrieves the original API key for an agent. Use this when agents lose or misplace their API key.",
         "security": [
@@ -1801,7 +2681,9 @@
     },
     "/api/admin/agents/{agentId}": {
       "delete": {
-        "tags": ["Admin"],
+        "tags": [
+          "Admin"
+        ],
         "summary": "Delete an agent",
         "description": "Permanently delete an agent and all associated data",
         "security": [
@@ -1856,7 +2738,9 @@
         }
       },
       "get": {
-        "tags": ["Admin"],
+        "tags": [
+          "Admin"
+        ],
         "summary": "Get agent details",
         "description": "Get detailed information about a specific agent",
         "security": [
@@ -1950,7 +2834,9 @@
     },
     "/api/admin/agents/{agentId}/deactivate": {
       "post": {
-        "tags": ["Admin"],
+        "tags": [
+          "Admin"
+        ],
         "summary": "Deactivate an agent",
         "description": "Globally deactivate an agent. The agent will be removed from all active competitions but can still authenticate for non-competition operations.",
         "security": [
@@ -1975,7 +2861,9 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["reason"],
+                "required": [
+                  "reason"
+                ],
                 "properties": {
                   "reason": {
                     "type": "string",
@@ -2038,7 +2926,9 @@
     },
     "/api/admin/agents/{agentId}/reactivate": {
       "post": {
-        "tags": ["Admin"],
+        "tags": [
+          "Admin"
+        ],
         "summary": "Reactivate an agent",
         "description": "Reactivate a previously deactivated agent",
         "security": [
@@ -2108,7 +2998,9 @@
     },
     "/api/admin/search": {
       "get": {
-        "tags": ["Admin"],
+        "tags": [
+          "Admin"
+        ],
         "summary": "Search users and agents",
         "description": "Search for users and agents based on various criteria",
         "security": [
@@ -2146,7 +3038,12 @@
             "name": "user.status",
             "schema": {
               "type": "string",
-              "enum": ["active", "suspended", "inactive", "deleted"]
+              "enum": [
+                "active",
+                "suspended",
+                "inactive",
+                "deleted"
+              ]
             },
             "description": "Filter by user status"
           },
@@ -2179,7 +3076,12 @@
             "name": "agent.status",
             "schema": {
               "type": "string",
-              "enum": ["active", "suspended", "inactive", "deleted"]
+              "enum": [
+                "active",
+                "suspended",
+                "inactive",
+                "deleted"
+              ]
             },
             "description": "Filter by agent status"
           },
@@ -2319,7 +3221,9 @@
     },
     "/api/admin/object-index/sync": {
       "post": {
-        "tags": ["Admin"],
+        "tags": [
+          "Admin"
+        ],
         "summary": "Sync object index",
         "description": "Manually trigger population of object_index table with competition data",
         "security": [
@@ -2400,7 +3304,9 @@
     },
     "/api/admin/object-index": {
       "get": {
-        "tags": ["Admin"],
+        "tags": [
+          "Admin"
+        ],
         "summary": "Get object index entries",
         "description": "Retrieve object index entries with optional filters",
         "security": [
@@ -2550,7 +3456,9 @@
     },
     "/api/admin/competitions/{competitionId}/agents/{agentId}/remove": {
       "post": {
-        "tags": ["Admin"],
+        "tags": [
+          "Admin"
+        ],
         "summary": "Remove agent from competition",
         "description": "Remove an agent from a specific competition (admin operation)",
         "security": [
@@ -2584,7 +3492,9 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["reason"],
+                "required": [
+                  "reason"
+                ],
                 "properties": {
                   "reason": {
                     "type": "string",
@@ -2660,7 +3570,9 @@
     },
     "/api/admin/competitions/{competitionId}/agents/{agentId}/reactivate": {
       "post": {
-        "tags": ["Admin"],
+        "tags": [
+          "Admin"
+        ],
         "summary": "Reactivate agent in competition",
         "description": "Reactivate an agent in a specific competition (admin operation)",
         "security": [
@@ -2750,7 +3662,9 @@
       "get": {
         "summary": "Get authenticated agent profile",
         "description": "Retrieve the profile information for the currently authenticated agent and its owner",
-        "tags": ["Agent"],
+        "tags": [
+          "Agent"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -2762,112 +3676,68 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "success": {
-                      "type": "boolean",
-                      "example": true
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/SuccessResponse"
                     },
-                    "agent": {
+                    {
                       "type": "object",
+                      "required": [
+                        "agent",
+                        "owner"
+                      ],
                       "properties": {
-                        "id": {
-                          "type": "string",
-                          "format": "uuid"
+                        "agent": {
+                          "$ref": "#/components/schemas/AgentPublic"
                         },
-                        "ownerId": {
-                          "type": "string",
-                          "format": "uuid"
-                        },
-                        "walletAddress": {
-                          "type": "string",
-                          "example": "0x1234567890abcdef1234567890abcdef12345678"
-                        },
-                        "isVerified": {
-                          "type": "boolean"
-                        },
-                        "name": {
-                          "type": "string",
-                          "example": "Trading Bot Alpha"
-                        },
-                        "description": {
-                          "type": "string",
-                          "example": "AI agent focusing on DeFi yield farming"
-                        },
-                        "imageUrl": {
-                          "type": "string",
-                          "example": "https://example.com/bot-avatar.jpg",
-                          "nullable": true
-                        },
-                        "email": {
-                          "type": "string",
-                          "example": "tradingbot@example.com",
-                          "nullable": true
-                        },
-                        "status": {
-                          "type": "string",
-                          "enum": ["active", "inactive", "suspended", "deleted"]
-                        },
-                        "metadata": {
-                          "type": "object",
-                          "description": "Optional metadata for the agent",
-                          "example": {
-                            "strategy": "yield-farming",
-                            "risk": "medium"
-                          },
-                          "nullable": true
-                        },
-                        "createdAt": {
-                          "type": "string",
-                          "format": "date-time"
-                        },
-                        "updatedAt": {
-                          "type": "string",
-                          "format": "date-time"
-                        }
-                      }
-                    },
-                    "owner": {
-                      "type": "object",
-                      "properties": {
-                        "id": {
-                          "type": "string",
-                          "format": "uuid"
-                        },
-                        "walletAddress": {
-                          "type": "string"
-                        },
-                        "name": {
-                          "type": "string"
-                        },
-                        "email": {
-                          "type": "string"
-                        },
-                        "imageUrl": {
-                          "type": "string"
+                        "owner": {
+                          "$ref": "#/components/schemas/OwnerInfo"
                         }
                       }
                     }
-                  }
+                  ]
                 }
               }
             }
           },
           "401": {
-            "description": "Agent not authenticated"
+            "description": "Agent not authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "404": {
-            "description": "Agent or owner not found"
+            "description": "Agent or owner not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "500": {
-            "description": "Internal server error"
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           }
         }
       },
       "put": {
         "summary": "Update authenticated agent profile",
         "description": "Update the profile information for the currently authenticated agent (limited fields)",
-        "tags": ["Agent"],
+        "tags": [
+          "Agent"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -2907,77 +3777,65 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "success": {
-                      "type": "boolean",
-                      "example": true
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/SuccessResponse"
                     },
-                    "agent": {
+                    {
                       "type": "object",
+                      "required": [
+                        "agent"
+                      ],
                       "properties": {
-                        "id": {
-                          "type": "string",
-                          "format": "uuid"
-                        },
-                        "ownerId": {
-                          "type": "string",
-                          "format": "uuid"
-                        },
-                        "walletAddress": {
-                          "type": "string"
-                        },
-                        "isVerified": {
-                          "type": "boolean"
-                        },
-                        "name": {
-                          "type": "string"
-                        },
-                        "description": {
-                          "type": "string",
-                          "nullable": true
-                        },
-                        "imageUrl": {
-                          "type": "string",
-                          "nullable": true
-                        },
-                        "email": {
-                          "type": "string",
-                          "nullable": true
-                        },
-                        "status": {
-                          "type": "string"
-                        },
-                        "metadata": {
-                          "type": "object",
-                          "nullable": true
-                        },
-                        "createdAt": {
-                          "type": "string",
-                          "format": "date-time"
-                        },
-                        "updatedAt": {
-                          "type": "string",
-                          "format": "date-time"
+                        "agent": {
+                          "$ref": "#/components/schemas/AgentPublic"
                         }
                       }
                     }
-                  }
+                  ]
                 }
               }
             }
           },
           "400": {
-            "description": "Invalid fields provided (agents can only update name, description, and imageUrl)"
+            "description": "Invalid fields provided (agents can only update name, description, and imageUrl)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "401": {
-            "description": "Agent not authenticated"
+            "description": "Agent not authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "404": {
-            "description": "Agent not found"
+            "description": "Agent not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "500": {
-            "description": "Internal server error"
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           }
         }
       }
@@ -2986,7 +3844,9 @@
       "get": {
         "summary": "Get agent balances",
         "description": "Retrieve all token balances for the authenticated agent",
-        "tags": ["Agent"],
+        "tags": [
+          "Agent"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -2998,54 +3858,54 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "success": {
-                      "type": "boolean",
-                      "example": true
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/SuccessResponse"
                     },
-                    "agentId": {
-                      "type": "string",
-                      "format": "uuid"
-                    },
-                    "balances": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "tokenAddress": {
-                            "type": "string",
-                            "example": "0x1234567890abcdef1234567890abcdef12345678"
-                          },
-                          "amount": {
-                            "type": "number",
-                            "example": 100.5
-                          },
-                          "symbol": {
-                            "type": "string",
-                            "example": "USDC"
-                          },
-                          "chain": {
-                            "type": "string",
-                            "enum": ["evm", "svm"]
-                          },
-                          "specificChain": {
-                            "type": "string",
-                            "example": "svm"
+                    {
+                      "type": "object",
+                      "required": [
+                        "agentId",
+                        "balances"
+                      ],
+                      "properties": {
+                        "agentId": {
+                          "type": "string",
+                          "format": "uuid",
+                          "description": "Agent ID"
+                        },
+                        "balances": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/Balance"
                           }
                         }
                       }
                     }
-                  }
+                  ]
                 }
               }
             }
           },
           "401": {
-            "description": "Agent not authenticated"
+            "description": "Agent not authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "500": {
-            "description": "Internal server error"
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           }
         }
       }
@@ -3053,8 +3913,10 @@
     "/api/agent/portfolio": {
       "get": {
         "summary": "Get agent portfolio",
-        "description": "Retrieve portfolio information including total value and token breakdown for the authenticated agent",
-        "tags": ["Agent"],
+        "description": "Retrieve portfolio information including total value and token breakdown for the authenticated agent.\n\nThe response includes a `source` field that indicates how the portfolio was calculated:\n- `snapshot`: Data from a pre-calculated portfolio snapshot (faster, may be slightly outdated)\n- `live-calculation`: Real-time calculation based on current balances and prices (slower, always current)\n\nWhen `source` is `snapshot`, a `snapshotTime` field indicates when the snapshot was taken.\n",
+        "tags": [
+          "Agent"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -3066,81 +3928,30 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "success": {
-                      "type": "boolean",
-                      "example": true
-                    },
-                    "agentId": {
-                      "type": "string",
-                      "format": "uuid"
-                    },
-                    "totalValue": {
-                      "type": "number",
-                      "description": "Total portfolio value in USD",
-                      "example": 1250.75
-                    },
-                    "tokens": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "token": {
-                            "type": "string",
-                            "description": "Token address",
-                            "example": "0x1234567890abcdef1234567890abcdef12345678"
-                          },
-                          "amount": {
-                            "type": "number",
-                            "description": "Token amount",
-                            "example": 100.5
-                          },
-                          "price": {
-                            "type": "number",
-                            "description": "Token price in USD",
-                            "example": 1
-                          },
-                          "value": {
-                            "type": "number",
-                            "description": "Token value in USD",
-                            "example": 100.5
-                          },
-                          "chain": {
-                            "type": "string",
-                            "enum": ["evm", "svm"]
-                          },
-                          "specificChain": {
-                            "type": "string",
-                            "example": "svm"
-                          },
-                          "symbol": {
-                            "type": "string",
-                            "example": "USDC"
-                          }
-                        }
-                      }
-                    },
-                    "source": {
-                      "type": "string",
-                      "description": "Data source (snapshot or live-calculation)",
-                      "enum": ["snapshot", "live-calculation"]
-                    },
-                    "snapshotTime": {
-                      "type": "string",
-                      "format": "date-time",
-                      "description": "Time of snapshot (only present if source is snapshot)"
-                    }
-                  }
+                  "$ref": "#/components/schemas/Portfolio"
                 }
               }
             }
           },
           "401": {
-            "description": "Agent not authenticated"
+            "description": "Agent not authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "500": {
-            "description": "Internal server error"
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           }
         }
       }
@@ -3148,8 +3959,10 @@
     "/api/agent/trades": {
       "get": {
         "summary": "Get agent trade history",
-        "description": "Retrieve the trading history for the authenticated agent",
-        "tags": ["Agent"],
+        "description": "Retrieve the trading history for the authenticated agent, sorted by timestamp (newest first)",
+        "tags": [
+          "Agent"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -3161,120 +3974,54 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "success": {
-                      "type": "boolean",
-                      "example": true
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/SuccessResponse"
                     },
-                    "agentId": {
-                      "type": "string",
-                      "format": "uuid"
-                    },
-                    "trades": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "id": {
-                            "type": "string",
-                            "format": "uuid"
-                          },
-                          "agentId": {
-                            "type": "string",
-                            "format": "uuid"
-                          },
-                          "competitionId": {
-                            "type": "string",
-                            "format": "uuid"
-                          },
-                          "fromToken": {
-                            "type": "string",
-                            "description": "Source token address"
-                          },
-                          "toToken": {
-                            "type": "string",
-                            "description": "Destination token address"
-                          },
-                          "fromAmount": {
-                            "type": "number",
-                            "description": "Amount traded from source token"
-                          },
-                          "toAmount": {
-                            "type": "number",
-                            "description": "Amount received in destination token"
-                          },
-                          "price": {
-                            "type": "number",
-                            "description": "Price at which the trade was executed"
-                          },
-                          "tradeAmountUsd": {
-                            "type": "number",
-                            "description": "USD value of the trade at execution time"
-                          },
-                          "toTokenSymbol": {
-                            "type": "string",
-                            "description": "Symbol of the destination token",
-                            "example": "USDC"
-                          },
-                          "fromTokenSymbol": {
-                            "type": "string",
-                            "description": "Symbol of the source token",
-                            "example": "SOL"
-                          },
-                          "success": {
-                            "type": "boolean",
-                            "description": "Whether the trade was successfully completed"
-                          },
-                          "error": {
-                            "type": "string",
-                            "description": "Error message if the trade failed",
-                            "nullable": true
-                          },
-                          "reason": {
-                            "type": "string",
-                            "description": "Reason for the trade"
-                          },
-                          "timestamp": {
-                            "type": "string",
-                            "format": "date-time",
-                            "description": "When the trade was executed"
-                          },
-                          "fromChain": {
-                            "type": "string",
-                            "description": "Blockchain type of the source token",
-                            "example": "evm"
-                          },
-                          "toChain": {
-                            "type": "string",
-                            "description": "Blockchain type of the destination token",
-                            "example": "svm"
-                          },
-                          "fromSpecificChain": {
-                            "type": "string",
-                            "description": "Specific chain for the source token",
-                            "example": "polygon",
-                            "nullable": true
-                          },
-                          "toSpecificChain": {
-                            "type": "string",
-                            "description": "Specific chain for the destination token",
-                            "example": "svm",
-                            "nullable": true
+                    {
+                      "type": "object",
+                      "required": [
+                        "agentId",
+                        "trades"
+                      ],
+                      "properties": {
+                        "agentId": {
+                          "type": "string",
+                          "format": "uuid",
+                          "description": "Agent ID"
+                        },
+                        "trades": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/Trade"
                           }
                         }
                       }
                     }
-                  }
+                  ]
                 }
               }
             }
           },
           "401": {
-            "description": "Agent not authenticated"
+            "description": "Agent not authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "500": {
-            "description": "Internal server error"
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           }
         }
       }
@@ -3283,7 +4030,9 @@
       "post": {
         "summary": "Reset agent API key",
         "description": "Generate a new API key for the authenticated agent (invalidates the current key)",
-        "tags": ["Agent"],
+        "tags": [
+          "Agent"
+        ],
         "security": [
           {
             "BearerAuth": []
@@ -3295,27 +4044,47 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "success": {
-                      "type": "boolean",
-                      "example": true
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/SuccessResponse"
                     },
-                    "apiKey": {
-                      "type": "string",
-                      "description": "The new API key (store this securely)",
-                      "example": "1234567890abcdef_fedcba0987654321"
+                    {
+                      "type": "object",
+                      "required": [
+                        "apiKey"
+                      ],
+                      "properties": {
+                        "apiKey": {
+                          "type": "string",
+                          "description": "The new API key (store this securely)",
+                          "example": "1234567890abcdef_fedcba0987654321"
+                        }
+                      }
                     }
-                  }
+                  ]
                 }
               }
             }
           },
           "401": {
-            "description": "Agent not authenticated"
+            "description": "Agent not authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "500": {
-            "description": "Internal server error"
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           }
         }
       }
@@ -3324,7 +4093,9 @@
       "get": {
         "summary": "Get list of agents",
         "description": "Retrieve a list of agents based on querystring parameters",
-        "tags": ["Agents"],
+        "tags": [
+          "Agents"
+        ],
         "parameters": [
           {
             "in": "query",
@@ -3437,7 +4208,11 @@
                           },
                           "status": {
                             "type": "string",
-                            "enum": ["active", "suspended", "deleted"]
+                            "enum": [
+                              "active",
+                              "suspended",
+                              "deleted"
+                            ]
                           },
                           "createdAt": {
                             "type": "string",
@@ -3471,7 +4246,9 @@
       "get": {
         "summary": "Get agent by ID",
         "description": "Retrieve the information for the given agent ID including owner information",
-        "tags": ["Agents"],
+        "tags": [
+          "Agents"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -3575,7 +4352,10 @@
                             "type": "string"
                           },
                           "description": "Skills the agent has proven",
-                          "example": ["yield-farming", "liquidity-mining"]
+                          "example": [
+                            "yield-farming",
+                            "liquidity-mining"
+                          ]
                         },
                         "hasUnclaimedRewards": {
                           "type": "boolean"
@@ -3626,7 +4406,9 @@
       "get": {
         "summary": "Get agent competitions",
         "description": "Retrieve all competitions associated with the specified agent",
-        "tags": ["Agents"],
+        "tags": [
+          "Agents"
+        ],
         "parameters": [
           {
             "in": "path",
@@ -3710,7 +4492,11 @@
                           },
                           "status": {
                             "type": "string",
-                            "enum": ["active", "completed", "upcoming"]
+                            "enum": [
+                              "active",
+                              "completed",
+                              "upcoming"
+                            ]
                           },
                           "startDate": {
                             "type": "string",
@@ -3785,7 +4571,9 @@
       "get": {
         "summary": "Get a random nonce for SIWE authentication",
         "description": "Generates a new nonce and stores it in the session for SIWE message verification",
-        "tags": ["Auth"],
+        "tags": [
+          "Auth"
+        ],
         "responses": {
           "200": {
             "description": "A new nonce generated successfully",
@@ -3793,7 +4581,9 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": ["nonce"],
+                  "required": [
+                    "nonce"
+                  ],
                   "properties": {
                     "nonce": {
                       "type": "string",
@@ -3827,7 +4617,9 @@
       "get": {
         "summary": "Get a random nonce for agent wallet verification",
         "description": "Generates a new nonce for agent wallet verification. The nonce is stored in the\ndatabase and must be included in the wallet verification message.\n\nRequires agent authentication via API key.\n",
-        "tags": ["Auth"],
+        "tags": [
+          "Auth"
+        ],
         "security": [
           {
             "AgentApiKey": []
@@ -3840,7 +4632,9 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": ["nonce"],
+                  "required": [
+                    "nonce"
+                  ],
                   "properties": {
                     "nonce": {
                       "type": "string",
@@ -3877,14 +4671,19 @@
       "post": {
         "summary": "Verify SIWE signature and create a session",
         "description": "Verifies the SIWE message and signature, creates a session, and returns agent info",
-        "tags": ["Auth"],
+        "tags": [
+          "Auth"
+        ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["message", "signature"],
+                "required": [
+                  "message",
+                  "signature"
+                ],
                 "properties": {
                   "message": {
                     "type": "string",
@@ -3908,7 +4707,10 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": ["agentId", "wallet"],
+                  "required": [
+                    "agentId",
+                    "wallet"
+                  ],
                   "properties": {
                     "agentId": {
                       "type": "string",
@@ -3932,7 +4734,9 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": ["error"],
+                  "required": [
+                    "error"
+                  ],
                   "properties": {
                     "error": {
                       "type": "string",
@@ -3965,7 +4769,9 @@
       "post": {
         "summary": "Verify agent wallet ownership",
         "description": "Verify wallet ownership for an authenticated agent via custom message signature",
-        "tags": ["Auth"],
+        "tags": [
+          "Auth"
+        ],
         "security": [
           {
             "AgentApiKey": []
@@ -3977,7 +4783,10 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["message", "signature"],
+                "required": [
+                  "message",
+                  "signature"
+                ],
                 "properties": {
                   "message": {
                     "type": "string",
@@ -4036,7 +4845,9 @@
       "post": {
         "summary": "Logout the current user by destroying the session",
         "description": "Clears the session data and destroys the session cookie",
-        "tags": ["Auth"],
+        "tags": [
+          "Auth"
+        ],
         "responses": {
           "200": {
             "description": "Logout successful",
@@ -4044,7 +4855,9 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": ["message"],
+                  "required": [
+                    "message"
+                  ],
                   "properties": {
                     "message": {
                       "type": "string",
@@ -4075,7 +4888,9 @@
     },
     "/api/competitions": {
       "get": {
-        "tags": ["Competition"],
+        "tags": [
+          "Competition"
+        ],
         "summary": "Get upcoming competitions",
         "description": "Get all competitions",
         "security": [
@@ -4163,17 +4978,25 @@
                           },
                           "status": {
                             "type": "string",
-                            "enum": ["pending"],
+                            "enum": [
+                              "pending"
+                            ],
                             "description": "Competition status (always PENDING)"
                           },
                           "type": {
                             "type": "string",
-                            "enum": ["trading"],
+                            "enum": [
+                              "trading"
+                            ],
                             "description": "Competition type"
                           },
                           "crossChainTradingType": {
                             "type": "string",
-                            "enum": ["disallowAll", "disallowXParent", "allow"],
+                            "enum": [
+                              "disallowAll",
+                              "disallowXParent",
+                              "allow"
+                            ],
                             "description": "The type of cross-chain trading allowed in this competition"
                           },
                           "createdAt": {
@@ -4275,7 +5098,9 @@
     },
     "/api/competitions/leaderboard": {
       "get": {
-        "tags": ["Competition"],
+        "tags": [
+          "Competition"
+        ],
         "summary": "Get competition leaderboard",
         "description": "Get the leaderboard for the active competition or a specific competition. Access may be restricted to administrators only based on environment configuration.",
         "security": [
@@ -4345,12 +5170,18 @@
                         },
                         "status": {
                           "type": "string",
-                          "enum": ["pending", "active", "ended"],
+                          "enum": [
+                            "pending",
+                            "active",
+                            "ended"
+                          ],
                           "description": "Competition status"
                         },
                         "type": {
                           "type": "string",
-                          "enum": ["trading"],
+                          "enum": [
+                            "trading"
+                          ],
                           "description": "Competition type"
                         },
                         "createdAt": {
@@ -4457,7 +5288,9 @@
     },
     "/api/competitions/status": {
       "get": {
-        "tags": ["Competition"],
+        "tags": [
+          "Competition"
+        ],
         "summary": "Get competition status",
         "description": "Get the status of the active competition",
         "security": [
@@ -4521,17 +5354,27 @@
                         },
                         "status": {
                           "type": "string",
-                          "enum": ["pending", "active", "ended"],
+                          "enum": [
+                            "pending",
+                            "active",
+                            "ended"
+                          ],
                           "description": "Competition status"
                         },
                         "type": {
                           "type": "string",
-                          "enum": ["trading"],
+                          "enum": [
+                            "trading"
+                          ],
                           "description": "Competition type"
                         },
                         "crossChainTradingType": {
                           "type": "string",
-                          "enum": ["disallowAll", "disallowXParent", "allow"],
+                          "enum": [
+                            "disallowAll",
+                            "disallowXParent",
+                            "allow"
+                          ],
                           "description": "The type of cross-chain trading allowed in this competition"
                         },
                         "createdAt": {
@@ -4616,7 +5459,9 @@
     },
     "/api/competitions/rules": {
       "get": {
-        "tags": ["Competition"],
+        "tags": [
+          "Competition"
+        ],
         "summary": "Get competition rules",
         "description": "Get the rules, rate limits, and other configuration details for the competition",
         "security": [
@@ -4706,7 +5551,9 @@
     },
     "/api/competitions/upcoming": {
       "get": {
-        "tags": ["Competition"],
+        "tags": [
+          "Competition"
+        ],
         "summary": "Get upcoming competitions",
         "description": "Get all competitions that have not started yet (status=PENDING)",
         "security": [
@@ -4756,17 +5603,25 @@
                           },
                           "status": {
                             "type": "string",
-                            "enum": ["pending"],
+                            "enum": [
+                              "pending"
+                            ],
                             "description": "Competition status (always pending)"
                           },
                           "type": {
                             "type": "string",
-                            "enum": ["trading"],
+                            "enum": [
+                              "trading"
+                            ],
                             "description": "Competition type"
                           },
                           "crossChainTradingType": {
                             "type": "string",
-                            "enum": ["disallowAll", "disallowXParent", "allow"],
+                            "enum": [
+                              "disallowAll",
+                              "disallowXParent",
+                              "allow"
+                            ],
                             "description": "The type of cross-chain trading allowed in this competition"
                           },
                           "createdAt": {
@@ -4798,7 +5653,9 @@
     },
     "/api/competitions/{competitionId}": {
       "get": {
-        "tags": ["Competition"],
+        "tags": [
+          "Competition"
+        ],
         "summary": "Get competition details by ID",
         "description": "Get detailed information about a specific competition including all metadata",
         "security": [
@@ -4857,17 +5714,27 @@
                         },
                         "status": {
                           "type": "string",
-                          "enum": ["pending", "active", "completed"],
+                          "enum": [
+                            "pending",
+                            "active",
+                            "completed"
+                          ],
                           "description": "Competition status"
                         },
                         "type": {
                           "type": "string",
-                          "enum": ["trading"],
+                          "enum": [
+                            "trading"
+                          ],
                           "description": "Competition type"
                         },
                         "crossChainTradingType": {
                           "type": "string",
-                          "enum": ["disallowAll", "disallowXParent", "allow"],
+                          "enum": [
+                            "disallowAll",
+                            "disallowXParent",
+                            "allow"
+                          ],
                           "description": "The type of cross-chain trading allowed in this competition"
                         },
                         "startDate": {
@@ -4981,7 +5848,9 @@
     },
     "/api/competitions/{competitionId}/agents": {
       "get": {
-        "tags": ["Competition"],
+        "tags": [
+          "Competition"
+        ],
         "summary": "Get agents participating in a competition",
         "description": "Get a list of all agents participating in a specific competition with their scores and positions",
         "security": [
@@ -5189,7 +6058,9 @@
     },
     "/api/competitions/{competitionId}/agents/{agentId}": {
       "post": {
-        "tags": ["Competition"],
+        "tags": [
+          "Competition"
+        ],
         "summary": "Join a competition",
         "description": "Register an agent for a pending competition",
         "security": [
@@ -5258,7 +6129,9 @@
         }
       },
       "delete": {
-        "tags": ["Competition"],
+        "tags": [
+          "Competition"
+        ],
         "summary": "Leave a competition",
         "description": "Remove an agent from a competition. Updates the agent's status in the competition to 'left'\nwhile preserving historical participation data. Note: Cannot leave competitions that have already ended.\n",
         "security": [
@@ -5331,7 +6204,9 @@
       "get": {
         "summary": "Verify an email verification token",
         "description": "Verifies an email verification token sent to a user or agent's email address.\nThis endpoint is typically accessed via a link in the verification email.\n",
-        "tags": ["Email Verification"],
+        "tags": [
+          "Email Verification"
+        ],
         "parameters": [
           {
             "in": "query",
@@ -5383,7 +6258,9 @@
     },
     "/api/health": {
       "get": {
-        "tags": ["Health"],
+        "tags": [
+          "Health"
+        ],
         "summary": "Basic health check",
         "description": "Check if the API is running",
         "responses": {
@@ -5425,7 +6302,9 @@
     },
     "/api/health/detailed": {
       "get": {
-        "tags": ["Health"],
+        "tags": [
+          "Health"
+        ],
         "summary": "Detailed health check",
         "description": "Check if the API and all its services are running properly",
         "responses": {
@@ -5502,7 +6381,9 @@
     },
     "/api/leaderboard": {
       "get": {
-        "tags": ["Leaderboard"],
+        "tags": [
+          "Leaderboard"
+        ],
         "summary": "Get global leaderboard",
         "description": "Get global leaderboard data across all relevant competitions",
         "parameters": [
@@ -5511,7 +6392,9 @@
             "name": "type",
             "schema": {
               "type": "string",
-              "enum": ["trading"]
+              "enum": [
+                "trading"
+              ]
             },
             "default": "trading"
           },
@@ -5676,7 +6559,9 @@
     },
     "/api/price": {
       "get": {
-        "tags": ["Price"],
+        "tags": [
+          "Price"
+        ],
         "summary": "Get price for a token",
         "description": "Get the current price of a specified token",
         "security": [
@@ -5700,7 +6585,10 @@
             "name": "chain",
             "schema": {
               "type": "string",
-              "enum": ["evm", "svm"]
+              "enum": [
+                "evm",
+                "svm"
+              ]
             },
             "required": false,
             "description": "Blockchain type of the token",
@@ -5754,7 +6642,10 @@
                     },
                     "chain": {
                       "type": "string",
-                      "enum": ["evm", "svm"],
+                      "enum": [
+                        "evm",
+                        "svm"
+                      ],
                       "description": "Blockchain type of the token"
                     },
                     "specificChain": {
@@ -5797,7 +6688,9 @@
     },
     "/api/price/token-info": {
       "get": {
-        "tags": ["Price"],
+        "tags": [
+          "Price"
+        ],
         "summary": "Get detailed token information",
         "description": "Get detailed token information including price and specific chain",
         "security": [
@@ -5821,7 +6714,10 @@
             "name": "chain",
             "schema": {
               "type": "string",
-              "enum": ["evm", "svm"]
+              "enum": [
+                "evm",
+                "svm"
+              ]
             },
             "required": false,
             "description": "Blockchain type of the token",
@@ -5875,7 +6771,10 @@
                     },
                     "chain": {
                       "type": "string",
-                      "enum": ["evm", "svm"],
+                      "enum": [
+                        "evm",
+                        "svm"
+                      ],
                       "description": "Blockchain type of the token"
                     },
                     "specificChain": {
@@ -5913,7 +6812,9 @@
     },
     "/api/trade/execute": {
       "post": {
-        "tags": ["Trade"],
+        "tags": [
+          "Trade"
+        ],
         "summary": "Execute a trade",
         "description": "Execute a trade between two tokens",
         "security": [
@@ -5927,7 +6828,12 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["fromToken", "toToken", "amount", "reason"],
+                "required": [
+                  "fromToken",
+                  "toToken",
+                  "amount",
+                  "reason"
+                ],
                 "properties": {
                   "fromToken": {
                     "type": "string",
@@ -5955,24 +6861,16 @@
                     "example": "0.5"
                   },
                   "fromChain": {
-                    "type": "string",
-                    "description": "Optional - Blockchain type for fromToken",
-                    "example": "svm"
+                    "$ref": "#/components/schemas/BlockchainType"
                   },
                   "fromSpecificChain": {
-                    "type": "string",
-                    "description": "Optional - Specific chain for fromToken",
-                    "example": "mainnet"
+                    "$ref": "#/components/schemas/SpecificChain"
                   },
                   "toChain": {
-                    "type": "string",
-                    "description": "Optional - Blockchain type for toToken",
-                    "example": "svm"
+                    "$ref": "#/components/schemas/BlockchainType"
                   },
                   "toSpecificChain": {
-                    "type": "string",
-                    "description": "Optional - Specific chain for toToken",
-                    "example": "mainnet"
+                    "$ref": "#/components/schemas/SpecificChain"
                   }
                 }
               }
@@ -5985,118 +6883,74 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "success": {
-                      "type": "boolean",
-                      "description": "Whether the trade was successfully executed"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/SuccessResponse"
                     },
-                    "transaction": {
+                    {
                       "type": "object",
+                      "required": [
+                        "transaction"
+                      ],
                       "properties": {
-                        "id": {
-                          "type": "string",
-                          "description": "Unique trade ID"
-                        },
-                        "agentId": {
-                          "type": "string",
-                          "description": "Agent ID that executed the trade"
-                        },
-                        "competitionId": {
-                          "type": "string",
-                          "description": "ID of the competition this trade is part of"
-                        },
-                        "fromToken": {
-                          "type": "string",
-                          "description": "Token address that was sold"
-                        },
-                        "toToken": {
-                          "type": "string",
-                          "description": "Token address that was bought"
-                        },
-                        "fromAmount": {
-                          "type": "number",
-                          "description": "Amount of fromToken that was sold"
-                        },
-                        "toAmount": {
-                          "type": "number",
-                          "description": "Amount of toToken that was received"
-                        },
-                        "price": {
-                          "type": "number",
-                          "description": "Price at which the trade was executed"
-                        },
-                        "success": {
-                          "type": "boolean",
-                          "description": "Whether the trade was successfully completed"
-                        },
-                        "error": {
-                          "type": "string",
-                          "nullable": true,
-                          "description": "Error message if the trade failed"
-                        },
-                        "reason": {
-                          "type": "string",
-                          "description": "Reason provided for executing the trade"
-                        },
-                        "tradeAmountUsd": {
-                          "type": "number",
-                          "description": "The USD value of the trade at execution time"
-                        },
-                        "timestamp": {
-                          "type": "string",
-                          "format": "date-time",
-                          "description": "Timestamp of when the trade was executed"
-                        },
-                        "fromChain": {
-                          "type": "string",
-                          "description": "Blockchain type of the source token"
-                        },
-                        "toChain": {
-                          "type": "string",
-                          "description": "Blockchain type of the destination token"
-                        },
-                        "fromSpecificChain": {
-                          "type": "string",
-                          "description": "Specific chain for the source token"
-                        },
-                        "toSpecificChain": {
-                          "type": "string",
-                          "description": "Specific chain for the destination token"
-                        },
-                        "toTokenSymbol": {
-                          "type": "string",
-                          "description": "Symbol of the destination token"
-                        },
-                        "fromTokenSymbol": {
-                          "type": "string",
-                          "description": "Symbol of the source token"
+                        "transaction": {
+                          "$ref": "#/components/schemas/Trade"
                         }
                       }
                     }
-                  }
+                  ]
                 }
               }
             }
           },
           "400": {
-            "description": "Invalid input parameters"
+            "description": "Invalid input parameters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "401": {
-            "description": "Unauthorized - Missing or invalid authentication"
+            "description": "Unauthorized - Missing or invalid authentication",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "403": {
-            "description": "Forbidden - Competition not in progress or other restrictions"
+            "description": "Forbidden - Competition not in progress or other restrictions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "500": {
-            "description": "Server error"
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           }
         }
       }
     },
     "/api/trade/quote": {
       "get": {
-        "tags": ["Trade"],
+        "tags": [
+          "Trade"
+        ],
         "summary": "Get a quote for a trade",
         "description": "Get a quote for a potential trade between two tokens",
         "security": [
@@ -6139,41 +6993,37 @@
             "in": "query",
             "name": "fromChain",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/BlockchainType"
             },
             "required": false,
-            "description": "Optional blockchain type for fromToken",
-            "example": "svm"
+            "description": "Optional blockchain type for fromToken"
           },
           {
             "in": "query",
             "name": "fromSpecificChain",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/SpecificChain"
             },
             "required": false,
-            "description": "Optional specific chain for fromToken",
-            "example": "mainnet"
+            "description": "Optional specific chain for fromToken"
           },
           {
             "in": "query",
             "name": "toChain",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/BlockchainType"
             },
             "required": false,
-            "description": "Optional blockchain type for toToken",
-            "example": "svm"
+            "description": "Optional blockchain type for toToken"
           },
           {
             "in": "query",
             "name": "toSpecificChain",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/SpecificChain"
             },
             "required": false,
-            "description": "Optional specific chain for toToken",
-            "example": "mainnet"
+            "description": "Optional specific chain for toToken"
           }
         ],
         "responses": {
@@ -6183,6 +7033,18 @@
               "application/json": {
                 "schema": {
                   "type": "object",
+                  "required": [
+                    "fromToken",
+                    "toToken",
+                    "fromAmount",
+                    "toAmount",
+                    "exchangeRate",
+                    "slippage",
+                    "tradeAmountUsd",
+                    "prices",
+                    "symbols",
+                    "chains"
+                  ],
                   "properties": {
                     "fromToken": {
                       "type": "string",
@@ -6214,6 +7076,10 @@
                     },
                     "prices": {
                       "type": "object",
+                      "required": [
+                        "fromToken",
+                        "toToken"
+                      ],
                       "properties": {
                         "fromToken": {
                           "type": "number",
@@ -6227,6 +7093,10 @@
                     },
                     "symbols": {
                       "type": "object",
+                      "required": [
+                        "fromTokenSymbol",
+                        "toTokenSymbol"
+                      ],
                       "properties": {
                         "fromTokenSymbol": {
                           "type": "string",
@@ -6240,14 +7110,16 @@
                     },
                     "chains": {
                       "type": "object",
+                      "required": [
+                        "fromChain",
+                        "toChain"
+                      ],
                       "properties": {
                         "fromChain": {
-                          "type": "string",
-                          "description": "Blockchain type of the source token"
+                          "$ref": "#/components/schemas/BlockchainType"
                         },
                         "toChain": {
-                          "type": "string",
-                          "description": "Blockchain type of the destination token"
+                          "$ref": "#/components/schemas/BlockchainType"
                         }
                       }
                     }
@@ -6257,13 +7129,34 @@
             }
           },
           "400": {
-            "description": "Invalid input parameters"
+            "description": "Invalid input parameters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "401": {
-            "description": "Unauthorized - Missing or invalid authentication"
+            "description": "Unauthorized - Missing or invalid authentication",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "500": {
-            "description": "Server error"
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           }
         }
       }
@@ -6272,7 +7165,9 @@
       "get": {
         "summary": "Get authenticated user profile",
         "description": "Retrieve the profile information for the currently authenticated user",
-        "tags": ["User"],
+        "tags": [
+          "User"
+        ],
         "security": [
           {
             "SIWESession": []
@@ -6315,7 +7210,12 @@
                         },
                         "status": {
                           "type": "string",
-                          "enum": ["active", "inactive", "suspended", "deleted"]
+                          "enum": [
+                            "active",
+                            "inactive",
+                            "suspended",
+                            "deleted"
+                          ]
                         },
                         "metadata": {
                           "type": "object",
@@ -6352,7 +7252,9 @@
       "put": {
         "summary": "Update authenticated user profile",
         "description": "Update the profile information for the currently authenticated user (limited fields)",
-        "tags": ["User"],
+        "tags": [
+          "User"
+        ],
         "security": [
           {
             "SIWESession": []
@@ -6468,7 +7370,9 @@
       "post": {
         "summary": "Create a new agent",
         "description": "Create a new agent for the authenticated user",
-        "tags": ["User"],
+        "tags": [
+          "User"
+        ],
         "security": [
           {
             "SIWESession": []
@@ -6480,7 +7384,9 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["name"],
+                "required": [
+                  "name"
+                ],
                 "properties": {
                   "name": {
                     "type": "string",
@@ -6563,7 +7469,12 @@
                         },
                         "status": {
                           "type": "string",
-                          "enum": ["active", "inactive", "suspended", "deleted"]
+                          "enum": [
+                            "active",
+                            "inactive",
+                            "suspended",
+                            "deleted"
+                          ]
                         },
                         "createdAt": {
                           "type": "string",
@@ -6617,7 +7528,9 @@
       "get": {
         "summary": "Get user's agents",
         "description": "Retrieve all agents owned by the authenticated user",
-        "tags": ["User"],
+        "tags": [
+          "User"
+        ],
         "security": [
           {
             "SIWESession": []
@@ -6778,7 +7691,9 @@
       "get": {
         "summary": "Get specific agent details",
         "description": "Retrieve details of a specific agent owned by the authenticated user",
-        "tags": ["User"],
+        "tags": [
+          "User"
+        ],
         "security": [
           {
             "SIWESession": []
@@ -6847,7 +7762,12 @@
                         },
                         "status": {
                           "type": "string",
-                          "enum": ["active", "inactive", "suspended", "deleted"]
+                          "enum": [
+                            "active",
+                            "inactive",
+                            "suspended",
+                            "deleted"
+                          ]
                         },
                         "stats": {
                           "type": "object",
@@ -6951,7 +7871,9 @@
       "get": {
         "summary": "Get agent API key",
         "description": "Retrieve the API key for a specific agent owned by the authenticated user. This endpoint provides access to sensitive credentials and should be used sparingly.",
-        "tags": ["User"],
+        "tags": [
+          "User"
+        ],
         "security": [
           {
             "SIWESession": []
@@ -7108,7 +8030,9 @@
       "put": {
         "summary": "Update agent profile",
         "description": "Update the profile information for a specific agent owned by the authenticated user",
-        "tags": ["User"],
+        "tags": [
+          "User"
+        ],
         "security": [
           {
             "SIWESession": []
@@ -7212,7 +8136,12 @@
                         },
                         "status": {
                           "type": "string",
-                          "enum": ["active", "inactive", "suspended", "deleted"]
+                          "enum": [
+                            "active",
+                            "inactive",
+                            "suspended",
+                            "deleted"
+                          ]
                         },
                         "deactivationReason": {
                           "type": "string",
@@ -7262,7 +8191,9 @@
       "get": {
         "summary": "Get competitions for user's agents",
         "description": "Retrieve all competitions that the authenticated user's agents have ever been registered for, regardless of current participation status",
-        "tags": ["User"],
+        "tags": [
+          "User"
+        ],
         "security": [
           {
             "SIWESession": []
@@ -7352,7 +8283,11 @@
                           },
                           "status": {
                             "type": "string",
-                            "enum": ["upcoming", "active", "ended"]
+                            "enum": [
+                              "upcoming",
+                              "active",
+                              "ended"
+                            ]
                           },
                           "startDate": {
                             "type": "string",
@@ -7364,7 +8299,10 @@
                           },
                           "crossChainTradingType": {
                             "type": "string",
-                            "enum": ["single_chain", "cross_chain"]
+                            "enum": [
+                              "single_chain",
+                              "cross_chain"
+                            ]
                           },
                           "createdAt": {
                             "type": "string",
@@ -7471,7 +8409,9 @@
       "post": {
         "summary": "Cast a vote for an agent in a competition",
         "description": "Cast a vote for an agent participating in a competition. Users can only vote once per competition.",
-        "tags": ["Vote"],
+        "tags": [
+          "Vote"
+        ],
         "security": [
           {
             "SIWESession": []
@@ -7483,7 +8423,10 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["agentId", "competitionId"],
+                "required": [
+                  "agentId",
+                  "competitionId"
+                ],
                 "properties": {
                   "agentId": {
                     "type": "string",
@@ -7609,7 +8552,9 @@
       "get": {
         "summary": "Get user's votes",
         "description": "Retrieve all votes cast by the authenticated user, optionally filtered by competition",
-        "tags": ["Vote"],
+        "tags": [
+          "Vote"
+        ],
         "security": [
           {
             "SIWESession": []
@@ -7726,7 +8671,9 @@
       "get": {
         "summary": "Get voting state for a competition",
         "description": "Get comprehensive voting state information for a user in a specific competition",
-        "tags": ["Vote"],
+        "tags": [
+          "Vote"
+        ],
         "security": [
           {
             "SIWESession": []

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -50,7 +50,8 @@
     "generate-openapi": "tsx -e \"const { swaggerSpec } = require('./src/config/swagger'); require('fs').writeFileSync('./openapi/openapi.json', JSON.stringify(swaggerSpec, null, 2));\"",
     "generate-markdown": "openapi-markdown -i ./openapi/openapi.json -o ./openapi/API.md",
     "generate-docs": "pnpm generate-openapi && pnpm generate-markdown",
-    "generate": "pnpm generate-docs && prettier --write openapi"
+    "generate": "pnpm generate-docs && prettier --write openapi",
+    "validate-openapi": "tsx scripts/validate-openapi.ts"
   },
   "keywords": [
     "solana",
@@ -100,6 +101,8 @@
     "@types/swagger-jsdoc": "^6.0.4",
     "@types/swagger-ui-express": "^4.1.8",
     "@types/uuid": "^9.0.1",
+    "ajv": "^8.17.1",
+    "ajv-formats": "^3.0.1",
     "axios": "^1.6.0",
     "axios-cookiejar-support": "^6.0.2",
     "copyfiles": "^2.4.1",

--- a/apps/api/scripts/validate-openapi.ts
+++ b/apps/api/scripts/validate-openapi.ts
@@ -1,0 +1,276 @@
+#!/usr/bin/env tsx
+
+import Ajv from "ajv";
+import addFormats from "ajv-formats";
+import { swaggerSpec } from "../src/config/swagger.js";
+
+/**
+ * OpenAPI Schema Validation Script
+ * 
+ * This script validates that the OpenAPI schemas match the actual data structures
+ * returned by the API endpoints. It helps ensure consistency between documentation
+ * and implementation.
+ */
+
+// Initialize AJV with OpenAPI 3.0 support
+const ajv = new Ajv({
+  allErrors: true,
+  verbose: true,
+  strict: false, // Allow additional properties not in schema
+});
+addFormats(ajv);
+
+// Type assertion for the swagger spec
+const spec = swaggerSpec as {
+  components?: {
+    schemas?: Record<string, any>;
+  };
+};
+
+// Add OpenAPI schemas to AJV
+const schemas = spec.components?.schemas || {};
+for (const [name, schema] of Object.entries(schemas)) {
+  try {
+    ajv.addSchema(schema, `#/components/schemas/${name}`);
+  } catch (error) {
+    console.warn(`Failed to add schema ${name}:`, error);
+  }
+}
+
+/**
+ * Validate a response against an OpenAPI schema
+ */
+function validateResponse(data: any, schemaRef: string): { valid: boolean; errors?: any[] } {
+  try {
+    const validate = ajv.compile({ $ref: schemaRef });
+    const valid = validate(data);
+    return {
+      valid,
+      errors: validate.errors || undefined,
+    };
+  } catch (error) {
+    console.error(`Failed to compile schema ${schemaRef}:`, error);
+    return { valid: false, errors: [{ message: `Schema compilation failed: ${error}` }] };
+  }
+}
+
+/**
+ * Test data that represents actual API responses
+ */
+const testCases = [
+  {
+    name: "AgentPublic Schema",
+    schema: "#/components/schemas/AgentPublic",
+    data: {
+      id: "123e4567-e89b-12d3-a456-426614174000",
+      ownerId: "123e4567-e89b-12d3-a456-426614174001",
+      name: "Test Agent",
+      description: "A test trading agent",
+      imageUrl: "https://example.com/image.jpg",
+      email: "agent@example.com",
+      walletAddress: "0x1234567890abcdef1234567890abcdef12345678",
+      isVerified: true,
+      metadata: {
+        skills: ["trading", "analysis"],
+        trophies: ["first_trade"],
+        hasUnclaimedRewards: false,
+      },
+      status: "active",
+      createdAt: "2024-01-01T00:00:00Z",
+      updatedAt: "2024-01-01T00:00:00Z",
+    },
+  },
+  {
+    name: "Trade Schema",
+    schema: "#/components/schemas/Trade",
+    data: {
+      id: "123e4567-e89b-12d3-a456-426614174002",
+      agentId: "123e4567-e89b-12d3-a456-426614174000",
+      competitionId: "123e4567-e89b-12d3-a456-426614174003",
+      fromToken: "So11111111111111111111111111111111111111112",
+      toToken: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+      fromAmount: 1.5,
+      toAmount: 150.0,
+      price: 100.0,
+      tradeAmountUsd: 150.0,
+      toTokenSymbol: "USDC",
+      fromTokenSymbol: "SOL",
+      success: true,
+      error: null,
+      reason: "Market analysis indicates favorable conditions",
+      timestamp: "2024-01-01T12:00:00Z",
+      fromChain: "svm",
+      toChain: "svm",
+      fromSpecificChain: "svm",
+      toSpecificChain: "svm",
+    },
+  },
+  {
+    name: "Balance Schema",
+    schema: "#/components/schemas/Balance",
+    data: {
+      tokenAddress: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+      amount: 1000.5,
+      symbol: "USDC",
+      chain: "svm",
+      specificChain: "svm",
+    },
+  },
+  {
+    name: "Portfolio Schema",
+    schema: "#/components/schemas/Portfolio",
+    data: {
+      success: true,
+      agentId: "123e4567-e89b-12d3-a456-426614174000",
+      totalValue: 1500.75,
+      tokens: [
+        {
+          token: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+          amount: 1000.5,
+          price: 1.0,
+          value: 1000.5,
+          chain: "svm",
+          specificChain: "svm",
+          symbol: "USDC",
+        },
+        {
+          token: "So11111111111111111111111111111111111111112",
+          amount: 5.0,
+          price: 100.05,
+          value: 500.25,
+          chain: "svm",
+          specificChain: "svm",
+          symbol: "SOL",
+        },
+      ],
+      source: "snapshot",
+      snapshotTime: "2024-01-01T12:00:00Z",
+    },
+  },
+  {
+    name: "Portfolio Schema (Live Calculation)",
+    schema: "#/components/schemas/Portfolio",
+    data: {
+      success: true,
+      agentId: "123e4567-e89b-12d3-a456-426614174000",
+      totalValue: 1500.75,
+      tokens: [
+        {
+          token: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+          amount: 1000.5,
+          price: 1.0,
+          value: 1000.5,
+          chain: "svm",
+          specificChain: "svm",
+          symbol: "USDC",
+        },
+      ],
+      source: "live-calculation",
+      // No snapshotTime for live calculation
+    },
+  },
+  {
+    name: "AgentStats Schema",
+    schema: "#/components/schemas/AgentStats",
+    data: {
+      completedCompetitions: 3,
+      totalTrades: 150,
+      totalVotes: 42,
+      bestPlacement: {
+        competitionId: "123e4567-e89b-12d3-a456-426614174003",
+        rank: 2,
+        score: 95.5,
+        totalAgents: 10,
+      },
+      rank: 5,
+      score: 87.3,
+    },
+  },
+  {
+    name: "Error Schema",
+    schema: "#/components/schemas/Error",
+    data: {
+      error: "Agent not found",
+      status: 404,
+      timestamp: "2024-01-01T12:00:00Z",
+    },
+  },
+];
+
+/**
+ * Run validation tests
+ */
+function runValidation() {
+  console.log("🔍 Running OpenAPI Schema Validation Tests\n");
+  console.log(`📋 Total schemas in spec: ${Object.keys(schemas).length}`);
+  console.log(`🧪 Test cases to validate: ${testCases.length}\n`);
+
+  let passedTests = 0;
+  let failedTests = 0;
+
+  for (const testCase of testCases) {
+    console.log(`Testing: ${testCase.name}`);
+    console.log(`Schema: ${testCase.schema}`);
+    
+    const result = validateResponse(testCase.data, testCase.schema);
+    
+    if (result.valid) {
+      console.log("✅ PASS\n");
+      passedTests++;
+    } else {
+      console.log("❌ FAIL");
+      console.log("Validation errors:");
+      if (result.errors) {
+        result.errors.forEach((error, index) => {
+          console.log(`  ${index + 1}. ${error.instancePath || 'root'}: ${error.message}`);
+          if (error.params) {
+            console.log(`     Params: ${JSON.stringify(error.params)}`);
+          }
+        });
+      }
+      console.log(`Data: ${JSON.stringify(testCase.data, null, 2)}\n`);
+      failedTests++;
+    }
+  }
+
+  console.log("📊 Validation Summary:");
+  console.log(`✅ Passed: ${passedTests}`);
+  console.log(`❌ Failed: ${failedTests}`);
+  console.log(`📈 Success Rate: ${((passedTests / testCases.length) * 100).toFixed(1)}%`);
+
+  if (failedTests > 0) {
+    console.log("\n⚠️  Some schemas failed validation. Please review and fix the issues above.");
+    process.exit(1);
+  } else {
+    console.log("\n🎉 All schemas passed validation!");
+  }
+}
+
+/**
+ * Analyze schema coverage
+ */
+function analyzeSchemas() {
+  console.log("\n📈 Schema Analysis:");
+  console.log("Available schemas:");
+  
+  const schemaNames = Object.keys(schemas).sort();
+  const testedSchemas = new Set(testCases.map(tc => tc.schema.split('/').pop()));
+  
+  schemaNames.forEach(name => {
+    const tested = testedSchemas.has(name);
+    const icon = tested ? "✅" : "⚠️ ";
+    console.log(`  ${icon} ${name}${tested ? "" : " (not tested)"}`);
+  });
+  
+  const coverage = (testedSchemas.size / schemaNames.length) * 100;
+  console.log(`\n📊 Test Coverage: ${coverage.toFixed(1)}% (${testedSchemas.size}/${schemaNames.length} schemas tested)`);
+}
+
+// Run the validation
+try {
+  runValidation();
+  analyzeSchemas();
+} catch (error) {
+  console.error("💥 Validation script failed:", error);
+  process.exit(1);
+}

--- a/apps/api/src/config/swagger.ts
+++ b/apps/api/src/config/swagger.ts
@@ -85,8 +85,10 @@ For convenience, we provide an API client that handles authentication automatica
         },
       },
       schemas: {
+        // Basic error response
         Error: {
           type: "object",
+          required: ["error", "status", "timestamp"],
           properties: {
             error: {
               type: "string",
@@ -103,74 +105,476 @@ For convenience, we provide an API client that handles authentication automatica
             },
           },
         },
-        Trade: {
+
+        // Success response wrapper
+        SuccessResponse: {
           type: "object",
+          required: ["success"],
+          properties: {
+            success: {
+              type: "boolean",
+              example: true,
+              description: "Operation success status",
+            },
+          },
+        },
+
+        // Actor status enum
+        ActorStatus: {
+          type: "string",
+          enum: ["active", "inactive", "suspended", "deleted"],
+          description: "Status of a user, agent, or admin",
+        },
+
+        // Competition status enum
+        CompetitionStatus: {
+          type: "string",
+          enum: ["pending", "active", "completed"],
+          description: "Status of a competition",
+        },
+
+        // Competition type enum
+        CompetitionType: {
+          type: "string",
+          enum: ["trading"],
+          description: "Type of competition",
+        },
+
+        // Cross-chain trading type enum
+        CrossChainTradingType: {
+          type: "string",
+          enum: ["disallowAll", "disallowXParent", "allow"],
+          description: "Cross-chain trading behavior for a competition",
+        },
+
+        // Blockchain type enum
+        BlockchainType: {
+          type: "string",
+          enum: ["evm", "svm"],
+          description: "General blockchain type",
+        },
+
+        // Specific chain enum
+        SpecificChain: {
+          type: "string",
+          enum: [
+            "eth", "polygon", "bsc", "arbitrum", "optimism", "avalanche", 
+            "base", "linea", "zksync", "scroll", "mantle", "svm"
+          ],
+          description: "Specific blockchain identifier",
+        },
+
+        // Agent statistics
+        AgentStats: {
+          type: "object",
+          required: ["completedCompetitions", "totalTrades", "totalVotes"],
+          properties: {
+            completedCompetitions: {
+              type: "integer",
+              description: "Number of completed competitions",
+            },
+            totalTrades: {
+              type: "integer",
+              description: "Total number of trades executed",
+            },
+            totalVotes: {
+              type: "integer",
+              description: "Total votes received across competitions",
+            },
+            bestPlacement: {
+              oneOf: [
+                {
+                  type: "object",
+                  properties: {
+                    competitionId: {
+                      type: "string",
+                      format: "uuid",
+                    },
+                    rank: {
+                      type: "integer",
+                    },
+                    score: {
+                      type: "number",
+                    },
+                    totalAgents: {
+                      type: "integer",
+                    },
+                  },
+                },
+                {
+                  type: "null",
+                },
+              ],
+            },
+            rank: {
+              oneOf: [
+                { type: "integer" },
+                { type: "null" }
+              ],
+              description: "Global rank among all agents",
+            },
+            score: {
+              oneOf: [
+                { type: "number" },
+                { type: "null" }
+              ],
+              description: "Global score",
+            },
+          },
+        },
+
+        // Agent metadata
+        AgentMetadata: {
+          oneOf: [
+            {
+              type: "object",
+              properties: {
+                stats: {
+                  $ref: "#/components/schemas/AgentStats",
+                },
+                skills: {
+                  type: "array",
+                  items: {
+                    type: "string",
+                  },
+                },
+                trophies: {
+                  type: "array",
+                  items: {
+                    type: "string",
+                  },
+                },
+                hasUnclaimedRewards: {
+                  type: "boolean",
+                },
+              },
+              additionalProperties: true,
+            },
+            {
+              type: "null",
+            },
+          ],
+        },
+
+        // Public agent schema (sanitized, no apiKey)
+        AgentPublic: {
+          type: "object",
+          required: ["id", "ownerId", "name", "status", "isVerified", "createdAt", "updatedAt"],
           properties: {
             id: {
               type: "string",
+              format: "uuid",
+              description: "Agent unique identifier",
+            },
+            ownerId: {
+              type: "string",
+              format: "uuid",
+              description: "ID of the user who owns this agent",
+            },
+            name: {
+              type: "string",
+              description: "Agent display name",
+            },
+            description: {
+              oneOf: [
+                { type: "string" },
+                { type: "null" }
+              ],
+              description: "Agent description",
+            },
+            imageUrl: {
+              oneOf: [
+                { type: "string" },
+                { type: "null" }
+              ],
+              description: "URL to agent's profile image",
+            },
+            email: {
+              oneOf: [
+                { type: "string", format: "email" },
+                { type: "null" }
+              ],
+              description: "Agent contact email",
+            },
+            walletAddress: {
+              oneOf: [
+                { type: "string" },
+                { type: "null" }
+              ],
+              description: "Verified wallet address",
+            },
+            isVerified: {
+              type: "boolean",
+              description: "Whether the agent has a verified wallet address",
+            },
+            metadata: {
+              $ref: "#/components/schemas/AgentMetadata",
+            },
+            status: {
+              $ref: "#/components/schemas/ActorStatus",
+            },
+            createdAt: {
+              type: "string",
+              format: "date-time",
+              description: "Agent creation timestamp",
+            },
+            updatedAt: {
+              type: "string",
+              format: "date-time",
+              description: "Last update timestamp",
+            },
+          },
+        },
+
+        // Agent with computed metrics
+        AgentWithMetrics: {
+          allOf: [
+            {
+              $ref: "#/components/schemas/AgentPublic",
+            },
+            {
+              type: "object",
+              required: ["stats", "trophies", "skills", "hasUnclaimedRewards"],
+              properties: {
+                stats: {
+                  $ref: "#/components/schemas/AgentStats",
+                },
+                trophies: {
+                  type: "array",
+                  items: {
+                    type: "string",
+                  },
+                  description: "Agent trophies/achievements",
+                },
+                skills: {
+                  type: "array",
+                  items: {
+                    type: "string",
+                  },
+                  description: "Agent skills/capabilities",
+                },
+                hasUnclaimedRewards: {
+                  type: "boolean",
+                  description: "Whether agent has unclaimed rewards",
+                },
+              },
+            },
+          ],
+        },
+
+        // Owner information for public display
+        OwnerInfo: {
+          type: "object",
+          required: ["id", "walletAddress"],
+          properties: {
+            id: {
+              type: "string",
+              format: "uuid",
+              description: "Owner user ID",
+            },
+                      name: {
+            oneOf: [
+              { type: "string" },
+              { type: "null" }
+            ],
+            description: "Owner display name",
+          },
+            walletAddress: {
+              type: "string",
+              description: "Owner wallet address",
+            },
+                      email: {
+            oneOf: [
+              { type: "string", format: "email" },
+              { type: "null" }
+            ],
+            description: "Owner email",
+          },
+          imageUrl: {
+            oneOf: [
+              { type: "string" },
+              { type: "null" }
+            ],
+            description: "Owner profile image URL",
+          },
+          metadata: {
+            oneOf: [
+              { type: "object" },
+              { type: "null" }
+            ],
+            description: "Owner metadata",
+          },
+            status: {
+              $ref: "#/components/schemas/ActorStatus",
+            },
+            createdAt: {
+              type: "string",
+              format: "date-time",
+              description: "Owner account creation timestamp",
+            },
+            updatedAt: {
+              type: "string",
+              format: "date-time",
+              description: "Owner account last update timestamp",
+            },
+          },
+        },
+
+        // Agent with owner information
+        AgentWithOwner: {
+          allOf: [
+            {
+              $ref: "#/components/schemas/AgentWithMetrics",
+            },
+            {
+              type: "object",
+              required: ["owner"],
+              properties: {
+                owner: {
+                  oneOf: [
+                    {
+                      $ref: "#/components/schemas/OwnerInfo",
+                    },
+                    {
+                      type: "null",
+                    },
+                  ],
+                  description: "Owner information (null if not found)",
+                },
+              },
+            },
+          ],
+        },
+
+        // Enhanced balance with chain information
+        Balance: {
+          type: "object",
+          required: ["tokenAddress", "amount", "symbol", "chain"],
+          properties: {
+            tokenAddress: {
+              type: "string",
+              description: "Token contract address",
+            },
+            amount: {
+              type: "number",
+              description: "Token balance amount",
+            },
+            symbol: {
+              type: "string",
+              description: "Token symbol",
+            },
+            chain: {
+              $ref: "#/components/schemas/BlockchainType",
+            },
+            specificChain: {
+              $ref: "#/components/schemas/SpecificChain",
+            },
+          },
+        },
+
+        // Complete trade schema matching database structure
+        Trade: {
+          type: "object",
+          required: [
+            "id", "agentId", "competitionId", "fromToken", "toToken",
+            "fromAmount", "toAmount", "price", "tradeAmountUsd",
+            "toTokenSymbol", "fromTokenSymbol", "success", "reason", "timestamp"
+          ],
+          properties: {
+            id: {
+              type: "string",
+              format: "uuid",
               description: "Unique trade ID",
             },
             agentId: {
               type: "string",
+              format: "uuid",
               description: "Agent ID that executed the trade",
             },
             competitionId: {
               type: "string",
+              format: "uuid",
               description: "ID of the competition this trade is part of",
             },
             fromToken: {
               type: "string",
-              description: "Token address that was sold",
+              description: "Source token address",
             },
             toToken: {
               type: "string",
-              description: "Token address that was bought",
+              description: "Destination token address",
             },
             fromAmount: {
               type: "number",
-              description: "Amount of fromToken that was sold",
+              description: "Amount of source token traded",
             },
             toAmount: {
               type: "number",
-              description: "Amount of toToken that was received",
+              description: "Amount of destination token received",
             },
             price: {
               type: "number",
-              description: "Price at which the trade was executed",
+              description: "Exchange rate (toAmount/fromAmount)",
+            },
+            tradeAmountUsd: {
+              type: "number",
+              description: "USD value of the trade at execution time",
+            },
+            toTokenSymbol: {
+              type: "string",
+              description: "Symbol of the destination token",
+            },
+            fromTokenSymbol: {
+              type: "string",
+              description: "Symbol of the source token",
             },
             success: {
               type: "boolean",
               description: "Whether the trade was successfully completed",
             },
             error: {
-              type: "string",
+              oneOf: [
+                { type: "string" },
+                { type: "null" }
+              ],
               description: "Error message if the trade failed",
+            },
+            reason: {
+              type: "string",
+              description: "Reason for executing the trade",
             },
             timestamp: {
               type: "string",
               format: "date-time",
-              description: "Timestamp of when the trade was executed",
+              description: "When the trade was executed",
             },
             fromChain: {
-              type: "string",
-              description: "Blockchain type of the source token",
+              $ref: "#/components/schemas/BlockchainType",
             },
             toChain: {
-              type: "string",
-              description: "Blockchain type of the destination token",
+              $ref: "#/components/schemas/BlockchainType",
             },
             fromSpecificChain: {
-              type: "string",
+              oneOf: [
+                { $ref: "#/components/schemas/SpecificChain" },
+                { type: "null" }
+              ],
               description: "Specific chain for the source token",
             },
             toSpecificChain: {
-              type: "string",
+              oneOf: [
+                { $ref: "#/components/schemas/SpecificChain" },
+                { type: "null" }
+              ],
               description: "Specific chain for the destination token",
             },
           },
         },
-        TokenBalance: {
+
+        // Portfolio token value
+        PortfolioTokenValue: {
           type: "object",
+          required: ["token", "amount", "price", "value", "chain", "symbol"],
           properties: {
             token: {
               type: "string",
@@ -178,15 +582,231 @@ For convenience, we provide an API client that handles authentication automatica
             },
             amount: {
               type: "number",
-              description: "Token balance amount",
+              description: "Token amount held",
+            },
+            price: {
+              type: "number",
+              description: "Token price in USD",
+            },
+            value: {
+              type: "number",
+              description: "Token value in USD (amount * price)",
             },
             chain: {
-              type: "string",
-              description: "Chain the token belongs to",
+              $ref: "#/components/schemas/BlockchainType",
             },
             specificChain: {
+              oneOf: [
+                { $ref: "#/components/schemas/SpecificChain" },
+                { type: "null" }
+              ],
+              description: "Specific chain identifier",
+            },
+            symbol: {
               type: "string",
-              description: "Specific chain for EVM tokens",
+              description: "Token symbol",
+            },
+          },
+        },
+
+        // Portfolio response (conditional fields based on source)
+        Portfolio: {
+          type: "object",
+          required: ["success", "agentId", "totalValue", "tokens", "source"],
+          properties: {
+            success: {
+              type: "boolean",
+              example: true,
+            },
+            agentId: {
+              type: "string",
+              format: "uuid",
+              description: "Agent ID",
+            },
+            totalValue: {
+              type: "number",
+              description: "Total portfolio value in USD",
+            },
+            tokens: {
+              type: "array",
+              items: {
+                $ref: "#/components/schemas/PortfolioTokenValue",
+              },
+              description: "Token holdings with values",
+            },
+            source: {
+              type: "string",
+              enum: ["snapshot", "live-calculation"],
+              description: "Data source for portfolio calculation",
+            },
+            snapshotTime: {
+              type: "string",
+              format: "date-time",
+              description: "Time of snapshot (only present if source is snapshot)",
+            },
+          },
+        },
+
+        // Basic competition schema
+        Competition: {
+          type: "object",
+          required: ["id", "name", "status", "type", "sandboxMode", "createdAt"],
+          properties: {
+            id: {
+              type: "string",
+              format: "uuid",
+              description: "Competition unique identifier",
+            },
+            name: {
+              type: "string",
+              description: "Competition name",
+            },
+            description: {
+              oneOf: [
+                { type: "string" },
+                { type: "null" }
+              ],
+              description: "Competition description",
+            },
+            type: {
+              $ref: "#/components/schemas/CompetitionType",
+            },
+            externalUrl: {
+              oneOf: [
+                { type: "string" },
+                { type: "null" }
+              ],
+              description: "External URL for competition details",
+            },
+            imageUrl: {
+              oneOf: [
+                { type: "string" },
+                { type: "null" }
+              ],
+              description: "URL to competition image",
+            },
+            startDate: {
+              oneOf: [
+                { type: "string", format: "date-time" },
+                { type: "null" }
+              ],
+              description: "Competition start date",
+            },
+            endDate: {
+              oneOf: [
+                { type: "string", format: "date-time" },
+                { type: "null" }
+              ],
+              description: "Competition end date",
+            },
+            votingStartDate: {
+              oneOf: [
+                { type: "string", format: "date-time" },
+                { type: "null" }
+              ],
+              description: "Voting start date",
+            },
+            votingEndDate: {
+              oneOf: [
+                { type: "string", format: "date-time" },
+                { type: "null" }
+              ],
+              description: "Voting end date",
+            },
+            status: {
+              $ref: "#/components/schemas/CompetitionStatus",
+            },
+            crossChainTradingType: {
+              $ref: "#/components/schemas/CrossChainTradingType",
+            },
+            sandboxMode: {
+              type: "boolean",
+              description: "Whether sandbox mode is enabled",
+            },
+            createdAt: {
+              type: "string",
+              format: "date-time",
+              description: "Competition creation timestamp",
+            },
+            updatedAt: {
+              oneOf: [
+                { type: "string", format: "date-time" },
+                { type: "null" }
+              ],
+              description: "Last update timestamp",
+            },
+          },
+        },
+
+        // Enhanced competition with agent-specific metrics
+        EnhancedCompetition: {
+          allOf: [
+            {
+              $ref: "#/components/schemas/Competition",
+            },
+            {
+              type: "object",
+              required: ["portfolioValue", "pnl", "pnlPercent", "totalTrades"],
+              properties: {
+                portfolioValue: {
+                  type: "number",
+                  description: "Agent's portfolio value in this competition",
+                },
+                pnl: {
+                  type: "number",
+                  description: "Agent's profit/loss in USD",
+                },
+                pnlPercent: {
+                  type: "number",
+                  description: "Agent's profit/loss percentage",
+                },
+                totalTrades: {
+                  type: "integer",
+                  description: "Number of trades by agent in this competition",
+                },
+                bestPlacement: {
+                  oneOf: [
+                    {
+                      type: "object",
+                      properties: {
+                        rank: {
+                          type: "integer",
+                        },
+                        totalAgents: {
+                          type: "integer",
+                        },
+                      },
+                    },
+                    {
+                      type: "null",
+                    },
+                  ],
+                },
+              },
+            },
+          ],
+        },
+
+        // Pagination metadata
+        PaginationMeta: {
+          type: "object",
+          required: ["total", "limit", "offset", "hasMore"],
+          properties: {
+            total: {
+              type: "integer",
+              description: "Total number of items",
+            },
+            limit: {
+              type: "integer",
+              description: "Maximum items per page",
+            },
+            offset: {
+              type: "integer",
+              description: "Number of items skipped",
+            },
+            hasMore: {
+              type: "boolean",
+              description: "Whether there are more items available",
             },
           },
         },

--- a/apps/api/src/routes/agent.routes.ts
+++ b/apps/api/src/routes/agent.routes.ts
@@ -26,73 +26,33 @@ export function configureAgentRoutes(agentController: AgentController): Router {
    *         content:
    *           application/json:
    *             schema:
-   *               type: object
-   *               properties:
-   *                 success:
-   *                   type: boolean
-   *                   example: true
-   *                 agent:
-   *                   type: object
+   *               allOf:
+   *                 - $ref: '#/components/schemas/SuccessResponse'
+   *                 - type: object
+   *                   required: [agent, owner]
    *                   properties:
-   *                     id:
-   *                       type: string
-   *                       format: uuid
-   *                     ownerId:
-   *                       type: string
-   *                       format: uuid
-   *                     walletAddress:
-   *                       type: string
-   *                       example: "0x1234567890abcdef1234567890abcdef12345678"
-   *                     isVerified:
-   *                       type: boolean
-   *                     name:
-   *                       type: string
-   *                       example: "Trading Bot Alpha"
-   *                     description:
-   *                       type: string
-   *                       example: "AI agent focusing on DeFi yield farming"
-   *                     imageUrl:
-   *                       type: string
-   *                       example: "https://example.com/bot-avatar.jpg"
-   *                       nullable: true
-   *                     email:
-   *                       type: string
-   *                       example: "tradingbot@example.com"
-   *                       nullable: true
-   *                     status:
-   *                       type: string
-   *                       enum: [active, inactive, suspended, deleted]
-   *                     metadata:
-   *                       type: object
-   *                       description: Optional metadata for the agent
-   *                       example: { "strategy": "yield-farming", "risk": "medium" }
-   *                       nullable: true
-   *                     createdAt:
-   *                       type: string
-   *                       format: date-time
-   *                     updatedAt:
-   *                       type: string
-   *                       format: date-time
-   *                 owner:
-   *                   type: object
-   *                   properties:
-   *                     id:
-   *                       type: string
-   *                       format: uuid
-   *                     walletAddress:
-   *                       type: string
-   *                     name:
-   *                       type: string
-   *                     email:
-   *                       type: string
-   *                     imageUrl:
-   *                       type: string
+   *                     agent:
+   *                       $ref: '#/components/schemas/AgentPublic'
+   *                     owner:
+   *                       $ref: '#/components/schemas/OwnerInfo'
    *       401:
    *         description: Agent not authenticated
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/Error'
    *       404:
    *         description: Agent or owner not found
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/Error'
    *       500:
    *         description: Internal server error
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/Error'
    */
   router.get("/profile", agentController.getProfile);
 
@@ -132,54 +92,37 @@ export function configureAgentRoutes(agentController: AgentController): Router {
    *         content:
    *           application/json:
    *             schema:
-   *               type: object
-   *               properties:
-   *                 success:
-   *                   type: boolean
-   *                   example: true
-   *                 agent:
-   *                   type: object
+   *               allOf:
+   *                 - $ref: '#/components/schemas/SuccessResponse'
+   *                 - type: object
+   *                   required: [agent]
    *                   properties:
-   *                     id:
-   *                       type: string
-   *                       format: uuid
-   *                     ownerId:
-   *                       type: string
-   *                       format: uuid
-   *                     walletAddress:
-   *                       type: string
-   *                     isVerified:
-   *                       type: boolean
-   *                     name:
-   *                       type: string
-   *                     description:
-   *                       type: string
-   *                       nullable: true
-   *                     imageUrl:
-   *                       type: string
-   *                       nullable: true
-   *                     email:
-   *                       type: string
-   *                       nullable: true
-   *                     status:
-   *                       type: string
-   *                     metadata:
-   *                       type: object
-   *                       nullable: true
-   *                     createdAt:
-   *                       type: string
-   *                       format: date-time
-   *                     updatedAt:
-   *                       type: string
-   *                       format: date-time
+   *                     agent:
+   *                       $ref: '#/components/schemas/AgentPublic'
    *       400:
    *         description: Invalid fields provided (agents can only update name, description, and imageUrl)
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/Error'
    *       401:
    *         description: Agent not authenticated
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/Error'
    *       404:
    *         description: Agent not found
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/Error'
    *       500:
    *         description: Internal server error
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/Error'
    */
   router.put("/profile", agentController.updateProfile);
 
@@ -199,38 +142,31 @@ export function configureAgentRoutes(agentController: AgentController): Router {
    *         content:
    *           application/json:
    *             schema:
-   *               type: object
-   *               properties:
-   *                 success:
-   *                   type: boolean
-   *                   example: true
-   *                 agentId:
-   *                   type: string
-   *                   format: uuid
-   *                 balances:
-   *                   type: array
-   *                   items:
-   *                     type: object
-   *                     properties:
-   *                       tokenAddress:
-   *                         type: string
-   *                         example: "0x1234567890abcdef1234567890abcdef12345678"
-   *                       amount:
-   *                         type: number
-   *                         example: 100.5
-   *                       symbol:
-   *                         type: string
-   *                         example: "USDC"
-   *                       chain:
-   *                         type: string
-   *                         enum: [evm, svm]
-   *                       specificChain:
-   *                         type: string
-   *                         example: "svm"
+   *               allOf:
+   *                 - $ref: '#/components/schemas/SuccessResponse'
+   *                 - type: object
+   *                   required: [agentId, balances]
+   *                   properties:
+   *                     agentId:
+   *                       type: string
+   *                       format: uuid
+   *                       description: Agent ID
+   *                     balances:
+   *                       type: array
+   *                       items:
+   *                         $ref: '#/components/schemas/Balance'
    *       401:
    *         description: Agent not authenticated
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/Error'
    *       500:
    *         description: Internal server error
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/Error'
    */
   router.get("/balances", agentController.getBalances);
 
@@ -239,7 +175,14 @@ export function configureAgentRoutes(agentController: AgentController): Router {
    * /api/agent/portfolio:
    *   get:
    *     summary: Get agent portfolio
-   *     description: Retrieve portfolio information including total value and token breakdown for the authenticated agent
+   *     description: |
+   *       Retrieve portfolio information including total value and token breakdown for the authenticated agent.
+   *       
+   *       The response includes a `source` field that indicates how the portfolio was calculated:
+   *       - `snapshot`: Data from a pre-calculated portfolio snapshot (faster, may be slightly outdated)
+   *       - `live-calculation`: Real-time calculation based on current balances and prices (slower, always current)
+   *       
+   *       When `source` is `snapshot`, a `snapshotTime` field indicates when the snapshot was taken.
    *     tags:
    *       - Agent
    *     security:
@@ -250,60 +193,19 @@ export function configureAgentRoutes(agentController: AgentController): Router {
    *         content:
    *           application/json:
    *             schema:
-   *               type: object
-   *               properties:
-   *                 success:
-   *                   type: boolean
-   *                   example: true
-   *                 agentId:
-   *                   type: string
-   *                   format: uuid
-   *                 totalValue:
-   *                   type: number
-   *                   description: Total portfolio value in USD
-   *                   example: 1250.75
-   *                 tokens:
-   *                   type: array
-   *                   items:
-   *                     type: object
-   *                     properties:
-   *                       token:
-   *                         type: string
-   *                         description: Token address
-   *                         example: "0x1234567890abcdef1234567890abcdef12345678"
-   *                       amount:
-   *                         type: number
-   *                         description: Token amount
-   *                         example: 100.5
-   *                       price:
-   *                         type: number
-   *                         description: Token price in USD
-   *                         example: 1.0
-   *                       value:
-   *                         type: number
-   *                         description: Token value in USD
-   *                         example: 100.5
-   *                       chain:
-   *                         type: string
-   *                         enum: [evm, svm]
-   *                       specificChain:
-   *                         type: string
-   *                         example: "svm"
-   *                       symbol:
-   *                         type: string
-   *                         example: "USDC"
-   *                 source:
-   *                   type: string
-   *                   description: Data source (snapshot or live-calculation)
-   *                   enum: [snapshot, live-calculation]
-   *                 snapshotTime:
-   *                   type: string
-   *                   format: date-time
-   *                   description: Time of snapshot (only present if source is snapshot)
+   *               $ref: '#/components/schemas/Portfolio'
    *       401:
    *         description: Agent not authenticated
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/Error'
    *       500:
    *         description: Internal server error
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/Error'
    */
   router.get("/portfolio", agentController.getPortfolio);
 
@@ -312,7 +214,7 @@ export function configureAgentRoutes(agentController: AgentController): Router {
    * /api/agent/trades:
    *   get:
    *     summary: Get agent trade history
-   *     description: Retrieve the trading history for the authenticated agent
+   *     description: Retrieve the trading history for the authenticated agent, sorted by timestamp (newest first)
    *     tags:
    *       - Agent
    *     security:
@@ -323,90 +225,31 @@ export function configureAgentRoutes(agentController: AgentController): Router {
    *         content:
    *           application/json:
    *             schema:
-   *               type: object
-   *               properties:
-   *                 success:
-   *                   type: boolean
-   *                   example: true
-   *                 agentId:
-   *                   type: string
-   *                   format: uuid
-   *                 trades:
-   *                   type: array
-   *                   items:
-   *                     type: object
-   *                     properties:
-   *                       id:
-   *                         type: string
-   *                         format: uuid
-   *                       agentId:
-   *                         type: string
-   *                         format: uuid
-   *                       competitionId:
-   *                         type: string
-   *                         format: uuid
-   *                       fromToken:
-   *                         type: string
-   *                         description: Source token address
-   *                       toToken:
-   *                         type: string
-   *                         description: Destination token address
-   *                       fromAmount:
-   *                         type: number
-   *                         description: Amount traded from source token
-   *                       toAmount:
-   *                         type: number
-   *                         description: Amount received in destination token
-   *                       price:
-   *                         type: number
-   *                         description: Price at which the trade was executed
-   *                       tradeAmountUsd:
-   *                         type: number
-   *                         description: USD value of the trade at execution time
-   *                       toTokenSymbol:
-   *                         type: string
-   *                         description: Symbol of the destination token
-   *                         example: "USDC"
-   *                       fromTokenSymbol:
-   *                         type: string
-   *                         description: Symbol of the source token
-   *                         example: "SOL"
-   *                       success:
-   *                         type: boolean
-   *                         description: Whether the trade was successfully completed
-   *                       error:
-   *                         type: string
-   *                         description: Error message if the trade failed
-   *                         nullable: true
-   *                       reason:
-   *                         type: string
-   *                         description: Reason for the trade
-   *                       timestamp:
-   *                         type: string
-   *                         format: date-time
-   *                         description: When the trade was executed
-   *                       fromChain:
-   *                         type: string
-   *                         description: Blockchain type of the source token
-   *                         example: "evm"
-   *                       toChain:
-   *                         type: string
-   *                         description: Blockchain type of the destination token
-   *                         example: "svm"
-   *                       fromSpecificChain:
-   *                         type: string
-   *                         description: Specific chain for the source token
-   *                         example: "polygon"
-   *                         nullable: true
-   *                       toSpecificChain:
-   *                         type: string
-   *                         description: Specific chain for the destination token
-   *                         example: "svm"
-   *                         nullable: true
+   *               allOf:
+   *                 - $ref: '#/components/schemas/SuccessResponse'
+   *                 - type: object
+   *                   required: [agentId, trades]
+   *                   properties:
+   *                     agentId:
+   *                       type: string
+   *                       format: uuid
+   *                       description: Agent ID
+   *                     trades:
+   *                       type: array
+   *                       items:
+   *                         $ref: '#/components/schemas/Trade'
    *       401:
    *         description: Agent not authenticated
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/Error'
    *       500:
    *         description: Internal server error
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/Error'
    */
   router.get("/trades", agentController.getTrades);
 
@@ -426,19 +269,27 @@ export function configureAgentRoutes(agentController: AgentController): Router {
    *         content:
    *           application/json:
    *             schema:
-   *               type: object
-   *               properties:
-   *                 success:
-   *                   type: boolean
-   *                   example: true
-   *                 apiKey:
-   *                   type: string
-   *                   description: The new API key (store this securely)
-   *                   example: "1234567890abcdef_fedcba0987654321"
+   *               allOf:
+   *                 - $ref: '#/components/schemas/SuccessResponse'
+   *                 - type: object
+   *                   required: [apiKey]
+   *                   properties:
+   *                     apiKey:
+   *                       type: string
+   *                       description: The new API key (store this securely)
+   *                       example: "1234567890abcdef_fedcba0987654321"
    *       401:
    *         description: Agent not authenticated
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/Error'
    *       500:
    *         description: Internal server error
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/Error'
    */
   router.post("/reset-api-key", agentController.resetApiKey);
 

--- a/apps/api/src/routes/trade.routes.ts
+++ b/apps/api/src/routes/trade.routes.ts
@@ -55,102 +55,50 @@ export function configureTradeRoutes(
    *                 description: Optional slippage tolerance in percentage
    *                 example: "0.5"
    *               fromChain:
-   *                 type: string
-   *                 description: Optional - Blockchain type for fromToken
-   *                 example: "svm"
+   *                 $ref: '#/components/schemas/BlockchainType'
    *               fromSpecificChain:
-   *                 type: string
-   *                 description: Optional - Specific chain for fromToken
-   *                 example: "mainnet"
+   *                 $ref: '#/components/schemas/SpecificChain'
    *               toChain:
-   *                 type: string
-   *                 description: Optional - Blockchain type for toToken
-   *                 example: "svm"
+   *                 $ref: '#/components/schemas/BlockchainType'
    *               toSpecificChain:
-   *                 type: string
-   *                 description: Optional - Specific chain for toToken
-   *                 example: "mainnet"
+   *                 $ref: '#/components/schemas/SpecificChain'
    *     responses:
    *       200:
    *         description: Trade executed successfully
    *         content:
    *           application/json:
    *             schema:
-   *               type: object
-   *               properties:
-   *                 success:
-   *                   type: boolean
-   *                   description: Whether the trade was successfully executed
-   *                 transaction:
-   *                   type: object
+   *               allOf:
+   *                 - $ref: '#/components/schemas/SuccessResponse'
+   *                 - type: object
+   *                   required: [transaction]
    *                   properties:
-   *                     id:
-   *                       type: string
-   *                       description: Unique trade ID
-   *                     agentId:
-   *                       type: string
-   *                       description: Agent ID that executed the trade
-   *                     competitionId:
-   *                       type: string
-   *                       description: ID of the competition this trade is part of
-   *                     fromToken:
-   *                       type: string
-   *                       description: Token address that was sold
-   *                     toToken:
-   *                       type: string
-   *                       description: Token address that was bought
-   *                     fromAmount:
-   *                       type: number
-   *                       description: Amount of fromToken that was sold
-   *                     toAmount:
-   *                       type: number
-   *                       description: Amount of toToken that was received
-   *                     price:
-   *                       type: number
-   *                       description: Price at which the trade was executed
-   *                     success:
-   *                       type: boolean
-   *                       description: Whether the trade was successfully completed
-   *                     error:
-   *                       type: string
-   *                       nullable: true
-   *                       description: Error message if the trade failed
-   *                     reason:
-   *                       type: string
-   *                       description: Reason provided for executing the trade
-   *                     tradeAmountUsd:
-   *                       type: number
-   *                       description: The USD value of the trade at execution time
-   *                     timestamp:
-   *                       type: string
-   *                       format: date-time
-   *                       description: Timestamp of when the trade was executed
-   *                     fromChain:
-   *                       type: string
-   *                       description: Blockchain type of the source token
-   *                     toChain:
-   *                       type: string
-   *                       description: Blockchain type of the destination token
-   *                     fromSpecificChain:
-   *                       type: string
-   *                       description: Specific chain for the source token
-   *                     toSpecificChain:
-   *                       type: string
-   *                       description: Specific chain for the destination token
-   *                     toTokenSymbol:
-   *                       type: string
-   *                       description: Symbol of the destination token
-   *                     fromTokenSymbol:
-   *                       type: string
-   *                       description: Symbol of the source token
+   *                     transaction:
+   *                       $ref: '#/components/schemas/Trade'
    *       400:
    *         description: Invalid input parameters
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/Error'
    *       401:
    *         description: Unauthorized - Missing or invalid authentication
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/Error'
    *       403:
    *         description: Forbidden - Competition not in progress or other restrictions
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/Error'
    *       500:
    *         description: Server error
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/Error'
    */
   router.post("/execute", controller.executeTrade);
 
@@ -189,31 +137,27 @@ export function configureTradeRoutes(
    *       - in: query
    *         name: fromChain
    *         schema:
-   *           type: string
+   *           $ref: '#/components/schemas/BlockchainType'
    *         required: false
    *         description: Optional blockchain type for fromToken
-   *         example: svm
    *       - in: query
    *         name: fromSpecificChain
    *         schema:
-   *           type: string
+   *           $ref: '#/components/schemas/SpecificChain'
    *         required: false
    *         description: Optional specific chain for fromToken
-   *         example: mainnet
    *       - in: query
    *         name: toChain
    *         schema:
-   *           type: string
+   *           $ref: '#/components/schemas/BlockchainType'
    *         required: false
    *         description: Optional blockchain type for toToken
-   *         example: svm
    *       - in: query
    *         name: toSpecificChain
    *         schema:
-   *           type: string
+   *           $ref: '#/components/schemas/SpecificChain'
    *         required: false
    *         description: Optional specific chain for toToken
-   *         example: mainnet
    *     responses:
    *       200:
    *         description: Quote generated successfully
@@ -221,6 +165,7 @@ export function configureTradeRoutes(
    *           application/json:
    *             schema:
    *               type: object
+   *               required: [fromToken, toToken, fromAmount, toAmount, exchangeRate, slippage, tradeAmountUsd, prices, symbols, chains]
    *               properties:
    *                 fromToken:
    *                   type: string
@@ -245,6 +190,7 @@ export function configureTradeRoutes(
    *                   description: Estimated USD value of the trade
    *                 prices:
    *                   type: object
+   *                   required: [fromToken, toToken]
    *                   properties:
    *                     fromToken:
    *                       type: number
@@ -254,6 +200,7 @@ export function configureTradeRoutes(
    *                       description: Price of the destination token in USD
    *                 symbols:
    *                   type: object
+   *                   required: [fromTokenSymbol, toTokenSymbol]
    *                   properties:
    *                     fromTokenSymbol:
    *                       type: string
@@ -263,19 +210,30 @@ export function configureTradeRoutes(
    *                       description: Symbol of the destination token
    *                 chains:
    *                   type: object
+   *                   required: [fromChain, toChain]
    *                   properties:
    *                     fromChain:
-   *                       type: string
-   *                       description: Blockchain type of the source token
+   *                       $ref: '#/components/schemas/BlockchainType'
    *                     toChain:
-   *                       type: string
-   *                       description: Blockchain type of the destination token
+   *                       $ref: '#/components/schemas/BlockchainType'
    *       400:
    *         description: Invalid input parameters
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/Error'
    *       401:
    *         description: Unauthorized - Missing or invalid authentication
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/Error'
    *       500:
    *         description: Server error
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/Error'
    */
   router.get("/quote", controller.getQuote);
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -150,6 +150,12 @@ importers:
       '@types/uuid':
         specifier: ^9.0.1
         version: 9.0.8
+      ajv:
+        specifier: ^8.17.1
+        version: 8.17.1
+      ajv-formats:
+        specifier: ^3.0.1
+        version: 3.0.1(ajv@8.17.1)
       axios-cookiejar-support:
         specifier: ^6.0.2
         version: 6.0.2(axios@1.9.0)(tough-cookie@5.1.2)
@@ -4424,8 +4430,19 @@ packages:
       react:
         optional: true
 
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
+
+  ajv@8.17.1:
+    resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==}
 
   ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
@@ -5656,6 +5673,9 @@ packages:
   fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
 
+  fast-uri@3.0.6:
+    resolution: {integrity: sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==}
+
   fast-xml-parser@4.4.1:
     resolution: {integrity: sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==}
     hasBin: true
@@ -6373,6 +6393,9 @@ packages:
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
   json-schema@0.4.0:
     resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
@@ -7868,6 +7891,10 @@ packages:
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
   require-main-filename@2.0.0:
@@ -13610,12 +13637,23 @@ snapshots:
     optionalDependencies:
       react: 19.1.0
 
+  ajv-formats@3.0.1(ajv@8.17.1):
+    optionalDependencies:
+      ajv: 8.17.1
+
   ajv@6.12.6:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
+
+  ajv@8.17.1:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.0.6
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
 
   ansi-colors@4.1.3: {}
 
@@ -14986,6 +15024,8 @@ snapshots:
 
   fast-safe-stringify@2.1.1: {}
 
+  fast-uri@3.0.6: {}
+
   fast-xml-parser@4.4.1:
     dependencies:
       strnum: 1.1.2
@@ -15753,6 +15793,8 @@ snapshots:
   json-rpc-random-id@1.0.1: {}
 
   json-schema-traverse@0.4.1: {}
+
+  json-schema-traverse@1.0.0: {}
 
   json-schema@0.4.0: {}
 
@@ -17256,6 +17298,8 @@ snapshots:
   relative-time-format@1.1.6: {}
 
   require-directory@2.1.1: {}
+
+  require-from-string@2.0.2: {}
 
   require-main-filename@2.0.0: {}
 


### PR DESCRIPTION
Validated and fixed OpenAPI spec definitions by introducing shared schemas and correcting nullable field definitions for improved accuracy and maintainability.

The previous OpenAPI spec had inconsistencies, particularly with `nullable` fields not conforming to OpenAPI 3.0 standards and a lack of reusable schema definitions. This PR addresses these issues by creating comprehensive shared schemas and updating route definitions to use them, along with implementing a validation script to ensure ongoing compliance.

Closes https://github.com/recallnet/js-recall/issues/798.