### PR TITLE
chore(api): updated backfill agent data and comps leaderboard script

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -48,6 +48,7 @@
     "end:competition": "tsx scripts/end-competition.ts",
     "comp:status": "tsx scripts/competition-status.ts",
     "scripts:populate-object-index": "tsx scripts/populate-object-index.ts",
+    "scripts:backfill-stats": "tsx scripts/backfill-stats.ts",
     "generate-openapi": "tsx -e \"const { swaggerSpec } = require('./src/config/swagger'); require('fs').writeFileSync('./openapi/openapi.json', JSON.stringify(swaggerSpec, null, 2));\"",
     "generate-markdown": "openapi-markdown -i ./openapi/openapi.json -o ./openapi/API.md",
     "generate-docs": "pnpm generate-openapi && pnpm generate-markdown",

--- a/apps/api/scripts/backfill-stats.ts
+++ b/apps/api/scripts/backfill-stats.ts
@@ -95,17 +95,6 @@ async function calculateBulkAgentStats(
       }
 
       const pnl = newest.totalValue - oldest.totalValue;
-
-      // const { pnl, startingValue } =
-      //   await services.agentManager.getAgentPerformanceForComp(
-      //     agentId,
-      //     competitionId,
-      //   );
-
-      if (competitionId === "624b96af-be44-4274-a5ef-76a27397c9c6") {
-        console.log("here");
-      }
-
       const ranking = rankings.get(agentId);
       if (typeof ranking === "undefined") {
         throw new Error(`cannot get ranking for ${agentId}`);
@@ -212,7 +201,6 @@ async function backfillCompetitionPnl() {
         });
       }
       if (leaderboardEntries.length > 0) {
-        // TODO: can we just add more leaderboard data?  or do we have to remove old rows?
         await batchInsertLeaderboard(leaderboardEntries);
       }
     }

--- a/apps/api/scripts/backfill-stats.ts
+++ b/apps/api/scripts/backfill-stats.ts
@@ -1,0 +1,240 @@
+import * as dotenv from "dotenv";
+import * as path from "path";
+import * as readline from "readline";
+
+import {
+  batchInsertLeaderboard,
+  getBoundedSnapshots,
+  getBulkAgentCompetitionRankings,
+} from "@/database/repositories/competition-repository.js";
+import { ServiceRegistry } from "@/services/index.js";
+import { COMPETITION_AGENT_STATUS, COMPETITION_STATUS } from "@/types/index.js";
+
+const services = new ServiceRegistry();
+
+// Load environment variables
+dotenv.config({ path: path.resolve(process.cwd(), ".env") });
+
+// Create readline interface for prompting user
+const rl = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout,
+});
+
+// Colors for console output
+const colors = {
+  red: "\x1b[31m",
+  yellow: "\x1b[33m",
+  green: "\x1b[32m",
+  blue: "\x1b[34m",
+  cyan: "\x1b[36m",
+  magenta: "\x1b[35m",
+  reset: "\x1b[0m",
+};
+
+// Prompt function that returns a promise
+function prompt(question: string): Promise<string> {
+  return new Promise((resolve) => {
+    rl.question(question, (answer) => {
+      resolve(answer);
+    });
+  });
+}
+/**
+ * Calculate PnL for an agent in a specific competition using portfolio snapshots
+ * This replicates the logic from AgentManager.getAgentPnlForComp
+ */
+async function calculateBulkAgentStats(
+  agentIds: string[],
+  competitionId: string,
+): Promise<
+  Map<
+    string,
+    { pnl: number; rank: number; totalAgents: number; startingValue: number }
+  >
+> {
+  try {
+    // Get agent's ranking in this competition
+    const rankings = await getBulkAgentCompetitionRankings(
+      competitionId,
+      agentIds,
+    );
+    const pnlMap = new Map<
+      string,
+      {
+        pnl: number;
+        startingValue: number;
+        rank: number;
+        totalAgents: number;
+      }
+    >();
+
+    for (const agentId of agentIds) {
+      console.log(
+        `Processing agent ${agentId} in competition ${competitionId}`,
+      );
+
+      const agent = await services.competitionManager.getAgentCompetitionRecord(
+        competitionId,
+        agentId,
+      );
+
+      if (agent?.status !== COMPETITION_AGENT_STATUS.ACTIVE) {
+        console.log(`Agent ${agentId} was deactivated, skipping`);
+        continue;
+      }
+
+      const snaps = await getBoundedSnapshots(competitionId, agentId);
+      const newest = snaps?.newest;
+      const oldest = snaps?.oldest;
+      if (typeof oldest?.totalValue !== "number") {
+        throw new Error("failed to get oldest total value snapshot");
+      }
+      if (typeof newest?.totalValue !== "number") {
+        throw new Error("failed to get newest total value snapshot");
+      }
+
+      const pnl = newest.totalValue - oldest.totalValue;
+
+      // const { pnl, startingValue } =
+      //   await services.agentManager.getAgentPerformanceForComp(
+      //     agentId,
+      //     competitionId,
+      //   );
+
+      if (competitionId === "624b96af-be44-4274-a5ef-76a27397c9c6") {
+        console.log("here");
+      }
+
+      const ranking = rankings.get(agentId);
+      if (typeof ranking === "undefined") {
+        throw new Error(`cannot get ranking for ${agentId}`);
+      }
+
+      pnlMap.set(agentId, {
+        pnl,
+        startingValue: oldest.totalValue,
+        rank: ranking.rank,
+        totalAgents: ranking.totalAgents,
+      });
+    }
+
+    return pnlMap;
+  } catch (error) {
+    console.error(
+      `${colors.red}Error calculating PnL for agents ${agentIds.join(
+        ", ",
+      )}:${colors.reset}`,
+      error,
+    );
+    throw error;
+  }
+}
+
+/**
+ * Backfill PnL data for all agents in a competition's leaderboard
+ */
+async function backfillCompetitionPnl() {
+  try {
+    console.log(
+      `${colors.cyan}╔════════════════════════════════════════════════════════════════╗${colors.reset}`,
+    );
+    console.log(
+      `${colors.cyan}║                  BACKFILL COMPETITION PNL + StartingValue      ║${colors.reset}`,
+    );
+    console.log(
+      `${colors.cyan}╚════════════════════════════════════════════════════════════════╝${colors.reset}`,
+    );
+
+    console.log(
+      `\nThis script will recalculate and update PnL values and startingValue values for all agents in a competition's leaderboard.`,
+    );
+    console.log(
+      `${colors.magenta}----------------------------------------${colors.reset}`,
+    );
+
+    const continueOperation = await prompt(
+      `${colors.yellow}Are you sure you want to continue? (y/n):${colors.reset} `,
+    );
+    if (continueOperation.toLowerCase() !== "y") {
+      console.log(`${colors.red}Operation cancelled.${colors.reset}`);
+      return;
+    }
+
+    console.log(
+      `${colors.magenta}----------------------------------------${colors.reset}`,
+    );
+
+    const competitions = await services.competitionManager.getAllCompetitions();
+    const endedCompetitions = competitions.filter(
+      (c) => c.status === COMPETITION_STATUS.ENDED,
+    );
+    console.log(
+      `${colors.magenta}----------------------------------------${colors.reset}`,
+    );
+    console.log(`Found ${endedCompetitions.length} ended competitions`);
+    console.log(
+      `${colors.magenta}----------------------------------------${colors.reset}`,
+    );
+    for (const competition of endedCompetitions) {
+      const agentIds =
+        await services.competitionManager.getAllCompetitionAgents(
+          competition.id,
+        );
+      console.log(
+        `${colors.magenta}----------------------------------------${colors.reset}`,
+      );
+      console.log(
+        `Processing competition ${competition.id} with ${agentIds.length} agents`,
+      );
+      console.log(
+        `${colors.magenta}----------------------------------------${colors.reset}`,
+      );
+      const pnlMap = await calculateBulkAgentStats(agentIds, competition.id);
+      const sortedPnlMap = new Map(
+        [...pnlMap.entries()].sort((a, b) => a[1].rank - b[1].rank),
+      );
+
+      // Collect all leaderboard entries for this competition
+      const leaderboardEntries = [];
+      for (const [
+        agentId,
+        { pnl, startingValue, rank, totalAgents },
+      ] of sortedPnlMap.entries()) {
+        leaderboardEntries.push({
+          agentId,
+          competitionId: competition.id,
+          rank,
+          totalAgents,
+          score: pnl + startingValue,
+          pnl,
+          startingValue,
+        });
+      }
+      if (leaderboardEntries.length > 0) {
+        // TODO: can we just add more leaderboard data?  or do we have to remove old rows?
+        await batchInsertLeaderboard(leaderboardEntries);
+      }
+    }
+
+    console.log(
+      `${colors.green}----------------------------------------${colors.reset}`,
+    );
+    console.log(
+      `${colors.green}Backfilling competition PnL completed${colors.reset}`,
+    );
+  } catch (error) {
+    console.error(
+      `\n${colors.red}Error backfilling competition PnL:${colors.reset}`,
+      error instanceof Error ? error.message : error,
+    );
+  } finally {
+    rl.close();
+
+    // Exit the process after clean closure
+    process.exit(0);
+  }
+}
+
+// Run the function
+backfillCompetitionPnl();

