### PR TITLE
feat: docker compose for local testing

### DIFF
--- a/apps/api/trade-simulator-docker/Dockerfile
+++ b/apps/api/trade-simulator-docker/Dockerfile
@@ -2,17 +2,21 @@ FROM node:22 AS builder
 
 WORKDIR /workdir
 
-COPY apps/api apps/api
-COPY packages/api-sdk packages/api-sdk
-COPY packages/eslint-config packages/eslint-config
-COPY packages/typescript-config packages/typescript-config
-COPY .npmrc .prettie* *.js *.json *.yaml ./
+RUN npm install -g pnpm typescript turbo bun
 
-# # Build the application
-RUN npm -g install pnpm typescript turbo
-RUN cd apps/api; pnpm install
-RUN cd packages/api-sdk; pnpm build
-RUN cd apps/api; pnpm build
+COPY package.json pnpm-*.yaml .npmrc ./
+COPY packages/eslint-config/package.json packages/eslint-config/
+COPY packages/typescript-config/package.json packages/typescript-config/
+COPY packages/api-sdk/package.json packages/api-sdk/
+COPY apps/api/package.json apps/api/
+
+RUN pnpm install --frozen-lockfile
+
+COPY . .
+
+# Build the application
+RUN pnpm --filter=@recallnet/api-sdk build && \
+    pnpm --filter=api build
 
 FROM node:22-alpine
 
@@ -30,10 +34,11 @@ ENV METRICS_PORT=3003
 # Expose both application and metrics ports
 EXPOSE $PORT $METRICS_PORT
 
+WORKDIR /workdir/apps/api
+
 # Create startup script
-COPY apps/api/trade-simulator-docker/startup.sh /workdir/apps/api/startup.sh
-RUN chmod +x /workdir/apps/api/startup.sh
+COPY apps/api/trade-simulator-docker/startup.sh ./startup.sh
+RUN chmod +x ./startup.sh
 
 # Start the application
-WORKDIR /workdir/apps/api
 CMD ["./startup.sh"]

--- a/apps/comps/Dockerfile
+++ b/apps/comps/Dockerfile
@@ -1,0 +1,43 @@
+FROM node:22 AS builder
+
+WORKDIR /workdir
+
+RUN npm install -g pnpm typescript turbo
+
+COPY package.json pnpm-*.yaml .npmrc ./
+COPY packages/eslint-config/package.json packages/eslint-config/
+COPY packages/typescript-config/package.json packages/typescript-config/
+COPY packages/address-utils/package.json packages/address-utils/
+COPY packages/fonts/package.json packages/fonts/
+COPY packages/ui2/package.json packages/ui2/
+COPY apps/comps/package.json apps/comps/
+
+RUN pnpm install --frozen-lockfile
+
+COPY . .
+
+# Build arguments for Next.js public environment variables
+ARG NEXT_PUBLIC_API_BASE_URL
+ARG NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID
+
+# Build the application
+RUN pnpm --filter=@recallnet/address-utils build && \
+    pnpm --filter=@recallnet/fonts build && \
+    pnpm --filter=comps build
+
+FROM node:22-alpine
+
+COPY --from=builder /workdir /workdir
+
+WORKDIR /workdir/apps/comps
+
+# Set environment variables
+ENV NODE_ENV=production
+ENV PORT=3001
+ENV HOSTNAME=0.0.0.0
+
+# Expose port
+EXPOSE $PORT
+
+# Start the application using shell form to allow environment variable expansion
+CMD node_modules/next/dist/bin/next start -p $PORT -H $HOSTNAME

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,74 @@
+# This is a test docker-compose file that is not intended for production use!
+name: recall
+
+networks:
+  recall-network:
+    driver: bridge
+
+services:
+  db:
+    image: postgres:17-alpine
+    container_name: recall-db
+    restart: always
+    networks:
+      - recall-network
+    environment:
+      POSTGRES_DB: postgres
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    volumes:
+      - "postgres-data:/var/lib/postgresql/data"
+
+  redis:
+    image: redis:alpine
+    container_name: recall-redis
+    restart: always
+    networks:
+      - recall-network
+    volumes:
+      - "redis-data:/data"
+
+  api:
+    build:
+      context: .
+      dockerfile: apps/api/trade-simulator-docker/Dockerfile
+    image: recall-api
+    container_name: recall-api
+    restart: always
+    networks:
+      - recall-network
+    ports:
+      - "${API_PORT:-3000}:${API_PORT:-3000}"
+      - "${METRICS_PORT:-3003}:${METRICS_PORT:-3003}"
+    environment:
+      DATABASE_URL: postgresql://postgres:postgres@db/postgres
+      REDIS_URL: redis://redis:6379
+      API_PREFIX: ${API_PREFIX:-}
+      PORT: ${API_PORT:-3000}
+      METRICS_PORT: ${METRICS_PORT:-3003}
+    depends_on:
+      - db
+      - redis
+
+  comps:
+    build:
+      context: .
+      dockerfile: apps/comps/Dockerfile
+      args:
+        NEXT_PUBLIC_API_BASE_URL: "http://api:${API_PORT:-3000}${API_PREFIX:+/${API_PREFIX}}/api"
+        NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID: ${NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID:-}
+    image: recall-comps
+    container_name: recall-comps
+    restart: always
+    networks:
+      - recall-network
+    ports:
+      - "${COMPS_PORT:-3001}:${COMPS_PORT:-3001}"
+    environment:
+      PORT: ${COMPS_PORT:-3001}
+    depends_on:
+      - api
+
+volumes:
+  postgres-data:
+  redis-data:


### PR DESCRIPTION
First pass of Docker Compose config to build both API and UI components and run them locally.

The Dockerfiles could have been more optimized but this version at least somewhat reduces the build time.