### PR TITLE
fix(api): remove inefficient agent metrics query, leaderboard query, & throw errors 

### DIFF
--- a/apps/api/e2e/utils/test-helpers.ts
+++ b/apps/api/e2e/utils/test-helpers.ts
@@ -7,6 +7,7 @@ import { expect } from "vitest";
 import { ApiSDK } from "@recallnet/api-sdk";
 
 import { db } from "@/database/db.js";
+import { clearSnapshotCache } from "@/database/repositories/competition-repository.js";
 import { portfolioSnapshots } from "@/database/schema/trading/defs.js";
 import { resetRateLimiters } from "@/middleware/rate-limiter.middleware.js";
 
@@ -274,6 +275,9 @@ export async function cleanupTestState(): Promise<void> {
 
   // Also reset rate limiters to ensure clean state between tests
   resetRateLimiters();
+
+  // Clear snapshot cache
+  clearSnapshotCache();
 
   return dbManager.cleanupTestState();
 }

--- a/apps/api/src/controllers/agent.controller.ts
+++ b/apps/api/src/controllers/agent.controller.ts
@@ -325,10 +325,11 @@ export function makeAgentController(services: ServiceRegistry) {
 
         // Check if we have snapshot data (preferred method)
         if (activeCompetition) {
-          // Try to get the latest snapshot for this agent
+          // Try to get the latest snapshot for this agent (limit to 1 for performance)
           const agentSnapshots = await getAgentPortfolioSnapshots(
             activeCompetition.id,
             agentId,
+            1, // Only fetch the most recent snapshot
           );
 
           // If we have a snapshot, use it

--- a/apps/api/src/database/repositories/agentscore-repository.ts
+++ b/apps/api/src/database/repositories/agentscore-repository.ts
@@ -1,4 +1,4 @@
-import { desc, eq, sql } from "drizzle-orm";
+import { desc, eq, inArray, sql } from "drizzle-orm";
 import { v4 as uuidv4 } from "uuid";
 
 import { db } from "@/database/db.js";
@@ -38,11 +38,13 @@ export interface AgentRankInfo {
  * the agent information and rank score.
  * @returns An array of objects with agent ID, name, and rank score
  */
-async function getAllAgentRanksImpl(): Promise<AgentRankInfo[]> {
+async function getAllAgentRanksImpl(
+  agentIds?: string[],
+): Promise<AgentRankInfo[]> {
   console.log("[AgentRankRepository] getAllAgentRanks called");
 
   try {
-    const rows = await db
+    const query = db
       .select({
         id: agents.id,
         imageUrl: agents.imageUrl,
@@ -55,6 +57,12 @@ async function getAllAgentRanksImpl(): Promise<AgentRankInfo[]> {
       })
       .from(agentScore)
       .innerJoin(agents, eq(agentScore.agentId, agents.id));
+
+    if (agentIds) {
+      query.where(inArray(agentScore.agentId, agentIds));
+    }
+
+    const rows = await query;
 
     return rows.map((agent) => {
       return {

--- a/apps/api/src/database/repositories/competition-repository.ts
+++ b/apps/api/src/database/repositories/competition-repository.ts
@@ -70,14 +70,31 @@ const competitionOrderByFields: Record<string, AnyColumn> = {
 };
 
 interface Snapshot24hResult {
-  /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-  earliestSnapshots: Array<any>;
-  /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-  snapshots24hAgo: Array<any>;
+  earliestSnapshots: Array<{
+    id: number;
+    agentId: string;
+    competitionId: string;
+    timestamp: Date;
+    totalValue: number;
+  }>;
+  snapshots24hAgo: Array<{
+    id: number;
+    agentId: string;
+    competitionId: string;
+    timestamp: Date;
+    totalValue: number;
+  }>;
 }
 
 const snapshotCache = new Map<string, [number, Snapshot24hResult]>();
 const MAX_CACHE_AGE = 1000 * 60 * 5; // 5 minutes
+
+/**
+ * Clear the snapshot cache - used for testing
+ */
+export function clearSnapshotCache(): void {
+  snapshotCache.clear();
+}
 
 /**
  * Find all competitions
@@ -809,7 +826,7 @@ async function get24hSnapshotsImpl(
     `[CompetitionRepository] get24hSnapshotsImpl called for ${agentIds.length} agents in competition ${competitionId}`,
   );
 
-  const cacheKey = competitionId + "-" + agentIds.join("-");
+  const cacheKey = `${competitionId}-${agentIds.join("-")}`;
   const cachedResult = snapshotCache.get(cacheKey);
   if (cachedResult) {
     const now = Date.now();
@@ -913,13 +930,15 @@ async function get24hSnapshotsImpl(
  * Get portfolio snapshots for an agent in a competition
  * @param competitionId Competition ID
  * @param agentId Agent ID
+ * @param limit Optional limit for the number of snapshots to return
  */
 async function getAgentPortfolioSnapshotsImpl(
   competitionId: string,
   agentId: string,
+  limit?: number,
 ) {
   try {
-    return await db
+    const query = db
       .select()
       .from(portfolioSnapshots)
       .where(
@@ -929,7 +948,13 @@ async function getAgentPortfolioSnapshotsImpl(
         ),
       )
       .orderBy(desc(portfolioSnapshots.timestamp));
-    // TODO: there's no limit here, this is a weakness in perf
+
+    // Apply limit if specified
+    if (limit !== undefined && limit > 0) {
+      return await query.limit(limit);
+    }
+
+    return await query;
   } catch (error) {
     console.error(
       "[CompetitionRepository] Error in getAgentPortfolioSnapshots:",

--- a/apps/api/src/services/portfolio-snapshotter.service.ts
+++ b/apps/api/src/services/portfolio-snapshotter.service.ts
@@ -248,10 +248,19 @@ export class PortfolioSnapshotter {
    * Get portfolio snapshots for an agent in a competition
    * @param competitionId The competition ID
    * @param agentId The agent ID
+   * @param limit Optional limit for the number of snapshots to return
    * @returns Array of portfolio snapshots
    */
-  async getAgentPortfolioSnapshots(competitionId: string, agentId: string) {
-    const snapshots = await getAgentPortfolioSnapshots(competitionId, agentId);
+  async getAgentPortfolioSnapshots(
+    competitionId: string,
+    agentId: string,
+    limit?: number,
+  ) {
+    const snapshots = await getAgentPortfolioSnapshots(
+      competitionId,
+      agentId,
+      limit,
+    );
 
     const promises = snapshots.map(async (snapshot) => {
       const tokenValues = await getPortfolioTokenValues(snapshot.id);


### PR DESCRIPTION
- Removes `calculateAgentMetrics` from the error fallback in `calculateBulkAgentMetrics`. Note: this method was triggered around 100 times in a 24 hour period due to timeouts in the `calculateBulkAgentMetrics` method, and `calculateAgentMetrics` calls `getAgentPortfolioSnapshots`...which is a problematic query.
- Alters the logic in `getLeaderboard` so that "pending" comps don't make unnecessary calls (i.e., a pending comp has effectively no "results" except the agent IDs)