### PR TITLE
feat(comps): handle user email conflicts

### DIFF
--- a/apps/api/e2e/utils/api-client.ts
+++ b/apps/api/e2e/utils/api-client.ts
@@ -511,6 +511,7 @@ export class ApiClient {
    */
   async updateUserProfile(profileData: {
     name?: string;
+    email?: string;
     imageUrl?: string;
     metadata?: Record<string, unknown>;
   }): Promise<UserProfileResponse | ErrorResponse> {

--- a/apps/api/src/controllers/user.controller.ts
+++ b/apps/api/src/controllers/user.controller.ts
@@ -78,6 +78,14 @@ export function makeUserController(services: ServiceRegistry) {
           throw new ApiError(404, "User not found");
         }
 
+        // Check if the email is already in use
+        if (email && email !== user.email) {
+          const existingUser = await services.userManager.getUserByEmail(email);
+          if (existingUser && existingUser.id !== userId) {
+            throw new ApiError(409, "Email already in use");
+          }
+        }
+
         // Prepare update data with only allowed fields
         const updateData = {
           id: userId,

--- a/apps/comps/app/profile/page.tsx
+++ b/apps/comps/app/profile/page.tsx
@@ -33,11 +33,7 @@ export default function ProfilePage() {
   }
 
   const handleUpdateProfile = async (data: UpdateProfileRequest) => {
-    try {
-      await updateProfile.mutateAsync(data);
-    } catch (error) {
-      console.error("Failed to update profile:", error);
-    }
+    await updateProfile.mutateAsync(data);
   };
 
   return (

--- a/apps/comps/app/profile/update/page.tsx
+++ b/apps/comps/app/profile/update/page.tsx
@@ -27,12 +27,8 @@ function UpdateProfileView() {
   }
 
   const handleUpdateProfile = async (data: UpdateProfileRequest) => {
-    try {
-      await updateProfile.mutateAsync(data);
-      redirect();
-    } catch (error) {
-      console.error("Failed to update profile:", error);
-    }
+    await updateProfile.mutateAsync(data);
+    redirect();
   };
 
   return (

--- a/apps/comps/components/update-profile.tsx
+++ b/apps/comps/components/update-profile.tsx
@@ -16,6 +16,7 @@ import {
 } from "@recallnet/ui2/components/form";
 import { Input } from "@recallnet/ui2/components/input";
 
+import { ConflictError } from "@/lib/api-client";
 import { UpdateProfileRequest } from "@/types/profile";
 import { asOptionalStringWithoutEmpty } from "@/utils/zod";
 
@@ -33,7 +34,7 @@ const formSchema = z.object({
 export type FormData = z.infer<typeof formSchema>;
 
 type UpdateProfileProps = {
-  onSubmit: (data: UpdateProfileRequest) => void;
+  onSubmit: (data: UpdateProfileRequest) => Promise<void>;
 };
 
 export const UpdateProfile: React.FC<UpdateProfileProps> = ({ onSubmit }) => {
@@ -47,14 +48,30 @@ export const UpdateProfile: React.FC<UpdateProfileProps> = ({ onSubmit }) => {
     },
   });
 
-  const handleSubmit = (data: FormData) => {
-    const transformedData: UpdateProfileRequest = {
-      name: data.name,
-      email: data.email,
-      imageUrl: data.image || undefined,
-      metadata: data.website ? { website: data.website } : undefined,
-    };
-    onSubmit(transformedData);
+  const handleSubmit = async (data: FormData) => {
+    try {
+      const transformedData: UpdateProfileRequest = {
+        name: data.name,
+        email: data.email,
+        imageUrl: data.image || undefined,
+        metadata: data.website ? { website: data.website } : undefined,
+      };
+      await onSubmit(transformedData);
+    } catch (error: unknown) {
+      // Handle ConflictError (409) for duplicate emails
+      if (
+        error instanceof ConflictError &&
+        error.message.toLowerCase().includes("email")
+      ) {
+        form.setError("email", {
+          type: "manual",
+          message: error.message,
+        });
+      } else {
+        // Re-throw other errors to be handled by parent
+        throw error;
+      }
+    }
   };
 
   return (
@@ -98,8 +115,7 @@ export const UpdateProfile: React.FC<UpdateProfileProps> = ({ onSubmit }) => {
                 </FormControl>
                 {!errors.email && (
                   <FormDescription>
-                    We&apos;ll email your API key here - make sure it&apos;s one
-                    you check often.
+                    We&apos;ll send an email to verify your email address.
                   </FormDescription>
                 )}
                 <FormMessage />


### PR DESCRIPTION
We weren't throwing API 40x errors if a duplicate user email was used, so a 500 is thrown. Also, the UI wasn't catching the error properly.

This PR ensures the initial user onboarding flow properly display errors within the form, and in the user profile page, we display a toast.
<img width="401" height="352" alt="Screenshot 2025-07-16 at 6 01 32 PM" src="https://github.com/user-attachments/assets/d36f70d5-bb6d-4bfd-b7db-73904a1a858f" />
<img width="587" height="378" alt="Screenshot 2025-07-16 at 6 01 46 PM" src="https://github.com/user-attachments/assets/62eb4572-c36e-44c2-b530-ec08dad1a17a" />

