### PR TITLE
feat: add super simple grafana and prometheus config with instructions

### DIFF
--- a/apps/api/trade-simulator-docker/docker-compose.monitoring.yml
+++ b/apps/api/trade-simulator-docker/docker-compose.monitoring.yml
@@ -1,0 +1,31 @@
+services:
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: recall-prometheus
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./monitoring/prometheus.yml:/etc/prometheus/prometheus.yml
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.path=/prometheus"
+      - "--web.console.libraries=/etc/prometheus/console_libraries"
+      - "--web.console.templates=/etc/prometheus/consoles"
+      - "--web.enable-lifecycle"
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: recall-grafana
+    ports:
+      - "3001:3000"
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_PASSWORD:-admin}
+    volumes:
+      - grafana-storage:/var/lib/grafana
+      - ./monitoring/grafana/datasources:/etc/grafana/provisioning/datasources
+      - ./monitoring/grafana/dashboards:/etc/grafana/provisioning/dashboards
+    depends_on:
+      - prometheus
+
+volumes:
+  grafana-storage:

--- a/apps/api/trade-simulator-docker/monitoring/README.md
+++ b/apps/api/trade-simulator-docker/monitoring/README.md
@@ -1,0 +1,109 @@
+# API Monitoring with Prometheus + Grafana
+
+Simple monitoring setup for Recall API with automatic dashboard provisioning.
+
+## Quick Setup
+
+1. **Configure your API target** - Edit `apps/api/trade-simulator-docker/monitoring/prometheus.yml`:
+
+   ```yaml
+   # Replace YOUR_ADMIN_API_KEY_HERE with your actual admin API key
+   bearer_token: 'YOUR_ADMIN_API_KEY_HERE'
+
+   # Replace target based on your setup:
+   targets: ['host.docker.internal:3000']  # For local API
+   # OR
+   targets: ['api.your-domain.com']        # For production API
+
+   # Update scheme if using HTTPS:
+   scheme: https  # For production APIs
+
+   # Update metrics path if using API_PREFIX:
+   metrics_path: '/your-prefix/api/metrics'  # e.g., '/testing-grounds/api/metrics'
+   ```
+
+2. **Start monitoring:**
+   ```bash
+   cd apps/api/trade-simulator-docker
+   docker-compose -f docker-compose.monitoring.yml up
+   ```
+
+## File Locations
+
+- **Config to edit**: `apps/api/trade-simulator-docker/monitoring/prometheus.yml`
+- **Docker compose**: `apps/api/trade-simulator-docker/docker-compose.monitoring.yml`
+- **Dashboard config**: `apps/api/trade-simulator-docker/monitoring/grafana/dashboards/recall-api-dashboard.json`
+
+## Configuration Examples
+
+Edit `apps/api/trade-simulator-docker/monitoring/prometheus.yml`:
+
+**Local API (Default Setup):**
+
+```yaml
+scheme: http
+targets: ["host.docker.internal:3000"]
+metrics_path: "/api/metrics"
+bearer_token: "your_admin_api_key_here"
+```
+
+**Production HTTPS API:**
+
+```yaml
+scheme: https
+targets: ["api.competitions.recall.network"]
+metrics_path: "/api/metrics"
+bearer_token: "your_admin_api_key_here"
+```
+
+**With API_PREFIX (e.g., "testing-grounds"):**
+
+```yaml
+scheme: http
+targets: ["host.docker.internal:3000"]
+metrics_path: "/testing-grounds/api/metrics"
+bearer_token: "your_admin_api_key_here"
+```
+
+## Notes
+
+- **Simple configuration**: Just edit `prometheus.yml` with your API details
+- **Standard ports**: Port 80 (HTTP) and 443 (HTTPS) don't need to be specified in targets
+- **Local Docker networking**: Use `host.docker.internal` to reach localhost from Docker containers
+- **SSL/TLS**: Prometheus handles certificate validation automatically
+- **Check connectivity**: Visit Prometheus at `localhost:9090` → Status → Targets to verify connection
+
+## Access Points
+
+- **Prometheus**: `http://localhost:9090`
+- **Grafana**: `http://localhost:3001` (admin/admin)
+
+## Available Metrics
+
+Your API exposes these metrics at `/api/metrics`:
+
+- `http_request_duration_ms` - HTTP request latency
+- `http_requests_total` - HTTP request count
+- `repository_query_duration_ms` - Database query latency
+- `repository_queries_total` - Database query count
+
+## Automatic Dashboard
+
+**Everything is pre-configured!** When you start monitoring:
+
+1. **Prometheus datasource** - Auto-configured and connected
+2. **"Recall API Monitoring" dashboard** - Auto-loaded with 10 panels showing:
+
+   - HTTP request rates and latency percentiles
+   - Database query rates, latency percentiles, and success rates
+   - Time-series graphs for performance trends
+   - Breakdown by routes, repositories, and SQL operations
+   - Query success rate monitoring with color-coded thresholds
+
+3. **Login to Grafana** at `http://localhost:3001` (admin/admin) and the dashboard will be ready to use!
+
+## Cleanup
+
+```bash
+docker-compose -f docker-compose.monitoring.yml down --volumes
+```

