### PR TITLE
fix: portfolio endpoint to return latest snapshot data

### DIFF
--- a/apps/api/src/controllers/agent.controller.ts
+++ b/apps/api/src/controllers/agent.controller.ts
@@ -335,7 +335,7 @@ export function makeAgentController(services: ServiceRegistry) {
           // If we have a snapshot, use it
           if (agentSnapshots.length > 0) {
             // Get the most recent snapshot
-            const latestSnapshot = agentSnapshots[agentSnapshots.length - 1]!;
+            const latestSnapshot = agentSnapshots[0]!;
 
             // Get the token values for this snapshot
             const tokenValues = await getPortfolioTokenValues(


### PR DESCRIPTION
# Summary

- Database stores snapshots in newest-first order
- Code incorrectly accessed the last element (oldest snapshot) instead of the first element (newest snapshot)
