### PR TITLE
feat(api): use env var for email auto-verify

### DIFF
--- a/.github/workflows/api-ci.yml
+++ b/.github/workflows/api-ci.yml
@@ -289,6 +289,9 @@ jobs:
           # Optional: API prefix
           API_PREFIX=testing
 
+          # Enable auto-verify user email
+          ENABLE_AUTO_VERIFY_USER_EMAIL=true
+
       - name: Run E2E tests
         working-directory: apps/api
         run: |

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -74,11 +74,15 @@ NOVES_API_KEY=your_noves_api_key_here
 # Optional: Disable ability for participants to view leaderboard activity (set true to activate)
 DISABLE_PARTICIPANT_LEADERBOARD_ACCESS=false
 
+# Agent wallet and email verification URL
 API_DOMAIN=http://localhost:3000
 
 # Optional: API prefix (e.g., API_PREFIX=development -> /development/api/...)
 API_PREFIX=
 
+# Email verification
+# Auto-verify user email addresses instead of requiring Loops email confirmation
+ENABLE_AUTO_VERIFY_USER_EMAIL=true
 # Loops API Key
 LOOPS_API_KEY=email_loops_api_key
 # Loops email template id

--- a/apps/api/.env.sandbox
+++ b/apps/api/.env.sandbox
@@ -73,3 +73,16 @@ NOVES_API_KEY=your_noves_api_key_here
 
 # Optional: Disable ability for participants to view leaderboard activity (set true to activate)
 DISABLE_PARTICIPANT_LEADERBOARD_ACCESS=false
+
+# Agent wallet and email verification URL
+API_DOMAIN=http://localhost:3002
+
+# Optional: API prefix (e.g., API_PREFIX=development -> /development/api/...)
+API_PREFIX=
+
+# Auto-verify user email addresses instead of requiring Loops email confirmation
+ENABLE_AUTO_VERIFY_USER_EMAIL=true
+
+# Optional: Logging sampling rates (0.0 - 1.0)
+REPOSITORY_LOG_SAMPLE_RATE=0.1 # Default: 0.1
+HTTP_LOG_SAMPLE_RATE=0.1 # Default: 0.1

--- a/apps/api/.env.test
+++ b/apps/api/.env.test
@@ -63,6 +63,10 @@ PORTFOLIO_PRICE_FRESHNESS_MS=10000
 DISABLE_PARTICIPANT_LEADERBOARD_ACCESS=false
 
 API_DOMAIN=http://localhost:3001
+
 # Optional: API prefix
 API_PREFIX=testing
+
+# Auto-verify user email addresses instead of requiring Loops email confirmation
+ENABLE_AUTO_VERIFY_USER_EMAIL=true
 

--- a/apps/api/src/config/index.ts
+++ b/apps/api/src/config/index.ts
@@ -155,6 +155,7 @@ export const config = {
     sandboxUrl: "https://api.sandbox.competitions.recall.network",
   },
   email: {
+    autoVerifyUserEmail: process.env.ENABLE_AUTO_VERIFY_USER_EMAIL === "true",
     apiKey: process.env.LOOPS_API_KEY || "",
     transactionalId: process.env.LOOPS_TRANSACTIONAL_ID || "",
   },

--- a/apps/api/src/controllers/admin.controller.ts
+++ b/apps/api/src/controllers/admin.controller.ts
@@ -3,7 +3,7 @@ import { NextFunction, Request, Response } from "express";
 import * as fs from "fs";
 import * as path from "path";
 
-import { reloadSecurityConfig } from "@/config/index.js";
+import { config, reloadSecurityConfig } from "@/config/index.js";
 import { addAgentToCompetition } from "@/database/repositories/competition-repository.js";
 import { objectIndexRepository } from "@/database/repositories/object-index.repository.js";
 import { flatParse } from "@/lib/flat-parse.js";
@@ -1730,12 +1730,9 @@ export function makeAdminController(services: ServiceRegistry) {
           });
         }
 
-        // Auto-verify email in development and test modes
+        // Auto-verify email (e.g. for development, test, or sandbox modes)
         if (!owner.isEmailVerified) {
-          if (
-            process.env.NODE_ENV === "development" ||
-            process.env.NODE_ENV === "test"
-          ) {
+          if (config.email.autoVerifyUserEmail) {
             console.log(
               `[DEV/TEST] Auto-verifying email for user ${agent.ownerId} in ${process.env.NODE_ENV} mode`,
             );

--- a/apps/api/src/controllers/user.controller.ts
+++ b/apps/api/src/controllers/user.controller.ts
@@ -282,13 +282,9 @@ export function makeUserController(services: ServiceRegistry) {
           throw new ApiError(404, "User not found");
         }
 
-        // Auto-verify email in development and test modes
+        // Auto-verify email (e.g. for development, test, or sandbox modes)
         if (!user.isEmailVerified) {
-          if (
-            (config.server.nodeEnv === "development" ||
-              config.server.nodeEnv === "test") &&
-            !(config.email.apiKey && config.email.transactionalId)
-          ) {
+          if (config.email.autoVerifyUserEmail) {
             console.log(
               `[DEV/TEST] Auto-verifying email for user ${userId} in ${config.server.nodeEnv} mode`,
             );

--- a/apps/api/turbo.json
+++ b/apps/api/turbo.json
@@ -56,7 +56,8 @@
         "LOOPS_TRANSACTIONAL_ID",
         "CORS_ORIGINS",
         "REPOSITORY_LOG_SAMPLE_RATE",
-        "HTTP_LOG_SAMPLE_RATE"
+        "HTTP_LOG_SAMPLE_RATE",
+        "ENABLE_AUTO_VERIFY_USER_EMAIL"
       ]
     }
   }


### PR DESCRIPTION
Since the UI will gate access to API keys, a user cannot see their API key until they've verified their email + joined an active sandbox competition. But, we don't want the sandbox to send a Loops email because the production instance will handle user verification and UI behavior.

Thus, a prerequisite is that the user must be effectively marked as verified _in the sandbox_, else, they cannot join a competition. This must be available in production (the "sandbox" runs in NODE_ENV=production) and not purely in `NODE_ENV` development or test modes.

With this PR, we can use `ENABLE_AUTO_VERIFY_USER_EMAIL` in the sandbox, development, or test modes to auto-verify users.