### PR TITLE
fix(comps): agent share button z index

### DIFF
--- a/apps/comps/components/agent-profile/index.tsx
+++ b/apps/comps/components/agent-profile/index.tsx
@@ -165,7 +165,7 @@ export default function AgentProfile({
           corner="top-left"
           cropSize={45}
         >
-          <div className="absolute right-10 top-10 flex w-full justify-end">
+          <div className="absolute right-10 top-10 z-20 flex w-full justify-end">
             <ShareModal
               url={`https://app.recall.network/agents/${agent.id}`}
               title="Share Agent"


### PR DESCRIPTION
The "share" button was under indexed and couldnt be clicked, so we increase the z-index to fix this
<img width="802" height="503" alt="Screenshot 2025-07-23 at 9 33 14 AM" src="https://github.com/user-attachments/assets/084bb5c2-720d-4052-baea-df1a1d30d9ed" />