--- a/apps/api/trade-simulator-docker/monitoring/grafana/dashboards/dashboard.yml
+++ b/apps/api/trade-simulator-docker/monitoring/grafana/dashboards/dashboard.yml
@@ -1,0 +1,8 @@
+apiVersion: 1
+
+providers:
+  - name: "default"
+    type: file
+    updateIntervalSeconds: 10
+    options:
+      path: /etc/grafana/provisioning/dashboards

--- a/apps/api/trade-simulator-docker/monitoring/grafana/dashboards/recall-api-dashboard.json
+++ b/apps/api/trade-simulator-docker/monitoring/grafana/dashboards/recall-api-dashboard.json
@@ -1,0 +1,331 @@
+{
+  "id": null,
+  "title": "Recall API Monitoring",
+  "tags": ["recall", "api", "monitoring"],
+  "timezone": "browser",
+  "panels": [
+    {
+      "id": 1,
+      "title": "HTTP Request Rate",
+      "type": "stat",
+      "targets": [
+        {
+          "expr": "rate(http_requests_total[5m])",
+          "legendFormat": "{{method}} {{route}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "reqps"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      }
+    },
+    {
+      "id": 2,
+      "title": "HTTP Request Latency (95th percentile)",
+      "type": "stat",
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, rate(http_request_duration_ms_bucket[5m]))",
+          "legendFormat": "95th percentile"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds",
+            "thresholds": {
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "yellow",
+                  "value": 200
+                },
+                {
+                  "color": "red",
+                  "value": 500
+                }
+              ]
+            }
+          },
+          "unit": "ms"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 6,
+        "y": 0
+      }
+    },
+    {
+      "id": 3,
+      "title": "Database Query Rate",
+      "type": "stat",
+      "targets": [
+        {
+          "expr": "rate(repository_queries_total[5m])",
+          "legendFormat": "{{repository}}.{{method}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "qps"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 12,
+        "y": 0
+      }
+    },
+    {
+      "id": 4,
+      "title": "Database Query Latency (95th percentile)",
+      "type": "stat",
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, rate(repository_query_duration_ms_bucket[5m]))",
+          "legendFormat": "95th percentile"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds",
+            "thresholds": {
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "yellow",
+                  "value": 50
+                },
+                {
+                  "color": "red",
+                  "value": 200
+                }
+              ]
+            }
+          },
+          "unit": "ms"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 18,
+        "y": 0
+      }
+    },
+    {
+      "id": 5,
+      "title": "HTTP Request Latency Over Time",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, rate(http_request_duration_ms_bucket[5m]))",
+          "legendFormat": "50th percentile"
+        },
+        {
+          "expr": "histogram_quantile(0.95, rate(http_request_duration_ms_bucket[5m]))",
+          "legendFormat": "95th percentile"
+        },
+        {
+          "expr": "histogram_quantile(0.99, rate(http_request_duration_ms_bucket[5m]))",
+          "legendFormat": "99th percentile"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "ms"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      }
+    },
+    {
+      "id": 6,
+      "title": "Database Query Latency Over Time",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, rate(repository_query_duration_ms_bucket[5m]))",
+          "legendFormat": "50th percentile"
+        },
+        {
+          "expr": "histogram_quantile(0.95, rate(repository_query_duration_ms_bucket[5m]))",
+          "legendFormat": "95th percentile"
+        },
+        {
+          "expr": "histogram_quantile(0.99, rate(repository_query_duration_ms_bucket[5m]))",
+          "legendFormat": "99th percentile"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "ms"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      }
+    },
+    {
+      "id": 7,
+      "title": "HTTP Requests by Route",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "rate(http_requests_total[5m])",
+          "legendFormat": "{{method}} {{route}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "reqps"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      }
+    },
+    {
+      "id": 8,
+      "title": "Database Queries by Repository",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "rate(repository_queries_total[5m])",
+          "legendFormat": "{{repository}} {{operation}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "qps"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      }
+    },
+    {
+      "id": 9,
+      "title": "Database Query Success Rate",
+      "type": "stat",
+      "targets": [
+        {
+          "expr": "rate(repository_queries_total{status=\"success\"}[5m]) / rate(repository_queries_total[5m]) * 100",
+          "legendFormat": "Success Rate"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds",
+            "thresholds": {
+              "steps": [
+                {
+                  "color": "red",
+                  "value": null
+                },
+                {
+                  "color": "yellow",
+                  "value": 95
+                },
+                {
+                  "color": "green",
+                  "value": 99
+                }
+              ]
+            }
+          },
+          "unit": "percent",
+          "min": 0,
+          "max": 100
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 24
+      }
+    },
+    {
+      "id": 10,
+      "title": "Database Queries by Operation Type",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "rate(repository_queries_total[5m])",
+          "legendFormat": "{{operation}} ({{status}})"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "qps"
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 24
+      }
+    }
+  ],
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "refresh": "5s",
+  "schemaVersion": 27,
+  "version": 1
+}

