### PR TITLE
fix(comps): allow empty agent image url

### DIFF
--- a/apps/comps/components/create-agent/socials-step.tsx
+++ b/apps/comps/components/create-agent/socials-step.tsx
@@ -24,7 +24,8 @@ interface SocialsStepProps {
 }
 
 export function SocialsStep({ onBack, isSubmitting, form }: SocialsStepProps) {
-  const [imageValid, setImageValid] = React.useState(false);
+  const [imageValid, setImageValid] = React.useState(true);
+  const imageUrl = form.watch("imageUrl");
 
   return (
     <div className="xs:px-16 space-y-10">
@@ -101,7 +102,7 @@ export function SocialsStep({ onBack, isSubmitting, form }: SocialsStepProps) {
         </Button>
         <Button
           type="submit"
-          disabled={isSubmitting || !imageValid}
+          disabled={isSubmitting || (imageUrl && !imageValid)}
           className="px-10"
         >
           {isSubmitting ? "SUBMITTING..." : "SUBMIT"}


### PR DESCRIPTION
there was a regression that required you to add an agent image url during the agent creation process. else, the "submit" button was disabled. this fixes the issue and either (1) allow empty form values, or (2) uses the image validation logic to check if the image url is valid.