### PR TITLE
feat: add reset agent api keys script

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -36,6 +36,7 @@
     "setup:admin": "tsx scripts/setup-admin.ts",
     "setup:all": "tsx scripts/setup-everything.ts",
     "register:agent": "tsx scripts/register-agent.ts",
+    "reset:agent:keys": "tsx scripts/reset-all-agent-api-keys.ts",
     "register:user": "tsx scripts/register-user.ts",
     "edit:agent": "tsx scripts/edit-agent.ts",
     "edit:user": "tsx scripts/edit-user.ts",

--- a/apps/api/scripts/reset-all-agent-api-keys.ts
+++ b/apps/api/scripts/reset-all-agent-api-keys.ts
@@ -1,0 +1,244 @@
+/**
+ * Reset All Agent API Keys Script
+ *
+ * This script resets the API keys for all agents in the database.
+ * It connects to a specific database and uses a specific ROOT_ENCRYPTION_KEY.
+ *
+ * Usage:
+ *   cd apps/api && pnpm tsx scripts/reset-all-agent-api-keys.ts
+ *
+ * The script will:
+ * 1. Connect to the specified database
+ * 2. Load all agents from the database
+ * 3. Reset each agent's API key using the AgentManager service
+ * 4. Display the results with new API keys
+ */
+import * as dotenv from "dotenv";
+import * as path from "path";
+
+import { ServiceRegistry } from "@/services/index.js";
+
+// Load environment variables (this will be overridden by the ones we set above)
+dotenv.config({ path: path.resolve(process.cwd(), ".env") });
+
+const services = new ServiceRegistry();
+
+// Colors for console output
+const colors = {
+  red: "\x1b[31m",
+  yellow: "\x1b[33m",
+  green: "\x1b[32m",
+  blue: "\x1b[34m",
+  cyan: "\x1b[36m",
+  magenta: "\x1b[35m",
+  reset: "\x1b[0m",
+};
+
+/**
+ * Reset API keys for all agents
+ */
+async function resetAllAgentApiKeys() {
+  try {
+    console.log(
+      `${colors.cyan}╔════════════════════════════════════════════════════════════════╗${colors.reset}`,
+    );
+    console.log(
+      `${colors.cyan}║                    RESET ALL AGENT API KEYS                    ║${colors.reset}`,
+    );
+    console.log(
+      `${colors.cyan}╚════════════════════════════════════════════════════════════════╝${colors.reset}`,
+    );
+
+    console.log(
+      `\n${colors.yellow}Database: ${process.env.DATABASE_URL}${colors.reset}`,
+    );
+    console.log(
+      `${colors.yellow}Encryption Key: ${process.env.ROOT_ENCRYPTION_KEY?.substring(0, 16)}...${colors.reset}`,
+    );
+
+    // Get all agents from the database
+    console.log(
+      `\n${colors.blue}Loading all agents from database...${colors.reset}`,
+    );
+    const agents = await services.agentManager.getAllAgents();
+
+    if (agents.length === 0) {
+      console.log(
+        `\n${colors.yellow}No agents found in the database.${colors.reset}`,
+      );
+      return;
+    }
+
+    console.log(
+      `\n${colors.green}Found ${agents.length} agent(s) to reset API keys for.${colors.reset}`,
+    );
+
+    // Confirm before proceeding
+    console.log(
+      `\n${colors.yellow}⚠️  WARNING: This will reset API keys for ALL agents!${colors.reset}`,
+    );
+    console.log(
+      `${colors.yellow}   All existing API keys will be invalidated.${colors.reset}`,
+    );
+
+    // For scripts, we'll proceed automatically since this is likely run in a controlled environment
+    // If you want to add a confirmation prompt, uncomment the lines below:
+
+    // const readline = require('readline');
+    // const rl = readline.createInterface({
+    //   input: process.stdin,
+    //   output: process.stdout,
+    // });
+    //
+    // const answer = await new Promise(resolve => {
+    //   rl.question(`\n${colors.cyan}Do you want to proceed? (y/N): ${colors.reset}`, resolve);
+    // });
+    // rl.close();
+    //
+    // if (answer.toLowerCase() !== 'y') {
+    //   console.log(`\n${colors.red}Operation cancelled.${colors.reset}`);
+    //   return;
+    // }
+
+    console.log(
+      `\n${colors.blue}Proceeding to reset API keys for all agents...${colors.reset}`,
+    );
+
+    // Reset API keys for all agents
+    const results = [];
+    let successCount = 0;
+    let errorCount = 0;
+
+    for (let i = 0; i < agents.length; i++) {
+      const agent = agents[i];
+
+      // Check if agent exists (TypeScript safety)
+      if (!agent) {
+        console.log(
+          `${colors.red}✗ Agent at index ${i} is undefined, skipping...${colors.reset}`,
+        );
+        errorCount++;
+        continue;
+      }
+
+      try {
+        console.log(
+          `\n${colors.cyan}[${i + 1}/${agents.length}] Resetting API key for agent: ${agent.name} (${agent.id})${colors.reset}`,
+        );
+
+        const resetResult = await services.agentManager.resetApiKey(agent.id);
+
+        if (resetResult && resetResult.apiKey) {
+          console.log(
+            `${colors.green}✓ Successfully reset API key for ${agent.name}${colors.reset}`,
+          );
+
+          results.push({
+            agentId: agent.id,
+            agentName: agent.name,
+            ownerId: agent.ownerId,
+            newApiKey: resetResult.apiKey,
+            success: true,
+          });
+          successCount++;
+        } else {
+          console.log(
+            `${colors.red}✗ Failed to reset API key for ${agent.name} - No result returned${colors.reset}`,
+          );
+
+          results.push({
+            agentId: agent.id,
+            agentName: agent.name,
+            ownerId: agent.ownerId,
+            newApiKey: null,
+            success: false,
+            error: "No result returned from resetApiKey",
+          });
+          errorCount++;
+        }
+      } catch (error) {
+        console.log(
+          `${colors.red}✗ Failed to reset API key for ${agent.name}: ${error instanceof Error ? error.message : error}${colors.reset}`,
+        );
+
+        results.push({
+          agentId: agent.id,
+          agentName: agent.name,
+          ownerId: agent.ownerId,
+          newApiKey: null,
+          success: false,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        errorCount++;
+      }
+    }
+
+    // Display summary
+    console.log(
+      `\n${colors.cyan}╔════════════════════════════════════════════════════════════════╗${colors.reset}`,
+    );
+    console.log(
+      `${colors.cyan}║                           SUMMARY                              ║${colors.reset}`,
+    );
+    console.log(
+      `${colors.cyan}╚════════════════════════════════════════════════════════════════╝${colors.reset}`,
+    );
+
+    console.log(
+      `\n${colors.green}Successfully reset: ${successCount} agent(s)${colors.reset}`,
+    );
+    console.log(`${colors.red}Failed: ${errorCount} agent(s)${colors.reset}`);
+
+    // Display detailed results
+    console.log(
+      `\n${colors.cyan}╔════════════════════════════════════════════════════════════════╗${colors.reset}`,
+    );
+    console.log(
+      `${colors.cyan}║                      DETAILED RESULTS                          ║${colors.reset}`,
+    );
+    console.log(
+      `${colors.cyan}╚════════════════════════════════════════════════════════════════╝${colors.reset}`,
+    );
+
+    results.forEach((result, index) => {
+      console.log(
+        `\n${colors.cyan}[${index + 1}] Agent: ${result.agentName} (${result.agentId})${colors.reset}`,
+      );
+      console.log(`    Owner ID: ${result.ownerId}`);
+
+      if (result.success) {
+        console.log(`    ${colors.green}✓ Status: SUCCESS${colors.reset}`);
+        console.log(
+          `    ${colors.magenta}New API Key: ${result.newApiKey}${colors.reset}`,
+        );
+      } else {
+        console.log(`    ${colors.red}✗ Status: FAILED${colors.reset}`);
+        console.log(`    ${colors.red}Error: ${result.error}${colors.reset}`);
+      }
+    });
+
+    console.log(
+      `\n${colors.green}API key reset operation completed.${colors.reset}`,
+    );
+
+    if (successCount > 0) {
+      console.log(
+        `\n${colors.yellow}⚠️  IMPORTANT: Save the new API keys above!${colors.reset}`,
+      );
+      console.log(
+        `${colors.yellow}   Old API keys are no longer valid.${colors.reset}`,
+      );
+    }
+  } catch (error) {
+    console.error(
+      `\n${colors.red}Error resetting agent API keys:${colors.reset}`,
+      error instanceof Error ? error.message : error,
+    );
+  } finally {
+    // Exit the process after clean closure
+    process.exit(0);
+  }
+}
+
+// Run the function
+resetAllAgentApiKeys();

--- a/apps/api/scripts/reset-all-agent-api-keys.ts
+++ b/apps/api/scripts/reset-all-agent-api-keys.ts
@@ -11,14 +11,15 @@
  * 1. Connect to the specified database
  * 2. Load all agents from the database
  * 3. Reset each agent's API key using the AgentManager service
- * 4. Display the results with new API keys
+ * 4. Display the results with success/failure counts
  */
 import * as dotenv from "dotenv";
 import * as path from "path";
+import * as readline from "readline";
 
 import { ServiceRegistry } from "@/services/index.js";
 
-// Load environment variables (this will be overridden by the ones we set above)
+// Load environment variables
 dotenv.config({ path: path.resolve(process.cwd(), ".env") });
 
 const services = new ServiceRegistry();
@@ -32,33 +33,199 @@ const colors = {
   cyan: "\x1b[36m",
   magenta: "\x1b[35m",
   reset: "\x1b[0m",
+  bold: "\x1b[1m",
+  dim: "\x1b[2m",
 };
+
+/**
+ * Create a readline interface for user input
+ */
+function createReadlineInterface(): readline.Interface {
+  return readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+}
+
+/**
+ * Ask user for confirmation
+ */
+async function askForConfirmation(): Promise<boolean> {
+  const rl = createReadlineInterface();
+
+  return new Promise((resolve) => {
+    rl.question(
+      `\n${colors.cyan}${colors.bold}Do you want to proceed? (y/N): ${colors.reset}`,
+      (answer) => {
+        rl.close();
+        resolve(answer.toLowerCase() === "y" || answer.toLowerCase() === "yes");
+      },
+    );
+  });
+}
+
+/**
+ * Validate environment setup
+ */
+function validateEnvironment(): boolean {
+  if (!process.env.DATABASE_URL) {
+    console.log(
+      `${colors.red}❌ DATABASE_URL environment variable is required${colors.reset}`,
+    );
+    return false;
+  }
+
+  if (!process.env.ROOT_ENCRYPTION_KEY) {
+    console.log(
+      `${colors.red}❌ ROOT_ENCRYPTION_KEY environment variable is required${colors.reset}`,
+    );
+    return false;
+  }
+
+  return true;
+}
+
+/**
+ * Display script header
+ */
+function displayHeader(): void {
+  console.log(
+    `${colors.cyan}${colors.bold}╔════════════════════════════════════════════════════════════════╗${colors.reset}`,
+  );
+  console.log(
+    `${colors.cyan}${colors.bold}║                    RESET ALL AGENT API KEYS                    ║${colors.reset}`,
+  );
+  console.log(
+    `${colors.cyan}${colors.bold}╚════════════════════════════════════════════════════════════════╝${colors.reset}`,
+  );
+}
+
+/**
+ * Display environment status
+ */
+function displayEnvironmentStatus(): void {
+  console.log(
+    `\n${colors.green}✓ Database connection configured${colors.reset}`,
+  );
+  console.log(`${colors.green}✓ Encryption key configured${colors.reset}`);
+}
+
+/**
+ * Display progress bar
+ */
+function displayProgress(
+  current: number,
+  total: number,
+  agentName: string,
+): void {
+  const percentage = Math.round((current / total) * 100);
+  const progressBar =
+    "█".repeat(Math.round(percentage / 5)) +
+    "░".repeat(20 - Math.round(percentage / 5));
+
+  console.log(
+    `\n${colors.cyan}[${current}/${total}] ${colors.bold}${agentName}${colors.reset}`,
+  );
+  console.log(`${colors.dim}${progressBar} ${percentage}%${colors.reset}`);
+}
+
+/**
+ * Display summary
+ */
+function displaySummary(
+  successCount: number,
+  errorCount: number,
+  total: number,
+): void {
+  console.log(
+    `\n${colors.cyan}${colors.bold}╔════════════════════════════════════════════════════════════════╗${colors.reset}`,
+  );
+  console.log(
+    `${colors.cyan}${colors.bold}║                           SUMMARY                              ║${colors.reset}`,
+  );
+  console.log(
+    `${colors.cyan}${colors.bold}╚════════════════════════════════════════════════════════════════╝${colors.reset}`,
+  );
+
+  console.log(
+    `\n${colors.bold}Total agents processed: ${total}${colors.reset}`,
+  );
+  console.log(
+    `${colors.green}${colors.bold}✓ Successfully reset: ${successCount}${colors.reset}`,
+  );
+  console.log(
+    `${colors.red}${colors.bold}✗ Failed: ${errorCount}${colors.reset}`,
+  );
+
+  const successRate = total > 0 ? Math.round((successCount / total) * 100) : 0;
+  console.log(
+    `${colors.magenta}${colors.bold}Success rate: ${successRate}%${colors.reset}`,
+  );
+}
+
+/**
+ * Display detailed results
+ */
+function displayDetailedResults(
+  results: Array<{
+    agentId: string;
+    agentName: string;
+    ownerId: string;
+    success: boolean;
+    error?: string;
+  }>,
+): void {
+  console.log(
+    `\n${colors.cyan}${colors.bold}╔════════════════════════════════════════════════════════════════╗${colors.reset}`,
+  );
+  console.log(
+    `${colors.cyan}${colors.bold}║                      DETAILED RESULTS                          ║${colors.reset}`,
+  );
+  console.log(
+    `${colors.cyan}${colors.bold}╚════════════════════════════════════════════════════════════════╝${colors.reset}`,
+  );
+
+  results.forEach((result, index) => {
+    console.log(
+      `\n${colors.cyan}[${index + 1}] ${colors.bold}${result.agentName}${colors.reset} ${colors.dim}(${result.agentId})${colors.reset}`,
+    );
+    console.log(`    ${colors.dim}Owner: ${result.ownerId}${colors.reset}`);
+
+    if (result.success) {
+      console.log(
+        `    ${colors.green}✓ API key successfully reset${colors.reset}`,
+      );
+    } else {
+      console.log(`    ${colors.red}✗ Failed to reset API key${colors.reset}`);
+      if (result.error) {
+        console.log(
+          `    ${colors.red}${colors.dim}Error: ${result.error}${colors.reset}`,
+        );
+      }
+    }
+  });
+}
 
 /**
  * Reset API keys for all agents
  */
-async function resetAllAgentApiKeys() {
+async function resetAllAgentApiKeys(): Promise<void> {
   try {
-    console.log(
-      `${colors.cyan}╔════════════════════════════════════════════════════════════════╗${colors.reset}`,
-    );
-    console.log(
-      `${colors.cyan}║                    RESET ALL AGENT API KEYS                    ║${colors.reset}`,
-    );
-    console.log(
-      `${colors.cyan}╚════════════════════════════════════════════════════════════════╝${colors.reset}`,
-    );
+    displayHeader();
 
-    console.log(
-      `\n${colors.yellow}Database: ${process.env.DATABASE_URL}${colors.reset}`,
-    );
-    console.log(
-      `${colors.yellow}Encryption Key: ${process.env.ROOT_ENCRYPTION_KEY?.substring(0, 16)}...${colors.reset}`,
-    );
+    // Validate environment
+    if (!validateEnvironment()) {
+      console.log(
+        `\n${colors.red}${colors.bold}❌ Environment validation failed. Exiting.${colors.reset}`,
+      );
+      process.exit(1);
+    }
+
+    displayEnvironmentStatus();
 
     // Get all agents from the database
     console.log(
-      `\n${colors.blue}Loading all agents from database...${colors.reset}`,
+      `\n${colors.blue}${colors.bold}Loading agents from database...${colors.reset}`,
     );
     const agents = await services.agentManager.getAllAgents();
 
@@ -70,175 +237,139 @@ async function resetAllAgentApiKeys() {
     }
 
     console.log(
-      `\n${colors.green}Found ${agents.length} agent(s) to reset API keys for.${colors.reset}`,
+      `\n${colors.green}${colors.bold}Found ${agents.length} agent(s)${colors.reset}`,
     );
 
-    // Confirm before proceeding
+    // Warning and confirmation
     console.log(
-      `\n${colors.yellow}⚠️  WARNING: This will reset API keys for ALL agents!${colors.reset}`,
+      `\n${colors.yellow}${colors.bold}⚠️  WARNING: This will reset API keys for ALL agents!${colors.reset}`,
     );
     console.log(
       `${colors.yellow}   All existing API keys will be invalidated.${colors.reset}`,
     );
+    console.log(
+      `${colors.yellow}   Make sure to update any systems using these keys.${colors.reset}`,
+    );
 
-    // For scripts, we'll proceed automatically since this is likely run in a controlled environment
-    // If you want to add a confirmation prompt, uncomment the lines below:
-
-    // const readline = require('readline');
-    // const rl = readline.createInterface({
-    //   input: process.stdin,
-    //   output: process.stdout,
-    // });
-    //
-    // const answer = await new Promise(resolve => {
-    //   rl.question(`\n${colors.cyan}Do you want to proceed? (y/N): ${colors.reset}`, resolve);
-    // });
-    // rl.close();
-    //
-    // if (answer.toLowerCase() !== 'y') {
-    //   console.log(`\n${colors.red}Operation cancelled.${colors.reset}`);
-    //   return;
-    // }
+    const confirmed = await askForConfirmation();
+    if (!confirmed) {
+      console.log(`\n${colors.red}Operation cancelled by user.${colors.reset}`);
+      return;
+    }
 
     console.log(
-      `\n${colors.blue}Proceeding to reset API keys for all agents...${colors.reset}`,
+      `\n${colors.blue}${colors.bold}Resetting API keys...${colors.reset}`,
     );
 
     // Reset API keys for all agents
-    const results = [];
+    const results: Array<{
+      agentId: string;
+      agentName: string;
+      ownerId: string;
+      success: boolean;
+      error?: string;
+    }> = [];
+
     let successCount = 0;
     let errorCount = 0;
 
     for (let i = 0; i < agents.length; i++) {
       const agent = agents[i];
 
-      // Check if agent exists (TypeScript safety)
       if (!agent) {
         console.log(
-          `${colors.red}✗ Agent at index ${i} is undefined, skipping...${colors.reset}`,
+          `${colors.red}⚠️  Agent at index ${i} is undefined, skipping...${colors.reset}`,
         );
         errorCount++;
         continue;
       }
 
-      try {
-        console.log(
-          `\n${colors.cyan}[${i + 1}/${agents.length}] Resetting API key for agent: ${agent.name} (${agent.id})${colors.reset}`,
-        );
+      displayProgress(i + 1, agents.length, agent.name);
 
+      try {
         const resetResult = await services.agentManager.resetApiKey(agent.id);
 
-        if (resetResult && resetResult.apiKey) {
-          console.log(
-            `${colors.green}✓ Successfully reset API key for ${agent.name}${colors.reset}`,
-          );
-
+        if (resetResult?.apiKey) {
+          console.log(`${colors.green}✓ Success${colors.reset}`);
           results.push({
             agentId: agent.id,
             agentName: agent.name,
             ownerId: agent.ownerId,
-            newApiKey: resetResult.apiKey,
             success: true,
           });
           successCount++;
         } else {
           console.log(
-            `${colors.red}✗ Failed to reset API key for ${agent.name} - No result returned${colors.reset}`,
+            `${colors.red}✗ Failed - No result returned${colors.reset}`,
           );
-
           results.push({
             agentId: agent.id,
             agentName: agent.name,
             ownerId: agent.ownerId,
-            newApiKey: null,
             success: false,
             error: "No result returned from resetApiKey",
           });
           errorCount++;
         }
       } catch (error) {
-        console.log(
-          `${colors.red}✗ Failed to reset API key for ${agent.name}: ${error instanceof Error ? error.message : error}${colors.reset}`,
-        );
+        const errorMessage =
+          error instanceof Error ? error.message : String(error);
+        console.log(`${colors.red}✗ Failed - ${errorMessage}${colors.reset}`);
 
         results.push({
           agentId: agent.id,
           agentName: agent.name,
           ownerId: agent.ownerId,
-          newApiKey: null,
           success: false,
-          error: error instanceof Error ? error.message : String(error),
+          error: errorMessage,
         });
         errorCount++;
       }
     }
 
-    // Display summary
-    console.log(
-      `\n${colors.cyan}╔════════════════════════════════════════════════════════════════╗${colors.reset}`,
-    );
-    console.log(
-      `${colors.cyan}║                           SUMMARY                              ║${colors.reset}`,
-    );
-    console.log(
-      `${colors.cyan}╚════════════════════════════════════════════════════════════════╝${colors.reset}`,
-    );
-
-    console.log(
-      `\n${colors.green}Successfully reset: ${successCount} agent(s)${colors.reset}`,
-    );
-    console.log(`${colors.red}Failed: ${errorCount} agent(s)${colors.reset}`);
-
-    // Display detailed results
-    console.log(
-      `\n${colors.cyan}╔════════════════════════════════════════════════════════════════╗${colors.reset}`,
-    );
-    console.log(
-      `${colors.cyan}║                      DETAILED RESULTS                          ║${colors.reset}`,
-    );
-    console.log(
-      `${colors.cyan}╚════════════════════════════════════════════════════════════════╝${colors.reset}`,
-    );
-
-    results.forEach((result, index) => {
-      console.log(
-        `\n${colors.cyan}[${index + 1}] Agent: ${result.agentName} (${result.agentId})${colors.reset}`,
-      );
-      console.log(`    Owner ID: ${result.ownerId}`);
-
-      if (result.success) {
-        console.log(`    ${colors.green}✓ Status: SUCCESS${colors.reset}`);
-        console.log(
-          `    ${colors.magenta}New API Key: ${result.newApiKey}${colors.reset}`,
-        );
-      } else {
-        console.log(`    ${colors.red}✗ Status: FAILED${colors.reset}`);
-        console.log(`    ${colors.red}Error: ${result.error}${colors.reset}`);
-      }
-    });
-
-    console.log(
-      `\n${colors.green}API key reset operation completed.${colors.reset}`,
-    );
+    // Display results
+    displayDetailedResults(results);
+    displaySummary(successCount, errorCount, agents.length);
 
     if (successCount > 0) {
       console.log(
-        `\n${colors.yellow}⚠️  IMPORTANT: Save the new API keys above!${colors.reset}`,
+        `\n${colors.yellow}${colors.bold}⚠️  IMPORTANT NOTES:${colors.reset}`,
       );
       console.log(
-        `${colors.yellow}   Old API keys are no longer valid.${colors.reset}`,
+        `${colors.yellow}   • ${successCount} agent(s) have new API keys${colors.reset}`,
+      );
+      console.log(
+        `${colors.yellow}   • Old API keys are no longer valid${colors.reset}`,
+      );
+      console.log(
+        `${colors.yellow}   • Update any systems using these keys${colors.reset}`,
+      );
+      console.log(
+        `${colors.yellow}   • New keys are available via the agent management interface${colors.reset}`,
       );
     }
+
+    console.log(
+      `\n${colors.green}${colors.bold}✓ API key reset operation completed${colors.reset}`,
+    );
   } catch (error) {
     console.error(
-      `\n${colors.red}Error resetting agent API keys:${colors.reset}`,
+      `\n${colors.red}${colors.bold}❌ Error resetting agent API keys:${colors.reset}`,
       error instanceof Error ? error.message : error,
     );
-  } finally {
-    // Exit the process after clean closure
-    process.exit(0);
+    process.exit(1);
   }
 }
 
 // Run the function
-resetAllAgentApiKeys();
+resetAllAgentApiKeys()
+  .then(() => {
+    process.exit(0);
+  })
+  .catch((error) => {
+    console.error(
+      `${colors.red}${colors.bold}Fatal error:${colors.reset}`,
+      error,
+    );
+    process.exit(1);
+  });


### PR DESCRIPTION
# Summary

- Adds simple utility script to allow administrator to reset all agent api keys in one go (so long as the `ROOT_ENCRYPTION_KEY` and `DATABASE_URL` are correctly set