### PR TITLE
feat(comps): remove agent name update

### DIFF
--- a/apps/api/e2e/tests/admin.test.ts
+++ b/apps/api/e2e/tests/admin.test.ts
@@ -382,6 +382,43 @@ describe("Admin API", () => {
     expect(usersResult.users![0]?.email).toBe(userEmail);
   });
 
+  test("should update an agent as admin", async () => {
+    // Setup admin client with the API key
+    const adminClient = createTestClient();
+    await adminClient.loginAsAdmin(adminApiKey);
+
+    // Register a new user with agent first
+    const userName = `User To Update ${Date.now()}`;
+    const userEmail = `update-${Date.now()}@test.com`;
+    const agentName = `Agent To Update ${Date.now()}`;
+
+    const registerResult = (await adminClient.registerUser({
+      walletAddress: generateRandomEthAddress(),
+      name: userName,
+      email: userEmail,
+      agentName,
+    })) as UserRegistrationResponse;
+    expect(registerResult.success).toBe(true);
+    expect(registerResult.agent).toBeDefined();
+
+    // Now update the agent
+    const updateResult = (await adminClient.updateAgentAsAdmin(
+      registerResult.agent!.id,
+      {
+        name: "Updated Name",
+        description: "Updated Description",
+        imageUrl: "https://example.com/updated-image.jpg",
+      },
+    )) as AgentProfileResponse;
+    expect(updateResult.success).toBe(true);
+    expect(updateResult.agent).toBeDefined();
+    expect(updateResult.agent.name).toBe("Updated Name");
+    expect(updateResult.agent.description).toBe("Updated Description");
+    expect(updateResult.agent.imageUrl).toBe(
+      "https://example.com/updated-image.jpg",
+    );
+  });
+
   test("should delete an agent as admin", async () => {
     // Setup admin client with the API key
     const adminClient = createTestClient();

--- a/apps/api/e2e/utils/api-client.ts
+++ b/apps/api/e2e/utils/api-client.ts
@@ -533,10 +533,9 @@ export class ApiClient {
 
   /**
    * Update an agent profile
-   * @param profileData Profile data to update including name, description, and imageUrl only (agents have limited self-service editing)
+   * @param profileData Profile data to update including description and imageUrl only (agents have limited self-service editing)
    */
   async updateAgentProfile(profileData: {
-    name?: string;
     description?: string;
     imageUrl?: string;
   }): Promise<AgentProfileResponse | ErrorResponse> {
@@ -621,6 +620,32 @@ export class ApiClient {
       return response.data;
     } catch (error) {
       return this.handleApiError(error, "list users");
+    }
+  }
+
+  /**
+   * Update an agent (admin only)
+   * @param agentId ID of the agent to update
+   * @param body Body of the update request
+   */
+  async updateAgentAsAdmin(
+    agentId: string,
+    body: {
+      name?: string;
+      description?: string;
+      imageUrl?: string;
+      email?: string;
+      metadata?: Record<string, unknown>;
+    },
+  ): Promise<ApiResponse | ErrorResponse> {
+    try {
+      const response = await this.axiosInstance.put(
+        `/api/admin/agents/${agentId}`,
+        body,
+      );
+      return response.data;
+    } catch (error) {
+      return this.handleApiError(error, "delete agent");
     }
   }
 

--- a/apps/api/e2e/utils/api-client.ts
+++ b/apps/api/e2e/utils/api-client.ts
@@ -645,7 +645,7 @@ export class ApiClient {
       );
       return response.data;
     } catch (error) {
-      return this.handleApiError(error, "delete agent");
+      return this.handleApiError(error, "update agent");
     }
   }
 

--- a/apps/api/openapi/API.md
+++ b/apps/api/openapi/API.md
@@ -455,6 +455,38 @@ Get detailed information about a specific agent
 | --------------- | ------ |
 | BearerAuth      |        |
 
+#### PUT
+
+##### Summary:
+
+Update an agent
+
+##### Description:
+
+Update an agent's information including name, description, email, and metadata
+
+##### Parameters
+
+| Name    | Located in | Description               | Required | Schema |
+| ------- | ---------- | ------------------------- | -------- | ------ |
+| agentId | path       | ID of the agent to update | Yes      | string |
+
+##### Responses
+
+| Code | Description                                  |
+| ---- | -------------------------------------------- |
+| 200  | Agent updated successfully                   |
+| 400  | Invalid parameters or request body           |
+| 401  | Unauthorized - Admin authentication required |
+| 404  | Agent not found                              |
+| 500  | Server error                                 |
+
+##### Security
+
+| Security Schema | Scopes |
+| --------------- | ------ |
+| BearerAuth      |        |
+
 ### /api/admin/agents/{agentId}/deactivate
 
 #### POST
@@ -771,13 +803,13 @@ Update the profile information for the currently authenticated agent (limited fi
 
 ##### Responses
 
-| Code | Description                                                                      |
-| ---- | -------------------------------------------------------------------------------- |
-| 200  | Agent profile updated successfully                                               |
-| 400  | Invalid fields provided (agents can only update name, description, and imageUrl) |
-| 401  | Agent not authenticated                                                          |
-| 404  | Agent not found                                                                  |
-| 500  | Internal server error                                                            |
+| Code | Description                                                               |
+| ---- | ------------------------------------------------------------------------- |
+| 200  | Agent profile updated successfully                                        |
+| 400  | Invalid fields provided (agents can only update description and imageUrl) |
+| 401  | Agent not authenticated                                                   |
+| 404  | Agent not found                                                           |
+| 500  | Internal server error                                                     |
 
 ##### Security
 

--- a/apps/api/openapi/openapi.json
+++ b/apps/api/openapi/openapi.json
@@ -1975,6 +1975,152 @@
             "description": "Server error"
           }
         }
