### PR TITLE
fix(api): add multi-origin CORS support for docs.recall.network

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -4,6 +4,7 @@ NODE_ENV=development
 
 # Frontend Configuration
 FRONTEND_URL=http://localhost:3001 # Enable CORS
+CORS_ORIGINS= # Optional: Comma-separated list of allowed CORS origins (overrides FRONTEND_URL if set)
 DOMAIN=.example.com # Cross-subdomain cookies (only set in production mode)
 SESSION_TTL=7200 # Session expiry (defaults to 2 hours)
 COOKIE_NAME=session # Session cookie name (defaults to `session`)

--- a/apps/api/.env.sandbox
+++ b/apps/api/.env.sandbox
@@ -4,6 +4,7 @@ NODE_ENV=sandbox
 
 # Frontend Configuration
 FRONTEND_URL=http://localhost:3001 # Enable CORS
+CORS_ORIGINS=https://register.recall.network,https://docs.recall.network # Comma-separated list of allowed CORS origins
 DOMAIN=.example.com # Cross-subdomain cookies (only set in production mode)
 SESSION_TLL=7200 # Session expiry (defaults to 2 hours)
 COOKIE_NAME=session # Session cookie name (defaults to `session`)

--- a/apps/api/src/config/index.ts
+++ b/apps/api/src/config/index.ts
@@ -161,6 +161,9 @@ export const config = {
   // Frontend app configuration for interfacing with the server
   app: {
     url: process.env.FRONTEND_URL || "http://localhost:3001", // TODO: resolve frontend/backend default ports
+    corsOrigins: process.env.CORS_ORIGINS
+      ? process.env.CORS_ORIGINS.split(",").map(origin => origin.trim())
+      : [process.env.FRONTEND_URL || "http://localhost:3001"],
     domain: process.env.DOMAIN,
     cookieName: process.env.COOKIE_NAME || "session",
     sessionPassword:

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -87,7 +87,7 @@ app.set("trust proxy", true);
 
 app.use(
   cors({
-    origin: config.app.url,
+    origin: config.app.corsOrigins,
     credentials: true,
     methods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
     allowedHeaders: ["Content-Type", "Authorization"],


### PR DESCRIPTION
## Problem

The Swagger-based API documentation at `https://docs.recall.network/api-reference/endpoints/trade` was failing because the sandbox API server (`api.sandbox.competitions.recall.network`) only allows CORS requests from `register.recall.network`, not from the docs domain.

**Root Cause**: Commit a146e57 added restrictive CORS configuration that only accepts `config.app.url` (set via `FRONTEND_URL`), which currently points to the registration portal.

## Solution

This PR adds support for multiple CORS origins while maintaining backward compatibility:

- **New `CORS_ORIGINS` environment variable**: Accepts comma-separated list of allowed origins
- **Backward compatibility**: Falls back to `FRONTEND_URL` if `CORS_ORIGINS` is not set
- **Updated sandbox config**: Includes both `register.recall.network` and `docs.recall.network`

## Changes

- `apps/api/src/config/index.ts`: Add `corsOrigins` array configuration
- `apps/api/src/index.ts`: Update CORS middleware to accept multiple origins
- `apps/api/.env.sandbox`: Add `CORS_ORIGINS` with both domains
- `apps/api/.env.example`: Document new environment variable

## Alternative Approaches

This is one possible solution among several approaches. Y'all may rather:
- Different environment variable naming/structure
- Server-side configuration instead of environment variables  
- Different CORS handling strategy
- Infrastructure-level CORS configuration

Feel free to modify this approach or close this PR if a different solution is preferred!

## Testing

After deployment, the docs site should be able to successfully make API calls to test endpoints.