### PR TITLE
feat: use and enforce join start and end dates in competitions

### DIFF
--- a/apps/api/drizzle/0022_giant_gabe_jones.sql
+++ b/apps/api/drizzle/0022_giant_gabe_jones.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "competitions" ADD COLUMN "join_start_date" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "competitions" ADD COLUMN "join_end_date" timestamp with time zone;

--- a/apps/api/drizzle/meta/0022_snapshot.json
+++ b/apps/api/drizzle/meta/0022_snapshot.json
@@ -1,0 +1,3416 @@
+{
+  "id": "9962bdd2-1c1e-445f-ad7d-eb70533ba2ba",
+  "prevId": "cc3d875a-871c-4edd-99cb-1c0d63c85244",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.admins": {
+      "name": "admins",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "varchar(400)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "actor_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "last_login_at": {
+          "name": "last_login_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_admins_username": {
+          "name": "idx_admins_username",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_admins_email": {
+          "name": "idx_admins_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_admins_api_key": {
+          "name": "idx_admins_api_key",
+          "columns": [
+            {
+              "expression": "api_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_admins_status": {
+          "name": "idx_admins_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "admins_username_unique": {
+          "name": "admins_username_unique",
+          "nullsNotDistinct": false,
+          "columns": ["username"]
+        },
+        "admins_email_unique": {
+          "name": "admins_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        },
+        "admins_api_key_unique": {
+          "name": "admins_api_key_unique",
+          "nullsNotDistinct": false,
+          "columns": ["api_key"]
+        },
+        "admins_username_key": {
+          "name": "admins_username_key",
+          "nullsNotDistinct": false,
+          "columns": ["username"]
+        },
+        "admins_email_key": {
+          "name": "admins_email_key",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        },
+        "admins_api_key_key": {
+          "name": "admins_api_key_key",
+          "nullsNotDistinct": false,
+          "columns": ["api_key"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_nonces": {
+      "name": "agent_nonces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nonce": {
+          "name": "nonce",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_agent_nonces_agent_id": {
+          "name": "idx_agent_nonces_agent_id",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_nonces_nonce": {
+          "name": "idx_agent_nonces_nonce",
+          "columns": [
+            {
+              "expression": "nonce",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_nonces_expires_at": {
+          "name": "idx_agent_nonces_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_nonces_agent_id_fkey": {
+          "name": "agent_nonces_agent_id_fkey",
+          "tableFrom": "agent_nonces",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agent_nonces_nonce_unique": {
+          "name": "agent_nonces_nonce_unique",
+          "nullsNotDistinct": false,
+          "columns": ["nonce"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wallet_address": {
+          "name": "wallet_address",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "varchar(400)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_email_verified": {
+          "name": "is_email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "actor_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "deactivation_reason": {
+          "name": "deactivation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deactivation_date": {
+          "name": "deactivation_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agents_owner_id": {
+          "name": "idx_agents_owner_id",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agents_status": {
+          "name": "idx_agents_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agents_wallet_address": {
+          "name": "idx_agents_wallet_address",
+          "columns": [
+            {
+              "expression": "wallet_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agents_api_key": {
+          "name": "idx_agents_api_key",
+          "columns": [
+            {
+              "expression": "api_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agents_owner_id_fkey": {
+          "name": "agents_owner_id_fkey",
+          "tableFrom": "agents",
+          "tableTo": "users",
+          "columnsFrom": ["owner_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agents_wallet_address_unique": {
+          "name": "agents_wallet_address_unique",
+          "nullsNotDistinct": false,
+          "columns": ["wallet_address"]
+        },
+        "agents_email_unique": {
+          "name": "agents_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        },
+        "agents_owner_id_name_key": {
+          "name": "agents_owner_id_name_key",
+          "nullsNotDistinct": false,
+          "columns": ["owner_id", "name"]
+        },
+        "agents_api_key_key": {
+          "name": "agents_api_key_key",
+          "nullsNotDistinct": false,
+          "columns": ["api_key"]
+        },
+        "agents_wallet_address_key": {
+          "name": "agents_wallet_address_key",
+          "nullsNotDistinct": false,
+          "columns": ["wallet_address"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.competition_agents": {
+      "name": "competition_agents",
+      "schema": "",
+      "columns": {
+        "competition_id": {
+          "name": "competition_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "competition_agent_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "deactivation_reason": {
+          "name": "deactivation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deactivated_at": {
+          "name": "deactivated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_competition_agents_status": {
+          "name": "idx_competition_agents_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_competition_agents_competition_id": {
+          "name": "idx_competition_agents_competition_id",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_competition_agents_agent_id": {
+          "name": "idx_competition_agents_agent_id",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_competition_agents_deactivated_at": {
+          "name": "idx_competition_agents_deactivated_at",
+          "columns": [
+            {
+              "expression": "deactivated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "competition_agents_competition_id_fkey": {
+          "name": "competition_agents_competition_id_fkey",
+          "tableFrom": "competition_agents",
+          "tableTo": "competitions",
+          "columnsFrom": ["competition_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "competition_agents_agent_id_fkey": {
+          "name": "competition_agents_agent_id_fkey",
+          "tableFrom": "competition_agents",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "competition_agents_pkey": {
+          "name": "competition_agents_pkey",
+          "columns": ["competition_id", "agent_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.competitions": {
+      "name": "competitions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "competition_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'trading'"
+        },
+        "external_url": {
+          "name": "external_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "voting_start_date": {
+          "name": "voting_start_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "voting_end_date": {
+          "name": "voting_end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "join_start_date": {
+          "name": "join_start_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "join_end_date": {
+          "name": "join_end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "competition_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sandbox_mode": {
+          "name": "sandbox_mode",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_competitions_status": {
+          "name": "idx_competitions_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.competitions_leaderboard": {
+      "name": "competitions_leaderboard",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_agents": {
+          "name": "total_agents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "score": {
+          "name": "score",
+          "type": "numeric(30, 15)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_competitions_leaderboard_agent_id": {
+          "name": "idx_competitions_leaderboard_agent_id",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_competitions_leaderboard_competition_id": {
+          "name": "idx_competitions_leaderboard_competition_id",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_competitions_leaderboard_agent_competition": {
+          "name": "idx_competitions_leaderboard_agent_competition",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "competitions_leaderboard_agent_id_fkey": {
+          "name": "competitions_leaderboard_agent_id_fkey",
+          "tableFrom": "competitions_leaderboard",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "competitions_leaderboard_competition_id_fkey": {
+          "name": "competitions_leaderboard_competition_id_fkey",
+          "tableFrom": "competitions_leaderboard",
+          "tableTo": "competitions",
+          "columnsFrom": ["competition_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_verification_tokens": {
+      "name": "email_verification_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token": {
+          "name": "token",
+          "type": "char(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used": {
+          "name": "used",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_email_verification_tokens_user_id_token": {
+          "name": "idx_email_verification_tokens_user_id_token",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_email_verification_tokens_agent_id_token": {
+          "name": "idx_email_verification_tokens_agent_id_token",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_verification_tokens_user_id_fkey": {
+          "name": "email_verification_tokens_user_id_fkey",
+          "tableFrom": "email_verification_tokens",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_verification_tokens_agent_id_fkey": {
+          "name": "email_verification_tokens_agent_id_fkey",
+          "tableFrom": "email_verification_tokens",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "email_verification_tokens_token_unique": {
+          "name": "email_verification_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        },
+        "email_verification_tokens_token_key": {
+          "name": "email_verification_tokens_token_key",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "wallet_address": {
+          "name": "wallet_address",
+          "type": "varchar(42)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_email_verified": {
+          "name": "is_email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "actor_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_users_wallet_address": {
+          "name": "idx_users_wallet_address",
+          "columns": [
+            {
+              "expression": "wallet_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_status": {
+          "name": "idx_users_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_wallet_address_unique": {
+          "name": "users_wallet_address_unique",
+          "nullsNotDistinct": false,
+          "columns": ["wallet_address"]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        },
+        "users_wallet_address_key": {
+          "name": "users_wallet_address_key",
+          "nullsNotDistinct": false,
+          "columns": ["wallet_address"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.votes": {
+      "name": "votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_votes_competition_id": {
+          "name": "idx_votes_competition_id",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_votes_agent_competition": {
+          "name": "idx_votes_agent_competition",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_votes_user_competition": {
+          "name": "idx_votes_user_competition",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "votes_user_id_fkey": {
+          "name": "votes_user_id_fkey",
+          "tableFrom": "votes",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "votes_agent_id_fkey": {
+          "name": "votes_agent_id_fkey",
+          "tableFrom": "votes",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "votes_competition_id_fkey": {
+          "name": "votes_competition_id_fkey",
+          "tableFrom": "votes",
+          "tableTo": "competitions",
+          "columnsFrom": ["competition_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "votes_user_agent_competition_key": {
+          "name": "votes_user_agent_competition_key",
+          "nullsNotDistinct": false,
+          "columns": ["user_id", "agent_id", "competition_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_score": {
+      "name": "agent_score",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mu": {
+          "name": "mu",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sigma": {
+          "name": "sigma",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ordinal": {
+          "name": "ordinal",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_score_agent_id": {
+          "name": "idx_agent_score_agent_id",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_score_agent_id_fkey": {
+          "name": "agent_score_agent_id_fkey",
+          "tableFrom": "agent_score",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_agent_score_agent_id": {
+          "name": "unique_agent_score_agent_id",
+          "nullsNotDistinct": false,
+          "columns": ["agent_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_score_history": {
+      "name": "agent_score_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mu": {
+          "name": "mu",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sigma": {
+          "name": "sigma",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ordinal": {
+          "name": "ordinal",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_score_history_agent_id": {
+          "name": "idx_agent_score_history_agent_id",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_score_history_competition_id": {
+          "name": "idx_agent_score_history_competition_id",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_score_history_agent_competition": {
+          "name": "idx_agent_score_history_agent_competition",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_score_history_agent_id_fkey": {
+          "name": "agent_score_history_agent_id_fkey",
+          "tableFrom": "agent_score_history",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_score_history_competition_id_fkey": {
+          "name": "agent_score_history_competition_id_fkey",
+          "tableFrom": "agent_score_history",
+          "tableTo": "competitions",
+          "columnsFrom": ["competition_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.object_index": {
+      "name": "object_index",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data_type": {
+          "name": "data_type",
+          "type": "sync_data_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_timestamp": {
+          "name": "event_timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_object_index_competition_id": {
+          "name": "idx_object_index_competition_id",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_object_index_agent_id": {
+          "name": "idx_object_index_agent_id",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_object_index_data_type": {
+          "name": "idx_object_index_data_type",
+          "columns": [
+            {
+              "expression": "data_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_object_index_competition_agent": {
+          "name": "idx_object_index_competition_agent",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_object_index_created_at": {
+          "name": "idx_object_index_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "object_index_competition_id_fkey": {
+          "name": "object_index_competition_id_fkey",
+          "tableFrom": "object_index",
+          "tableTo": "competitions",
+          "columnsFrom": ["competition_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "object_index_agent_id_fkey": {
+          "name": "object_index_agent_id_fkey",
+          "tableFrom": "object_index",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "trading_comps.balances": {
+      "name": "balances",
+      "schema": "trading_comps",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_address": {
+          "name": "token_address",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "specific_chain": {
+          "name": "specific_chain",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_balances_specific_chain": {
+          "name": "idx_balances_specific_chain",
+          "columns": [
+            {
+              "expression": "specific_chain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_balances_agent_id": {
+          "name": "idx_balances_agent_id",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "balances_agent_id_fkey": {
+          "name": "balances_agent_id_fkey",
+          "tableFrom": "balances",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "balances_agent_id_token_address_key": {
+          "name": "balances_agent_id_token_address_key",
+          "nullsNotDistinct": false,
+          "columns": ["agent_id", "token_address"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "trading_comps.portfolio_snapshots": {
+      "name": "portfolio_snapshots",
+      "schema": "trading_comps",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "total_value": {
+          "name": "total_value",
+          "type": "numeric(30, 15)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_portfolio_snapshots_agent_competition": {
+          "name": "idx_portfolio_snapshots_agent_competition",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_portfolio_snapshots_timestamp": {
+          "name": "idx_portfolio_snapshots_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_portfolio_snapshots_competition_agent_timestamp": {
+          "name": "idx_portfolio_snapshots_competition_agent_timestamp",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "portfolio_snapshots_agent_id_fkey": {
+          "name": "portfolio_snapshots_agent_id_fkey",
+          "tableFrom": "portfolio_snapshots",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "portfolio_snapshots_competition_id_fkey": {
+          "name": "portfolio_snapshots_competition_id_fkey",
+          "tableFrom": "portfolio_snapshots",
+          "tableTo": "competitions",
+          "columnsFrom": ["competition_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "trading_comps.portfolio_token_values": {
+      "name": "portfolio_token_values",
+      "schema": "trading_comps",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "portfolio_snapshot_id": {
+          "name": "portfolio_snapshot_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_address": {
+          "name": "token_address",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_usd": {
+          "name": "value_usd",
+          "type": "numeric(30, 15)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "specific_chain": {
+          "name": "specific_chain",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_portfolio_token_values_snapshot_id": {
+          "name": "idx_portfolio_token_values_snapshot_id",
+          "columns": [
+            {
+              "expression": "portfolio_snapshot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_portfolio_token_values_specific_chain": {
+          "name": "idx_portfolio_token_values_specific_chain",
+          "columns": [
+            {
+              "expression": "specific_chain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "portfolio_token_values_portfolio_snapshot_id_fkey": {
+          "name": "portfolio_token_values_portfolio_snapshot_id_fkey",
+          "tableFrom": "portfolio_token_values",
+          "tableTo": "portfolio_snapshots",
+          "schemaTo": "trading_comps",
+          "columnsFrom": ["portfolio_snapshot_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "trading_comps.prices": {
+      "name": "prices",
+      "schema": "trading_comps",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "chain": {
+          "name": "chain",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "specific_chain": {
+          "name": "specific_chain",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_prices_chain": {
+          "name": "idx_prices_chain",
+          "columns": [
+            {
+              "expression": "chain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_prices_specific_chain": {
+          "name": "idx_prices_specific_chain",
+          "columns": [
+            {
+              "expression": "specific_chain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_prices_timestamp": {
+          "name": "idx_prices_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_prices_token": {
+          "name": "idx_prices_token",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_prices_token_chain": {
+          "name": "idx_prices_token_chain",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_prices_token_specific_chain": {
+          "name": "idx_prices_token_specific_chain",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "specific_chain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_prices_token_timestamp": {
+          "name": "idx_prices_token_timestamp",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "trading_comps.trades": {
+      "name": "trades",
+      "schema": "trading_comps",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_token": {
+          "name": "from_token",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_token": {
+          "name": "to_token",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_amount": {
+          "name": "from_amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_amount": {
+          "name": "to_amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trade_amount_usd": {
+          "name": "trade_amount_usd",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_token_symbol": {
+          "name": "to_token_symbol",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_token_symbol": {
+          "name": "from_token_symbol",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "from_chain": {
+          "name": "from_chain",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_chain": {
+          "name": "to_chain",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_specific_chain": {
+          "name": "from_specific_chain",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_specific_chain": {
+          "name": "to_specific_chain",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_trades_competition_id": {
+          "name": "idx_trades_competition_id",
+          "columns": [
+            {
+              "expression": "competition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_trades_from_chain": {
+          "name": "idx_trades_from_chain",
+          "columns": [
+            {
+              "expression": "from_chain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_trades_from_specific_chain": {
+          "name": "idx_trades_from_specific_chain",
+          "columns": [
+            {
+              "expression": "from_specific_chain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_trades_agent_id": {
+          "name": "idx_trades_agent_id",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_trades_timestamp": {
+          "name": "idx_trades_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_trades_to_chain": {
+          "name": "idx_trades_to_chain",
+          "columns": [
+            {
+              "expression": "to_chain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_trades_to_specific_chain": {
+          "name": "idx_trades_to_specific_chain",
+          "columns": [
+            {
+              "expression": "to_specific_chain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trades_agent_id_fkey": {
+          "name": "trades_agent_id_fkey",
+          "tableFrom": "trades",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "trades_competition_id_fkey": {
+          "name": "trades_competition_id_fkey",
+          "tableFrom": "trades",
+          "tableTo": "competitions",
+          "columnsFrom": ["competition_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "trading_comps.trading_competitions": {
+      "name": "trading_competitions",
+      "schema": "trading_comps",
+      "columns": {
+        "competitionId": {
+          "name": "competitionId",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cross_chain_trading_type": {
+          "name": "cross_chain_trading_type",
+          "type": "cross_chain_trading_type",
+          "typeSchema": "trading_comps",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'disallowAll'"
+        }
+      },
+      "indexes": {
+        "idx_competitions_cross_chain_trading": {
+          "name": "idx_competitions_cross_chain_trading",
+          "columns": [
+            {
+              "expression": "cross_chain_trading_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trading_competitions_competitionId_competitions_id_fk": {
+          "name": "trading_competitions_competitionId_competitions_id_fk",
+          "tableFrom": "trading_competitions",
+          "tableTo": "competitions",
+          "columnsFrom": ["competitionId"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "trading_comps.trading_competitions_leaderboard": {
+      "name": "trading_competitions_leaderboard",
+      "schema": "trading_comps",
+      "columns": {
+        "competitions_leaderboard_id": {
+          "name": "competitions_leaderboard_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pnl": {
+          "name": "pnl",
+          "type": "numeric(30, 15)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_trading_competitions_leaderboard_pnl": {
+          "name": "idx_trading_competitions_leaderboard_pnl",
+          "columns": [
+            {
+              "expression": "pnl",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trading_competitions_leaderboard_competitions_leaderboard_id_competitions_leaderboard_id_fk": {
+          "name": "trading_competitions_leaderboard_competitions_leaderboard_id_competitions_leaderboard_id_fk",
+          "tableFrom": "trading_competitions_leaderboard",
+          "tableTo": "competitions_leaderboard",
+          "columnsFrom": ["competitions_leaderboard_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.epochs": {
+      "name": "epochs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "epochs_number_unique": {
+          "name": "epochs_number_unique",
+          "nullsNotDistinct": false,
+          "columns": ["number"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rewards": {
+      "name": "rewards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "epoch": {
+          "name": "epoch",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(78, 0)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "leaf_hash": {
+          "name": "leaf_hash",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimed": {
+          "name": "claimed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_rewards_epoch": {
+          "name": "idx_rewards_epoch",
+          "columns": [
+            {
+              "expression": "epoch",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_rewards_address": {
+          "name": "idx_rewards_address",
+          "columns": [
+            {
+              "expression": "address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rewards_epoch_epochs_id_fk": {
+          "name": "rewards_epoch_epochs_id_fk",
+          "tableFrom": "rewards",
+          "tableTo": "epochs",
+          "columnsFrom": ["epoch"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rewards_roots": {
+      "name": "rewards_roots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "epoch": {
+          "name": "epoch",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root_hash": {
+          "name": "root_hash",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tx": {
+          "name": "tx",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_rewards_roots_epoch": {
+          "name": "uq_rewards_roots_epoch",
+          "columns": [
+            {
+              "expression": "epoch",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rewards_roots_epoch_epochs_id_fk": {
+          "name": "rewards_roots_epoch_epochs_id_fk",
+          "tableFrom": "rewards_roots",
+          "tableTo": "epochs",
+          "columnsFrom": ["epoch"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rewards_tree": {
+      "name": "rewards_tree",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "epoch": {
+          "name": "epoch",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idx": {
+          "name": "idx",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_rewards_tree_epoch_level_idx": {
+          "name": "idx_rewards_tree_epoch_level_idx",
+          "columns": [
+            {
+              "expression": "epoch",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "level",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idx",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_rewards_tree_level_hash": {
+          "name": "idx_rewards_tree_level_hash",
+          "columns": [
+            {
+              "expression": "level",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_rewards_tree_level_idx": {
+          "name": "idx_rewards_tree_level_idx",
+          "columns": [
+            {
+              "expression": "level",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idx",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rewards_tree_epoch_epochs_id_fk": {
+          "name": "rewards_tree_epoch_epochs_id_fk",
+          "tableFrom": "rewards_tree",
+          "tableTo": "epochs",
+          "columnsFrom": ["epoch"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stakes": {
+      "name": "stakes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token_id": {
+          "name": "token_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(78, 0)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "epoch_created": {
+          "name": "epoch_created",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "staked_at": {
+          "name": "staked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "can_unstake_after": {
+          "name": "can_unstake_after",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unstaked_at": {
+          "name": "unstaked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "can_withdraw_after": {
+          "name": "can_withdraw_after",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "withdrawn_at": {
+          "name": "withdrawn_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "relocked_at": {
+          "name": "relocked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_stakes_address": {
+          "name": "idx_stakes_address",
+          "columns": [
+            {
+              "expression": "address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stakes_user_id_users_id_fk": {
+          "name": "stakes_user_id_users_id_fk",
+          "tableFrom": "stakes",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "stakes_epoch_created_epochs_id_fk": {
+          "name": "stakes_epoch_created_epochs_id_fk",
+          "tableFrom": "stakes",
+          "tableTo": "epochs",
+          "columnsFrom": ["epoch_created"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vote_assignments": {
+      "name": "vote_assignments",
+      "schema": "",
+      "columns": {
+        "stake_id": {
+          "name": "stake_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "epoch": {
+          "name": "epoch",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(78, 0)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_vote_assignments_user_epoch": {
+          "name": "idx_vote_assignments_user_epoch",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "epoch",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_vote_assignments_epoch": {
+          "name": "idx_vote_assignments_epoch",
+          "columns": [
+            {
+              "expression": "epoch",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vote_assignments_stake_id_stakes_id_fk": {
+          "name": "vote_assignments_stake_id_stakes_id_fk",
+          "tableFrom": "vote_assignments",
+          "tableTo": "stakes",
+          "columnsFrom": ["stake_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vote_assignments_user_id_users_id_fk": {
+          "name": "vote_assignments_user_id_users_id_fk",
+          "tableFrom": "vote_assignments",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vote_assignments_epoch_epochs_id_fk": {
+          "name": "vote_assignments_epoch_epochs_id_fk",
+          "tableFrom": "vote_assignments",
+          "tableTo": "epochs",
+          "columnsFrom": ["epoch"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "vote_assignments_pkey": {
+          "name": "vote_assignments_pkey",
+          "columns": ["stake_id", "user_id", "epoch"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.votes_available": {
+      "name": "votes_available",
+      "schema": "",
+      "columns": {
+        "address": {
+          "name": "address",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "epoch": {
+          "name": "epoch",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(78, 0)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_number": {
+          "name": "block_number",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transaction_hash": {
+          "name": "transaction_hash",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "log_index": {
+          "name": "log_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "votes_available_epoch_epochs_id_fk": {
+          "name": "votes_available_epoch_epochs_id_fk",
+          "tableFrom": "votes_available",
+          "tableTo": "epochs",
+          "columnsFrom": ["epoch"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "votes_available_pkey": {
+          "name": "votes_available_pkey",
+          "columns": ["address", "epoch"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.votes_performed": {
+      "name": "votes_performed",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "epoch": {
+          "name": "epoch",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(78, 0)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_votes_performed_agent_epoch": {
+          "name": "idx_votes_performed_agent_epoch",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "epoch",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_votes_performed_epoch": {
+          "name": "idx_votes_performed_epoch",
+          "columns": [
+            {
+              "expression": "epoch",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "votes_performed_user_id_users_id_fk": {
+          "name": "votes_performed_user_id_users_id_fk",
+          "tableFrom": "votes_performed",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "votes_performed_agent_id_agents_id_fk": {
+          "name": "votes_performed_agent_id_agents_id_fk",
+          "tableFrom": "votes_performed",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "votes_performed_epoch_epochs_id_fk": {
+          "name": "votes_performed_epoch_epochs_id_fk",
+          "tableFrom": "votes_performed",
+          "tableTo": "epochs",
+          "columnsFrom": ["epoch"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "votes_performed_pkey": {
+          "name": "votes_performed_pkey",
+          "columns": ["user_id", "agent_id", "epoch"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.actor_status": {
+      "name": "actor_status",
+      "schema": "public",
+      "values": ["active", "inactive", "suspended", "deleted"]
+    },
+    "public.competition_agent_status": {
+      "name": "competition_agent_status",
+      "schema": "public",
+      "values": ["active", "withdrawn", "disqualified"]
+    },
+    "public.competition_status": {
+      "name": "competition_status",
+      "schema": "public",
+      "values": ["pending", "active", "ended"]
+    },
+    "public.competition_type": {
+      "name": "competition_type",
+      "schema": "public",
+      "values": ["trading"]
+    },
+    "public.sync_data_type": {
+      "name": "sync_data_type",
+      "schema": "public",
+      "values": [
+        "trade",
+        "agent_score_history",
+        "agent_score",
+        "competitions_leaderboard",
+        "portfolio_snapshot"
+      ]
+    },
+    "trading_comps.cross_chain_trading_type": {
+      "name": "cross_chain_trading_type",
+      "schema": "trading_comps",
+      "values": ["disallowAll", "disallowXParent", "allow"]
+    }
+  },
+  "schemas": {
+    "trading_comps": "trading_comps"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -155,6 +155,13 @@
       "when": 1752182200160,
       "tag": "0021_little_photon",
       "breakpoints": true
+    },
+    {
+      "idx": 22,
+      "version": "7",
+      "when": 1752786251228,
+      "tag": "0022_giant_gabe_jones",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/e2e/utils/api-client.ts
+++ b/apps/api/e2e/utils/api-client.ts
@@ -421,6 +421,8 @@ export class ApiClient {
     endDate?: string,
     votingStartDate?: string,
     votingEndDate?: string,
+    joinStartDate?: string,
+    joinEndDate?: string,
   ): Promise<CreateCompetitionResponse | ErrorResponse> {
     try {
       const response = await this.axiosInstance.post(
@@ -436,6 +438,8 @@ export class ApiClient {
           endDate,
           votingStartDate,
           votingEndDate,
+          joinStartDate,
+          joinEndDate,
         },
       );
 

--- a/apps/api/e2e/utils/api-types.ts
+++ b/apps/api/e2e/utils/api-types.ts
@@ -359,6 +359,9 @@ export interface Competition {
   votingEndDate: string | null;
   votingEnabled?: boolean;
   userVotingInfo?: CompetitionVotingState;
+  // Join date constraint fields
+  joinStartDate: string | null;
+  joinEndDate: string | null;
 }
 
 // Leaderboard entry (per-competition leaderboard)

--- a/apps/api/e2e/utils/test-helpers.ts
+++ b/apps/api/e2e/utils/test-helpers.ts
@@ -174,6 +174,8 @@ export async function createTestCompetition(
   type?: string,
   votingStartDate?: string,
   votingEndDate?: string,
+  joinStartDate?: string,
+  joinEndDate?: string,
 ): Promise<CreateCompetitionResponse> {
   // Ensure database is initialized
   await ensureDatabaseInitialized();
@@ -189,6 +191,8 @@ export async function createTestCompetition(
     undefined, // endDate
     votingStartDate,
     votingEndDate,
+    joinStartDate,
+    joinEndDate,
   );
 
   if (!result.success) {

--- a/apps/api/openapi/API.md
+++ b/apps/api/openapi/API.md
@@ -81,12 +81,12 @@ Create a new competition without starting it. It will be in PENDING status and c
 
 ##### Responses
 
-| Code | Description                                  |
-| ---- | -------------------------------------------- |
-| 201  | Competition created successfully             |
-| 400  | Missing required parameters                  |
-| 401  | Unauthorized - Admin authentication required |
-| 500  | Server error                                 |
+| Code | Description                                                                                                                   |
+| ---- | ----------------------------------------------------------------------------------------------------------------------------- |
+| 201  | Competition created successfully                                                                                              |
+| 400  | Bad Request - Various validation errors: - Missing required parameters - joinStartDate must be before or equal to joinEndDate |
+| 401  | Unauthorized - Admin authentication required                                                                                  |
+| 500  | Server error                                                                                                                  |
 
 ##### Security
 

--- a/apps/api/openapi/API.md
+++ b/apps/api/openapi/API.md
@@ -1335,14 +1335,14 @@ Register an agent for a pending competition
 
 ##### Responses
 
-| Code | Description                                                                                                                                                                                                                                       |
-| ---- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 200  | Successfully joined competition                                                                                                                                                                                                                   |
-| 400  | Bad request - Invalid UUID format for competitionId or agentId                                                                                                                                                                                    |
-| 401  | Unauthorized - Missing or invalid authentication                                                                                                                                                                                                  |
-| 403  | Forbidden - Various business rule violations: - Cannot join competition that has already started/ended - Agent does not belong to requesting user - Agent is already registered for this competition - Agent is not eligible to join competitions |
-| 404  | Competition or agent not found                                                                                                                                                                                                                    |
-| 500  | Server error                                                                                                                                                                                                                                      |
+| Code | Description                                                                                                                                                                                                                                                                                                                                                            |
+| ---- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 200  | Successfully joined competition                                                                                                                                                                                                                                                                                                                                        |
+| 400  | Bad request - Invalid UUID format for competitionId or agentId                                                                                                                                                                                                                                                                                                         |
+| 401  | Unauthorized - Missing or invalid authentication                                                                                                                                                                                                                                                                                                                       |
+| 403  | Forbidden - Various business rule violations: - Cannot join competition that has already started/ended - Competition joining has not yet opened (before joinStartDate) - Competition joining has closed (after joinEndDate) - Agent does not belong to requesting user - Agent is already registered for this competition - Agent is not eligible to join competitions |
+| 404  | Competition or agent not found                                                                                                                                                                                                                                                                                                                                         |
+| 500  | Server error                                                                                                                                                                                                                                                                                                                                                           |
 
 ##### Security
 
@@ -1477,32 +1477,6 @@ Get global leaderboard data across all relevant competitions
 | 200  | Global leaderboard data |
 | 400  | Invalid parameters      |
 | 500  | Server error            |
-
-### /api/metrics
-
-#### GET
-
-##### Summary:
-
-Get Prometheus metrics
-
-##### Description:
-
-Expose Prometheus metrics for monitoring (admin-only endpoint)
-
-##### Responses
-
-| Code | Description                                  |
-| ---- | -------------------------------------------- |
-| 200  | Prometheus metrics in text format            |
-| 401  | Unauthorized - Admin authentication required |
-| 500  | Error generating metrics                     |
-
-##### Security
-
-| Security Schema | Scopes |
-| --------------- | ------ |
-| BearerAuth      |        |
 
 ### /api/price
 

--- a/apps/api/openapi/openapi.json
+++ b/apps/api/openapi/openapi.json
@@ -334,6 +334,12 @@
                     "description": "URL to competition image",
                     "example": "https://example.com/competition-image.jpg"
                   },
+                  "endDate": {
+                    "type": "string",
+                    "format": "date-time",
+                    "description": "End date for the competition (ISO 8601 format)",
+                    "example": "2024-02-15T23:59:59Z"
+                  },
                   "votingStartDate": {
                     "type": "string",
                     "format": "date-time",
@@ -345,6 +351,18 @@
                     "format": "date-time",
                     "description": "End date for voting (ISO 8601 format)",
                     "example": "2024-01-30T23:59:59Z"
+                  },
+                  "joinStartDate": {
+                    "type": "string",
+                    "format": "date-time",
+                    "description": "Start date for joining the competition (ISO 8601 format)",
+                    "example": "2024-01-01T00:00:00Z"
+                  },
+                  "joinEndDate": {
+                    "type": "string",
+                    "format": "date-time",
+                    "description": "End date for joining the competition (ISO 8601 format)",
+                    "example": "2024-01-14T23:59:59Z"
                   }
                 }
               }
@@ -473,6 +491,12 @@
                     "type": "string",
                     "description": "URL to competition image (used when creating a new competition)",
                     "example": "https://example.com/competition-image.jpg"
+                  },
+                  "endDate": {
+                    "type": "string",
+                    "format": "date-time",
+                    "description": "End date for the competition (ISO 8601 format)",
+                    "example": "2024-02-15T23:59:59Z"
                   },
                   "votingStartDate": {
                     "type": "string",
@@ -5376,7 +5400,7 @@
             "description": "Unauthorized - Missing or invalid authentication"
           },
           "403": {
-            "description": "Forbidden - Various business rule violations:\n- Cannot join competition that has already started/ended\n- Agent does not belong to requesting user\n- Agent is already registered for this competition\n- Agent is not eligible to join competitions\n"
+            "description": "Forbidden - Various business rule violations:\n- Cannot join competition that has already started/ended\n- Competition joining has not yet opened (before joinStartDate)\n- Competition joining has closed (after joinEndDate)\n- Agent does not belong to requesting user\n- Agent is already registered for this competition\n- Agent is not eligible to join competitions\n"
           },
           "404": {
             "description": "Competition or agent not found"
@@ -5799,37 +5823,6 @@
           },
           "500": {
             "description": "Server error"
-          }
-        }
-      }
-    },
-    "/api/metrics": {
-      "get": {
-        "tags": ["Admin"],
-        "summary": "Get Prometheus metrics",
-        "description": "Expose Prometheus metrics for monitoring (admin-only endpoint)",
-        "security": [
-          {
-            "BearerAuth": []
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Prometheus metrics in text format",
-            "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "string",
-                  "example": "# HELP http_requests_total Total number of HTTP requests\n# TYPE http_requests_total counter\nhttp_requests_total{method=\"GET\",route=\"/api/agent/profile\",status_code=\"200\"} 42\n\n# HELP http_request_duration_ms Duration of HTTP requests in milliseconds\n# TYPE http_request_duration_ms histogram\nhttp_request_duration_ms_bucket{method=\"GET\",route=\"/api/agent/profile\",status_code=\"200\",le=\"10\"} 15\n\n# HELP repository_queries_total Total number of repository queries\n# TYPE repository_queries_total counter\nrepository_queries_total{repository=\"AgentRepository\",method=\"getAgent\",operation=\"SELECT\"} 28\n"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized - Admin authentication required"
-          },
-          "500": {
-            "description": "Error generating metrics"
           }
         }
       }

--- a/apps/api/openapi/openapi.json
+++ b/apps/api/openapi/openapi.json
@@ -355,13 +355,13 @@
                   "joinStartDate": {
                     "type": "string",
                     "format": "date-time",
-                    "description": "Start date for joining the competition (ISO 8601 format)",
+                    "description": "Start date for joining the competition (ISO 8601 format). Must be before or equal to joinEndDate if both are provided.",
                     "example": "2024-01-01T00:00:00Z"
                   },
                   "joinEndDate": {
                     "type": "string",
                     "format": "date-time",
-                    "description": "End date for joining the competition (ISO 8601 format)",
+                    "description": "End date for joining the competition (ISO 8601 format). Must be after or equal to joinStartDate if both are provided.",
                     "example": "2024-01-14T23:59:59Z"
                   }
                 }
@@ -439,7 +439,7 @@
             }
           },
           "400": {
-            "description": "Missing required parameters"
+            "description": "Bad Request - Various validation errors:\n- Missing required parameters\n- joinStartDate must be before or equal to joinEndDate"
           },
           "401": {
             "description": "Unauthorized - Admin authentication required"

--- a/apps/api/src/controllers/admin.controller.ts
+++ b/apps/api/src/controllers/admin.controller.ts
@@ -545,6 +545,8 @@ export function makeAdminController(services: ServiceRegistry) {
           endDate,
           votingStartDate,
           votingEndDate,
+          joinStartDate,
+          joinEndDate,
         } = result.data;
 
         // Create a new competition
@@ -559,6 +561,8 @@ export function makeAdminController(services: ServiceRegistry) {
           endDate ? new Date(endDate) : undefined,
           votingStartDate ? new Date(votingStartDate) : undefined,
           votingEndDate ? new Date(votingEndDate) : undefined,
+          joinStartDate ? new Date(joinStartDate) : undefined,
+          joinEndDate ? new Date(joinEndDate) : undefined,
         );
 
         // Return the created competition

--- a/apps/api/src/controllers/admin.schema.ts
+++ b/apps/api/src/controllers/admin.schema.ts
@@ -41,20 +41,33 @@ export const AdminRegisterUserSchema = z.object({
 /**
  * Admin create competition schema
  */
-export const AdminCreateCompetitionSchema = z.object({
-  name: z.string().min(1, "Competition name is required"),
-  description: z.string().optional(),
-  tradingType: CrossChainTradingTypeSchema.optional(),
-  sandboxMode: z.boolean().optional(),
-  externalUrl: z.url().optional(),
-  imageUrl: z.url().optional(),
-  type: CompetitionTypeSchema.optional(),
-  endDate: z.iso.datetime().optional(),
-  votingStartDate: z.iso.datetime().optional(),
-  votingEndDate: z.iso.datetime().optional(),
-  joinStartDate: z.iso.datetime().optional(),
-  joinEndDate: z.iso.datetime().optional(),
-});
+export const AdminCreateCompetitionSchema = z
+  .object({
+    name: z.string().min(1, "Competition name is required"),
+    description: z.string().optional(),
+    tradingType: CrossChainTradingTypeSchema.optional(),
+    sandboxMode: z.boolean().optional(),
+    externalUrl: z.url().optional(),
+    imageUrl: z.url().optional(),
+    type: CompetitionTypeSchema.optional(),
+    endDate: z.iso.datetime().optional(),
+    votingStartDate: z.iso.datetime().optional(),
+    votingEndDate: z.iso.datetime().optional(),
+    joinStartDate: z.iso.datetime().optional(),
+    joinEndDate: z.iso.datetime().optional(),
+  })
+  .refine(
+    (data) => {
+      if (data.joinStartDate && data.joinEndDate) {
+        return new Date(data.joinStartDate) <= new Date(data.joinEndDate);
+      }
+      return true;
+    },
+    {
+      message: "joinStartDate must be before or equal to joinEndDate",
+      path: ["joinStartDate"],
+    },
+  );
 
 /**
  * Admin start competition schema

--- a/apps/api/src/controllers/admin.schema.ts
+++ b/apps/api/src/controllers/admin.schema.ts
@@ -52,6 +52,8 @@ export const AdminCreateCompetitionSchema = z.object({
   endDate: z.iso.datetime().optional(),
   votingStartDate: z.iso.datetime().optional(),
   votingEndDate: z.iso.datetime().optional(),
+  joinStartDate: z.iso.datetime().optional(),
+  joinEndDate: z.iso.datetime().optional(),
 });
 
 /**

--- a/apps/api/src/database/schema/core/defs.ts
+++ b/apps/api/src/database/schema/core/defs.ts
@@ -183,6 +183,8 @@ export const competitions = pgTable(
     endDate: timestamp("end_date", { withTimezone: true }),
     votingStartDate: timestamp("voting_start_date", { withTimezone: true }),
     votingEndDate: timestamp("voting_end_date", { withTimezone: true }),
+    joinStartDate: timestamp("join_start_date", { withTimezone: true }),
+    joinEndDate: timestamp("join_end_date", { withTimezone: true }),
     status: competitionStatus("status").notNull(),
     sandboxMode: boolean("sandbox_mode").notNull().default(false),
     createdAt: timestamp("created_at", {

--- a/apps/api/src/routes/admin.routes.ts
+++ b/apps/api/src/routes/admin.routes.ts
@@ -79,6 +79,16 @@ export function configureAdminRoutes(
    *                 format: date-time
    *                 description: End date for voting (ISO 8601 format)
    *                 example: "2024-01-30T23:59:59Z"
+   *               joinStartDate:
+   *                 type: string
+   *                 format: date-time
+   *                 description: Start date for joining the competition (ISO 8601 format)
+   *                 example: "2024-01-01T00:00:00Z"
+   *               joinEndDate:
+   *                 type: string
+   *                 format: date-time
+   *                 description: End date for joining the competition (ISO 8601 format)
+   *                 example: "2024-01-14T23:59:59Z"
    *     responses:
    *       201:
    *         description: Competition created successfully

--- a/apps/api/src/routes/admin.routes.ts
+++ b/apps/api/src/routes/admin.routes.ts
@@ -82,12 +82,12 @@ export function configureAdminRoutes(
    *               joinStartDate:
    *                 type: string
    *                 format: date-time
-   *                 description: Start date for joining the competition (ISO 8601 format)
+   *                 description: Start date for joining the competition (ISO 8601 format). Must be before or equal to joinEndDate if both are provided.
    *                 example: "2024-01-01T00:00:00Z"
    *               joinEndDate:
    *                 type: string
    *                 format: date-time
-   *                 description: End date for joining the competition (ISO 8601 format)
+   *                 description: End date for joining the competition (ISO 8601 format). Must be after or equal to joinStartDate if both are provided.
    *                 example: "2024-01-14T23:59:59Z"
    *     responses:
    *       201:
@@ -141,7 +141,10 @@ export function configureAdminRoutes(
    *                       format: date-time
    *                       description: Competition creation date
    *       400:
-   *         description: Missing required parameters
+   *         description: |-
+   *           Bad Request - Various validation errors:
+   *           - Missing required parameters
+   *           - joinStartDate must be before or equal to joinEndDate
    *       401:
    *         description: Unauthorized - Admin authentication required
    *       500:

--- a/apps/api/src/routes/competitions.routes.ts
+++ b/apps/api/src/routes/competitions.routes.ts
@@ -890,6 +890,8 @@ export function configureCompetitionsRoutes(
    *         description: |
    *           Forbidden - Various business rule violations:
    *           - Cannot join competition that has already started/ended
+   *           - Competition joining has not yet opened (before joinStartDate)
+   *           - Competition joining has closed (after joinEndDate)
    *           - Agent does not belong to requesting user
    *           - Agent is already registered for this competition
    *           - Agent is not eligible to join competitions

--- a/apps/api/src/services/competition-manager.service.ts
+++ b/apps/api/src/services/competition-manager.service.ts
@@ -977,15 +977,7 @@ export class CompetitionManager {
       throw new Error("Agent does not belong to requesting user");
     }
 
-    // 4. Check agent status is eligible
-    if (
-      agent.status === ACTOR_STATUS.DELETED ||
-      agent.status === ACTOR_STATUS.SUSPENDED
-    ) {
-      throw new Error("Agent is not eligible to join competitions");
-    }
-
-    // 5. Check join date constraints (only if dates are provided)
+    // 4. Check join date constraints FIRST (must take precedence over other errors)
     const now = new Date();
 
     if (competition.joinStartDate && now < competition.joinStartDate) {
@@ -1004,6 +996,14 @@ export class CompetitionManager {
       error.type = COMPETITION_JOIN_ERROR_TYPES.JOIN_CLOSED;
       error.code = 403;
       throw error;
+    }
+
+    // 5. Check agent status is eligible
+    if (
+      agent.status === ACTOR_STATUS.DELETED ||
+      agent.status === ACTOR_STATUS.SUSPENDED
+    ) {
+      throw new Error("Agent is not eligible to join competitions");
     }
 
     // 6. Check if competition status is pending

--- a/apps/api/src/types/index.ts
+++ b/apps/api/src/types/index.ts
@@ -399,6 +399,8 @@ export interface Competition {
   endDate: Date | null;
   votingStartDate: Date | null;
   votingEndDate: Date | null;
+  joinStartDate: Date | null;
+  joinEndDate: Date | null;
   status: CompetitionStatus;
   crossChainTradingType: CrossChainTradingType; // Controls cross-chain trading behavior
   sandboxMode: boolean; // Controls automatic agent joining behavior
@@ -1119,3 +1121,27 @@ export const AdminSearchUsersAndAgentsQuerySchema = z.strictObject({
 export type AdminSearchUsersAndAgentsQuery = z.infer<
   typeof AdminSearchUsersAndAgentsQuerySchema
 >;
+
+/**
+ * Competition join error types for specific error handling
+ */
+export const COMPETITION_JOIN_ERROR_TYPES = {
+  COMPETITION_NOT_FOUND: "COMPETITION_NOT_FOUND",
+  AGENT_NOT_FOUND: "AGENT_NOT_FOUND",
+  AGENT_NOT_ELIGIBLE: "AGENT_NOT_ELIGIBLE",
+  COMPETITION_ALREADY_STARTED: "COMPETITION_ALREADY_STARTED",
+  AGENT_ALREADY_REGISTERED: "AGENT_ALREADY_REGISTERED",
+  JOIN_NOT_YET_OPEN: "JOIN_NOT_YET_OPEN",
+  JOIN_CLOSED: "JOIN_CLOSED",
+} as const;
+
+export type CompetitionJoinErrorType =
+  (typeof COMPETITION_JOIN_ERROR_TYPES)[keyof typeof COMPETITION_JOIN_ERROR_TYPES];
+
+/**
+ * Competition join error interface
+ */
+export interface CompetitionJoinError extends Error {
+  type: CompetitionJoinErrorType;
+  code: number;
+}


### PR DESCRIPTION
# Competition Join Date Constraints - Implementation Summary

## Overview
Added optional `joinStartDate` and `joinEndDate` fields to competitions, allowing administrators to configure time-based restrictions on when agents can join pending competitions.

## Key Features
- **Optional constraints**: When dates are not provided, existing behavior is preserved (backward compatible)
- **Time-based validation**: Agents can only join competitions within the configured time window
- **Admin-only configuration**: Join dates can only be set during competition creation
- **Clear error messages**: Users receive specific error messages with actual opening/closing times

## Database Changes
- Added `joinStartDate` and `joinEndDate` timestamp fields to `competitions` table
- Fields are nullable for backward compatibility
- Database migrations generated and applied

## API Enhancements

### Admin Endpoints
- **POST `/api/admin/competition/create`**: Added optional `joinStartDate` and `joinEndDate` parameters
- **POST `/api/admin/competition/start`**: Join dates can only be set during creation, not when starting existing competitions

### Validation Logic
- Join requests are validated against date constraints before existing business rules
- Validation only applies when dates are provided (null dates are ignored)
- Enhanced error handling with typed error system following established `VoteManager` patterns

## Error Handling Improvements
- Implemented typed error system with `CompetitionJoinError` interface
- Added `COMPETITION_JOIN_ERROR_TYPES` constants for maintainable error handling
- Controller properly maps service errors to appropriate HTTP status codes
- Error messages include specific opening/closing times for better UX

## Testing
- **Comprehensive e2e test suite** covering all scenarios:
  - Valid join within time window
  - Rejection before join start date  
  - Rejection after join end date
  - Backward compatibility with null dates
  - Error message validation
- **Updated test infrastructure** (API client, types, helpers) to support new parameters
- All tests passing with proper error validation

## Documentation Updates
- **OpenAPI specifications** updated for all relevant endpoints
- **Join competition endpoint** now documents new 403 error scenarios
- **Admin endpoints** properly document new optional date fields
- **Type definitions** updated across the codebase

## Validation Rules
1. **Date Logic**: `joinStartDate` <= current time <= `joinEndDate`
2. **Precedence**: Date validation occurs before existing business rule checks
3. **Null Handling**: Null dates are ignored (no restrictions applied)
4. **Error Priority**: Date constraint errors take precedence over other join restrictions

## Files Modified
- `apps/api/src/database/schema/core/defs.ts` - Schema changes
- `apps/api/src/types/index.ts` - Type definitions and error constants
- `apps/api/src/services/competition-manager.service.ts` - Business logic
- `apps/api/src/controllers/admin.controller.ts` - Admin endpoints
- `apps/api/src/controllers/admin.schema.ts` - Request validation
- `apps/api/src/controllers/competition.controller.ts` - Error handling
- `apps/api/src/routes/admin.routes.ts` - OpenAPI documentation
- `apps/api/src/routes/competitions.routes.ts` - OpenAPI documentation
- E2E test infrastructure and comprehensive test cases

## Migration Notes
- Database migrations generated and applied
- No breaking changes to existing API contracts
- Feature is immediately available for new competitions
- Existing competitions continue to work without modification 