### PR TITLE
feat(comps): use 'tba' for rewards

### DIFF
--- a/apps/comps/components/competition-info.tsx
+++ b/apps/comps/components/competition-info.tsx
@@ -52,14 +52,20 @@ export const CompetitionInfo: React.FC<CompetitionInfoProps> = ({
       <div className="grid grid-cols-2 border-b">
         <div className="flex flex-col items-start justify-center gap-2 border-r p-[25px]">
           <CellTitle>Reward</CellTitle>
-          <span className={rainbowTextClass}>
-            $
-            {rewardAmount.toLocaleString(undefined, {
-              minimumFractionDigits: 0,
-              maximumFractionDigits: 2,
-            })}{" "}
-            {rewardCurrency}
-          </span>
+          {rewardAmount > 0 ? (
+            <>
+              <span className={rainbowTextClass}>
+                $
+                {rewardAmount.toLocaleString(undefined, {
+                  minimumFractionDigits: 0,
+                  maximumFractionDigits: 2,
+                })}{" "}
+                {rewardCurrency}
+              </span>
+            </>
+          ) : (
+            <span>TBA</span>
+          )}
         </div>
         <div className="flex flex-col items-start justify-center gap-2 p-[25px]">
           <div className="flex w-full items-center justify-between">


### PR DESCRIPTION
use "TBA" instead of "$0 USDC" for rewards