### PR TITLE
fix: optimize portfolio snapshot type for trades and req fallback

### DIFF
--- a/apps/api/src/controllers/agent.controller.ts
+++ b/apps/api/src/controllers/agent.controller.ts
@@ -379,9 +379,9 @@ export function makeAgentController(services: ServiceRegistry) {
           console.log(
             `[AgentController] No portfolio snapshots found for agent ${agentId} in competition ${activeCompetition.id}`,
           );
-          // Request a snapshot asynchronously (don't await)
+          // Request a snapshot for this agent asynchronously (don't await)
           services.portfolioSnapshotter
-            .takePortfolioSnapshots(activeCompetition.id)
+            .takePortfolioSnapshotForAgent(activeCompetition.id, agentId)
             .catch((error) => {
               console.error(
                 `[AgentController] Error taking snapshot for agent ${agentId}:`,

--- a/apps/api/src/services/trade-simulator.service.ts
+++ b/apps/api/src/services/trade-simulator.service.ts
@@ -403,17 +403,17 @@ export class TradeSimulator {
                 New ${toToken} Balance: ${await this.balanceManager.getBalance(agentId, toToken)}
             `);
 
-      // Trigger a portfolio snapshot after successful trade execution
+      // Trigger a portfolio snapshot for the trading agent only
       // We run this asynchronously without awaiting to avoid delaying the trade response
       this.portfolioSnapshotter
-        .takePortfolioSnapshots(competitionId)
+        .takePortfolioSnapshotForAgent(competitionId, agentId)
         .catch((error) => {
           console.error(
-            `[TradeSimulator] Error taking portfolio snapshot after trade: ${error.message}`,
+            `[TradeSimulator] Error taking portfolio snapshot for agent ${agentId} after trade: ${error.message}`,
           );
         });
       console.log(
-        `[TradeSimulator] Portfolio snapshot triggered for competition ${competitionId} after trade`,
+        `[TradeSimulator] Portfolio snapshot triggered for agent ${agentId} in competition ${competitionId} after trade`,
       );
 
       return {


### PR DESCRIPTION
# Summary

Portfolio snapshots were being triggered for all agents in a competition in several scenarios where only a single agent's portfolio had actually changed. This created unnecessary database load and API calls that scaled poorly with competition size.

## Changes Made
1. Trade Execution Optimization

- Before: Every trade → snapshot all agents in competition
- After: Every trade → snapshot only the trading agent
- File: apps/api/src/services/trade-simulator.service.ts
- Change: takePortfolioSnapshots() → takePortfolioSnapshotForAgent()

2. Portfolio Request Fallback Optimization

- Before: Agent requests portfolio with no snapshots → snapshot all agents
- After: Agent requests portfolio with no snapshots → snapshot only requesting agent
- File: apps/api/src/controllers/agent.controller.ts
- Change: takePortfolioSnapshots() → takePortfolioSnapshotForAgent()