+      },
+      "put": {
+        "tags": ["Admin"],
+        "summary": "Update an agent",
+        "description": "Update an agent's information including name, description, email, and metadata",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "agentId",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "ID of the agent to update"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "Agent's new name",
+                    "example": "Updated Trading Bot"
+                  },
+                  "description": {
+                    "type": "string",
+                    "description": "Agent's new description",
+                    "example": "Updated description"
+                  },
+                  "imageUrl": {
+                    "type": "string",
+                    "description": "URL to agent's new profile image",
+                    "example": "https://example.com/new-bot-avatar.jpg"
+                  },
+                  "email": {
+                    "type": "string",
+                    "description": "Agent's new email",
+                    "example": "newemail@example.com"
+                  },
+                  "metadata": {
+                    "type": "object",
+                    "description": "Agent's new metadata",
+                    "example": {
+                      "strategy": "updated-strategy"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Agent updated successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "description": "Operation success status"
+                    },
+                    "agent": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "description": "Agent ID"
+                        },
+                        "ownerId": {
+                          "type": "string",
+                          "description": "Agent owner ID"
+                        },
+                        "walletAddress": {
+                          "type": "string",
+                          "description": "Agent wallet address",
+                          "nullable": true
+                        },
+                        "name": {
+                          "type": "string",
+                          "description": "Agent name"
+                        },
+                        "email": {
+                          "type": "string",
+                          "description": "Agent email",
+                          "nullable": true
+                        },
+                        "description": {
+                          "type": "string",
+                          "description": "Agent description",
+                          "nullable": true
+                        },
+                        "status": {
+                          "type": "string",
+                          "description": "Agent status"
+                        },
+                        "imageUrl": {
+                          "type": "string",
+                          "description": "URL to the agent's image",
+                          "nullable": true
+                        },
+                        "metadata": {
+                          "type": "object",
+                          "description": "Agent metadata",
+                          "nullable": true
+                        },
+                        "createdAt": {
+                          "type": "string",
+                          "format": "date-time",
+                          "description": "Agent creation timestamp"
+                        },
+                        "updatedAt": {
+                          "type": "string",
+                          "format": "date-time",
+                          "description": "Agent update timestamp"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid parameters or request body"
+          },
+          "401": {
+            "description": "Unauthorized - Admin authentication required"
+          },
+          "404": {
+            "description": "Agent not found"
+          },
+          "500": {
+            "description": "Server error"
+          }
+        }
       }
     },
     "/api/admin/agents/{agentId}/deactivate": {
@@ -3014,11 +3160,6 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "name": {
-                    "type": "string",
-                    "description": "Agent's display name",
-                    "example": "Trading Bot Beta"
-                  },
                   "description": {
                     "type": "string",
                     "description": "Agent description",
@@ -3102,7 +3243,7 @@
             }
           },
           "400": {
-            "description": "Invalid fields provided (agents can only update name, description, and imageUrl)"
+            "description": "Invalid fields provided (agents can only update description and imageUrl)"
           },
           "401": {
             "description": "Agent not authenticated"

--- a/apps/api/src/controllers/admin.schema.ts
+++ b/apps/api/src/controllers/admin.schema.ts
@@ -207,3 +207,21 @@ export const AdminAddAgentToCompetitionParamsSchema = z.object({
   competitionId: UuidSchema,
   agentId: UuidSchema,
 });
+
+/**
+ * Admin update agent params schema
+ */
+export const AdminUpdateAgentParamsSchema = z.object({
+  agentId: UuidSchema,
+});
+
+/**
+ * Admin update agent body schema
+ */
+export const AdminUpdateAgentBodySchema = z.object({
+  name: z.string().min(1, "Name must be at least 1 character").optional(),
+  description: z.string().optional(),
+  imageUrl: z.url("Invalid image URL format").optional(),
+  email: z.email("Invalid email format").optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
+});

--- a/apps/api/src/controllers/agent.controller.ts
+++ b/apps/api/src/controllers/agent.controller.ts
@@ -78,7 +78,7 @@ export function makeAgentController(services: ServiceRegistry) {
 
     /**
      * Update profile for the authenticated agent
-     * Limited to name, description, and imageUrl only (agent self-service)
+     * Limited to description and imageUrl only (agent self-service)
      * @param req Express request with agentId from API key
      * @param res Express response
      * @param next Express next function
@@ -94,7 +94,7 @@ export function makeAgentController(services: ServiceRegistry) {
         }
         const {
           agentId,
-          body: { name, description, imageUrl },
+          body: { description, imageUrl },
         } = data;
 
         // Get the current agent
@@ -106,7 +106,6 @@ export function makeAgentController(services: ServiceRegistry) {
         // Prepare update data with only allowed fields
         const updateData = {
           id: agentId,
-          name: name ?? agent.name,
           description,
           imageUrl,
         };

--- a/apps/api/src/routes/admin.routes.ts
+++ b/apps/api/src/routes/admin.routes.ts
@@ -1429,6 +1429,115 @@ export function configureAdminRoutes(
 
   /**
    * @openapi
+   * /api/admin/agents/{agentId}:
+   *   put:
+   *     tags:
+   *       - Admin
+   *     summary: Update an agent
+   *     description: Update an agent's information including name, description, email, and metadata
+   *     security:
+   *       - BearerAuth: []
+   *     parameters:
+   *       - in: path
+   *         name: agentId
+   *         schema:
+   *           type: string
+   *         required: true
+   *         description: ID of the agent to update
+   *     requestBody:
+   *       required: true
+   *       content:
+   *         application/json:
+   *           schema:
+   *             type: object
+   *             properties:
+   *               name:
+   *                 type: string
+   *                 description: Agent's new name
+   *                 example: "Updated Trading Bot"
+   *               description:
+   *                 type: string
+   *                 description: Agent's new description
+   *                 example: "Updated description"
+   *               imageUrl:
+   *                 type: string
+   *                 description: URL to agent's new profile image
+   *                 example: "https://example.com/new-bot-avatar.jpg"
+   *               email:
+   *                 type: string
+   *                 description: Agent's new email
+   *                 example: "newemail@example.com"
+   *               metadata:
+   *                 type: object
+   *                 description: Agent's new metadata
+   *                 example: { "strategy": "updated-strategy" }
+   *     responses:
+   *       200:
+   *         description: Agent updated successfully
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   *               properties:
+   *                 success:
+   *                   type: boolean
+   *                   description: Operation success status
+   *                 agent:
+   *                   type: object
+   *                   properties:
+   *                     id:
+   *                       type: string
+   *                       description: Agent ID
+   *                     ownerId:
+   *                       type: string
+   *                       description: Agent owner ID
+   *                     walletAddress:
+   *                       type: string
+   *                       description: Agent wallet address
+   *                       nullable: true
+   *                     name:
+   *                       type: string
+   *                       description: Agent name
+   *                     email:
+   *                       type: string
+   *                       description: Agent email
+   *                       nullable: true
+   *                     description:
+   *                       type: string
+   *                       description: Agent description
+   *                       nullable: true
+   *                     status:
+   *                       type: string
+   *                       description: Agent status
+   *                     imageUrl:
+   *                       type: string
+   *                       description: URL to the agent's image
+   *                       nullable: true
+   *                     metadata:
+   *                       type: object
+   *                       description: Agent metadata
+   *                       nullable: true
+   *                     createdAt:
+   *                       type: string
+   *                       format: date-time
+   *                       description: Agent creation timestamp
+   *                     updatedAt:
+   *                       type: string
+   *                       format: date-time
+   *                       description: Agent update timestamp
+   *       400:
+   *         description: Invalid parameters or request body
+   *       401:
+   *         description: Unauthorized - Admin authentication required
+   *       404:
+   *         description: Agent not found
+   *       500:
+   *         description: Server error
+   */
+  router.put("/agents/:agentId", controller.updateAgent);
+
+  /**
+   * @openapi
    * /api/admin/search:
    *   get:
    *     tags:

--- a/apps/api/src/routes/agent.routes.ts
+++ b/apps/api/src/routes/agent.routes.ts
@@ -113,10 +113,6 @@ export function configureAgentRoutes(agentController: AgentController): Router {
    *           schema:
    *             type: object
    *             properties:
-   *               name:
-   *                 type: string
-   *                 description: Agent's display name
-   *                 example: "Trading Bot Beta"
    *               description:
    *                 type: string
    *                 description: Agent description
@@ -173,7 +169,7 @@ export function configureAgentRoutes(agentController: AgentController): Router {
    *                       type: string
    *                       format: date-time
    *       400:
-   *         description: Invalid fields provided (agents can only update name, description, and imageUrl)
+   *         description: Invalid fields provided (agents can only update description and imageUrl)
    *       401:
    *         description: Agent not authenticated
    *       404:

--- a/apps/api/src/types/index.ts
+++ b/apps/api/src/types/index.ts
@@ -843,11 +843,6 @@ export const UpdateUserAgentProfileSchema = z
  */
 export const UpdateAgentProfileBodySchema = z
   .object({
-    name: z
-      .string("Invalid name format")
-      .trim()
-      .min(1, { message: "Name must be at least 1 character" })
-      .optional(),
     description: z
       .string("Invalid description format")
       .trim()

--- a/apps/comps/app/api/sandbox/agents/[agentId]/route.ts
+++ b/apps/comps/app/api/sandbox/agents/[agentId]/route.ts
@@ -16,7 +16,7 @@ import { AdminAgentKeyResponse } from "@/types";
  */
 async function handleUpdateAgent(
   request: NextRequest,
-  { params }: { params: { agentId: string } },
+  { params }: { params: Promise<{ agentId: string }> },
 ) {
   // Extract session cookie
   const sessionCookie = extractSessionCookie(request);
@@ -25,7 +25,7 @@ async function handleUpdateAgent(
   }
 
   // Get the agent ID from the route params
-  const { agentId } = params;
+  const { agentId } = await params;
 
   // Get the update payload from the request body
   const updatePayload = await request.json();

--- a/apps/comps/app/api/sandbox/agents/[agentId]/route.ts
+++ b/apps/comps/app/api/sandbox/agents/[agentId]/route.ts
@@ -1,0 +1,45 @@
+import { NextRequest } from "next/server";
+
+import {
+  extractSessionCookie,
+  sandboxAdminRequest,
+} from "@/app/api/sandbox/_lib/sandbox-config";
+import {
+  createSuccessResponse,
+  withErrorHandling,
+} from "@/app/api/sandbox/_lib/sandbox-response";
+import { AdminAgentKeyResponse } from "@/types";
+
+/**
+ * PUT /api/sandbox/agents/[agentId]
+ * Updates an agent in the sandbox environment using the admin API
+ */
+async function handleUpdateAgent(
+  request: NextRequest,
+  { params }: { params: { agentId: string } },
+) {
+  // Extract session cookie
+  const sessionCookie = extractSessionCookie(request);
+  if (!sessionCookie) {
+    throw new Error("Authentication required");
+  }
+
+  // Get the agent ID from the route params
+  const { agentId } = params;
+
+  // Get the update payload from the request body
+  const updatePayload = await request.json();
+
+  // Update agent in sandbox using the admin API
+  const updateData = await sandboxAdminRequest<AdminAgentKeyResponse>(
+    `/admin/agents/${agentId}`,
+    {
+      method: "PUT",
+      body: JSON.stringify(updatePayload),
+    },
+  );
+
+  return createSuccessResponse(updateData);
+}
+
+export const PUT = withErrorHandling(handleUpdateAgent);

--- a/apps/comps/hooks/useSandbox.ts
+++ b/apps/comps/hooks/useSandbox.ts
@@ -4,6 +4,7 @@ import { ENABLE_SANDBOX } from "@/config";
 import { sandboxClient } from "@/lib/sandbox-client";
 import {
   AdminAgentKeyResponse,
+  AdminAgentUpdateResponse,
   AdminCreateAgentResponse,
   AdminUserResponse,
 } from "@/types/admin";
@@ -57,7 +58,7 @@ export const useSandboxAgentApiKey = (agentName: string | null) => {
  */
 export const useUpdateSandboxAgent = () => {
   return useMutation<
-    AdminAgentKeyResponse,
+    AdminAgentUpdateResponse,
     Error,
     {
       agentId: string;

--- a/apps/comps/hooks/useSandbox.ts
+++ b/apps/comps/hooks/useSandbox.ts
@@ -50,3 +50,25 @@ export const useSandboxAgentApiKey = (agentName: string | null) => {
     enabled: !!agentName && ENABLE_SANDBOX,
   });
 };
+
+/**
+ * Hook to update an agent in the sandbox environment
+ * @returns Mutation for updating an agent
+ */
+export const useUpdateSandboxAgent = () => {
+  return useMutation<
+    AdminAgentKeyResponse,
+    Error,
+    {
+      agentId: string;
+      name?: string;
+      description?: string;
+      imageUrl?: string;
+      email?: string;
+      metadata?: Record<string, unknown>;
+    }
+  >({
+    mutationFn: ({ agentId, ...agentData }) =>
+      sandboxClient.updateAgent(agentId, agentData),
+  });
+};

--- a/apps/comps/lib/sandbox-client.ts
+++ b/apps/comps/lib/sandbox-client.ts
@@ -6,6 +6,7 @@ import {
 } from "@/types";
 import {
   AdminAgentKeyResponse,
+  AdminAgentUpdateResponse,
   AdminCreateAgentResponse,
   AdminUserResponse,
 } from "@/types/admin";
@@ -106,7 +107,7 @@ export class SandboxClient {
       email?: string;
       metadata?: Record<string, unknown>;
     },
-  ): Promise<AdminAgentKeyResponse> {
+  ): Promise<AdminAgentUpdateResponse> {
     const response = await fetch(`${SANDBOX_API_BASE}/agents/${agentId}`, {
       method: "PUT",
       headers: {

--- a/apps/comps/lib/sandbox-client.ts
+++ b/apps/comps/lib/sandbox-client.ts
@@ -92,6 +92,39 @@ export class SandboxClient {
   }
 
   /**
+   * Update an agent in the sandbox environment
+   * @param agentId - ID of the agent to update
+   * @param agentData - Agent update data
+   * @returns Agent API key response
+   */
+  async updateAgent(
+    agentId: string,
+    agentData: {
+      name?: string;
+      description?: string;
+      imageUrl?: string;
+      email?: string;
+      metadata?: Record<string, unknown>;
+    },
+  ): Promise<AdminAgentKeyResponse> {
+    const response = await fetch(`${SANDBOX_API_BASE}/agents/${agentId}`, {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      credentials: "include", // Include cookies for authentication
+      body: JSON.stringify(agentData),
+    });
+
+    if (!response.ok) {
+      const error = await response.json();
+      throw new Error(error.error || "Failed to update agent in sandbox");
+    }
+
+    return response.json();
+  }
+
+  /**
    * Get competitions
    */
   async getCompetitions(): Promise<CompetitionsResponse> {

--- a/apps/comps/types/admin.ts
+++ b/apps/comps/types/admin.ts
@@ -55,6 +55,11 @@ export interface AdminAgentKeyResponse {
   agent: AdminAgentWithKey;
 }
 
+export interface AdminAgentUpdateResponse {
+  success: boolean;
+  agent: Omit<AdminAgent, "apiKey">;
+}
+
 export interface AdminUser {
   id: string;
   walletAddress: string;


### PR DESCRIPTION
closes https://github.com/recallnet/js-recall/issues/954

1. we remove the ability for an agent to update their "name". this is needed anways imo, else, we could have agents updating their names w/o user knowing.
2. add an admin API to update an agent
3. let the UI gatekeep agent name updates and sync them b/w "live" and "sandbox" servers