--- a/apps/api/src/database/repositories/competition-repository.ts
+++ b/apps/api/src/database/repositories/competition-repository.ts
@@ -840,7 +840,18 @@ async function get24hSnapshotsImpl(
   }
 
   try {
-    const twentyFourHoursAgo = new Date(Date.now() - 24 * 60 * 60 * 1000);
+    const comp = await dbRead
+      .select({ endDate: competitions.endDate })
+      .from(competitions)
+      .where(
+        and(
+          eq(competitions.status, COMPETITION_STATUS.ENDED),
+          eq(competitions.id, competitionId),
+        ),
+      );
+    const endDate = comp[0]?.endDate;
+    const endTime = endDate ? endDate.valueOf() : Date.now();
+    const twentyFourHoursAgo = new Date(endTime - 24 * 60 * 60 * 1000);
 
     // Get earliest snapshots for each agent (for PnL calculation)
     const earliestSubquery = dbRead

--- a/apps/api/src/services/competition-manager.service.ts
+++ b/apps/api/src/services/competition-manager.service.ts
@@ -534,6 +534,9 @@ export class CompetitionManager {
    */
   async getLeaderboard(competitionId: string) {
     try {
+      // TODO: this function has many paths it potentially takes depending on
+      //  the state of several tables. We should refactor and ideally only have
+      //  one, which doesn't have to do calculations for every (uncached) request.
       const competition = await findById(competitionId);
       const competitionStatus = competition?.status;
 


### PR DESCRIPTION
@dtbuchholz Your PR looks great, but it looked like it needed to be rebased onto main to work correctly on the staging and prod databases.  
So this is mostly what you did in https://github.com/recallnet/js-recall/pull/933 but includes the `startingValue` data too.

I tested by downloading a backup yesterday's staging database, running api and app against it, then running the script.  After that all the agents data looks correct in the app.

closes #796 