--- a/apps/api/trade-simulator-docker/monitoring/grafana/datasources/prometheus.yml
+++ b/apps/api/trade-simulator-docker/monitoring/grafana/datasources/prometheus.yml
@@ -1,0 +1,8 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true

--- a/apps/api/trade-simulator-docker/monitoring/prometheus.yml
+++ b/apps/api/trade-simulator-docker/monitoring/prometheus.yml
@@ -1,0 +1,13 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: "recall-api"
+    scheme: http # Use 'https' for production APIs
+    static_configs:
+      - targets: ["host.docker.internal:3000"] # Replace with your API host:port
+    metrics_path: "/api/metrics" # Replace with '/${API_PREFIX}/api/metrics' if using API_PREFIX
+    bearer_token: "YOUR_ADMIN_API_KEY_HERE" # Replace with your actual admin API key
+    scrape_interval: 30s
+    scrape_timeout: 10s


### PR DESCRIPTION
# Summary

Added complete monitoring infrastructure for the Recall API using Prometheus and Grafana with automatic dashboard provisioning.

## Changes

### New Files Added
- `apps/api/trade-simulator-docker/docker-compose.monitoring.yml` - Docker Compose configuration for monitoring stack
- `apps/api/trade-simulator-docker/monitoring/prometheus.yml` - Prometheus configuration with placeholders
- `apps/api/trade-simulator-docker/monitoring/grafana/datasources/prometheus.yml` - Auto-configured Prometheus datasource
- `apps/api/trade-simulator-docker/monitoring/grafana/dashboards/dashboard.yml` - Dashboard provisioning config
- `apps/api/trade-simulator-docker/monitoring/grafana/dashboards/recall-api-dashboard.json` - Pre-built monitoring dashboard
- `apps/api/trade-simulator-docker/monitoring/README.md` - Setup and configuration instructions

## Features

### Monitoring Stack
- **Prometheus** (port 9090) - Metrics collection and storage
- **Grafana** (port 3001) - Visualization and dashboards
- **Auto-provisioning** - Dashboard and datasource automatically configured

### Pre-built Dashboard (10 panels)
- HTTP request rates and latency percentiles
- Database query rates, latency, and success rates
- Time-series performance trends
- Breakdown by routes, repositories, and SQL operations
- Color-coded success rate monitoring

### Configuration
- **Simple setup** - Edit single `prometheus.yml` file with API details
- **Flexible targets** - Supports localhost, production HTTPS, and API prefix configurations
- **Secure authentication** - Uses admin API keys for metrics endpoint access
- **No environment dependencies** - Self-contained configuration

## Usage

```bash
# 1. Edit prometheus.yml with your API details and admin key
# 2. Start monitoring
cd apps/api/trade-simulator-docker
docker-compose -f docker-compose.monitoring.yml up
```

## Integration

Works seamlessly with existing logging and metrics infrastructure:
- Leverages existing `/api/metrics` endpoint (secured with admin auth)
- Compatible with 10% log sampling implementation  
- Provides metrics collection despite reduced log volume
- Integrates with repository timing and HTTP request metrics
