### PR TITLE
fix: reduce inner loop to limit 1

### DIFF
--- a/apps/api/src/database/repositories/competition-repository.ts
+++ b/apps/api/src/database/repositories/competition-repository.ts
@@ -10,7 +10,6 @@ import {
   isNotNull,
   lte,
   max,
-  min,
   sql,
 } from "drizzle-orm";
 import { unionAll } from "drizzle-orm/pg-core";

--- a/apps/api/src/database/repositories/competition-repository.ts
+++ b/apps/api/src/database/repositories/competition-repository.ts
@@ -844,9 +844,7 @@ async function get24hSnapshotsImpl(competitionId: string, agentIds: string[]) {
     );
 
     return {
-      earliestSnapshots: earliestSnapshots.map(
-        (row) => row.portfolio_snapshots,
-      ),
+      earliestSnapshots: earliestSnapshots,  // ✅ Direct mapping - already flat!
       snapshots24hAgo: snapshots24hAgo.map((row) => ({
         id: row.id,
         agentId: row.agentId,

--- a/apps/api/src/database/repositories/competition-repository.ts
+++ b/apps/api/src/database/repositories/competition-repository.ts
@@ -798,19 +798,22 @@ async function get24hSnapshotsImpl(competitionId: string, agentIds: string[]) {
 
     const twentyFourHoursAgo = new Date(Date.now() - 24 * 60 * 60 * 1000);
 
-      // Get earliest snapshots for each agent (optimized)
-      const earliestSnapshots = await Promise.all(
-        agentIds.map(agentId =>
-          db.select()
-            .from(portfolioSnapshots)
-            .where(and(
+    // Get earliest snapshots for each agent (optimized)
+    const earliestSnapshots = await Promise.all(
+      agentIds.map((agentId) =>
+        db
+          .select()
+          .from(portfolioSnapshots)
+          .where(
+            and(
               eq(portfolioSnapshots.competitionId, competitionId),
-              eq(portfolioSnapshots.agentId, agentId)
-            ))
-            .orderBy(asc(portfolioSnapshots.timestamp))
-            .limit(1)
-        )
-      ).then(results => results.flat().map(row => row));
+              eq(portfolioSnapshots.agentId, agentId),
+            ),
+          )
+          .orderBy(asc(portfolioSnapshots.timestamp))
+          .limit(1),
+      ),
+    ).then((results) => results.flat().map((row) => row));
 
     // Get snapshots closest to 24h ago using window functions
     const snapshots24hAgo = await db
@@ -843,7 +846,7 @@ async function get24hSnapshotsImpl(competitionId: string, agentIds: string[]) {
     );
 
     return {
-      earliestSnapshots: earliestSnapshots,  // ✅ Direct mapping - already flat!
+      earliestSnapshots: earliestSnapshots, // ✅ Direct mapping - already flat!
       snapshots24hAgo: snapshots24hAgo.map((row) => ({
         id: row.id,
         agentId: row.agentId,


### PR DESCRIPTION
Looking at the timing breakdown:
GroupAggregate: ~29.4ms (82% of total time!)
Nested Loop scanning: ~25.3ms
Final lookup: 0.007ms (negligible)
The problem: We're processing 143,700 rows to find MAX timestamp for just 10 agents. 99.1% IMPROVEMENT FOUND!
LATERAL JOIN Results:
Execution Time: 0.176 ms (vs ~36ms before)
Improvement: 99.1% faster
Buffers: 42 (vs 1,100 before)