### PR TITLE
chore: Small cleanups

### DIFF
--- a/.cursor/rules/org-general-practices.mdc
+++ b/.cursor/rules/org-general-practices.mdc
@@ -12,7 +12,8 @@ alwaysApply: true
 – **Environment Awareness:** Write code that correctly handles different environments (e.g., dev, test, prod).
 – **Focused Changes:** Only make changes that are requested or clearly understood and directly related to the task. Avoid implementing unrelated improvements or refactors without explicit instruction (see Agent Task Scope below).
 – **Incremental Improvement:** When fixing bugs, avoid introducing new patterns/technologies unless necessary after exhausting existing options. If a new pattern replaces an old one, remove the old implementation.
-– **File Size:** Avoid overly long files. Consider refactoring files exceeding 200–300 lines.
+– **File Size:** Avoid overly long files. Consider refactoring files exceeding 200–300 lines
+- **Function Size:** Avoid overly long functions.  Break up large functions using helper functions that encapsulate related functionality into smaller and more focused pieces.
 – **Script Usage:** Avoid writing one-off scripts if a more integrated solution is feasible.
 
 ## Data Handling

--- a/apps/api/src/controllers/trade.controller.ts
+++ b/apps/api/src/controllers/trade.controller.ts
@@ -115,7 +115,7 @@ export function makeTradeController(services: ServiceRegistry) {
         }
 
         // Execute the trade with optional chain parameters
-        const result = await services.tradeSimulator.executeTrade(
+        const trade = await services.tradeSimulator.executeTrade(
           agentId,
           competitionId,
           fromToken,
@@ -126,14 +126,10 @@ export function makeTradeController(services: ServiceRegistry) {
           chainOptions,
         );
 
-        if (!result.success) {
-          throw new ApiError(400, result.error || "Trade execution failed");
-        }
-
         // Return successful trade result
         res.status(200).json({
           success: true,
-          transaction: result.trade,
+          transaction: trade,
         });
       } catch (error) {
         next(error);

--- a/apps/api/src/services/__tests__/trade-simulator.constraints.test.ts
+++ b/apps/api/src/services/__tests__/trade-simulator.constraints.test.ts
@@ -102,15 +102,14 @@ describe("TradeSimulator - Trading Constraints", () => {
         };
 
         // Access private method using type assertion
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const result = (tradeSimulator as any).validateTradingConstraints(
-          validPriceData,
-          "VALID_TOKEN",
-          mockConstraints,
-        );
-
-        expect(result.success).toBe(true);
-        expect(result.error).toBeUndefined();
+        expect(() =>
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (tradeSimulator as any).validateTradingConstraints(
+            validPriceData,
+            "VALID_TOKEN",
+            mockConstraints,
+          ),
+        ).not.toThrow();
       });
 
       it("should fail validation for token with young pair (< 168 hours)", () => {
@@ -127,19 +126,14 @@ describe("TradeSimulator - Trading Constraints", () => {
           fdv: 2000000,
         };
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const result = (tradeSimulator as any).validateTradingConstraints(
-          youngPairData,
-          "YOUNG_TOKEN",
-          mockConstraints,
-        );
-
-        expect(result.success).toBe(false);
-        expect(result.error).toContain("Token pair is too young");
-        expect(result.error).toContain("100.00 hours old");
-        expect(result.error).toContain(
-          `minimum: ${MINIMUM_PAIR_AGE_HOURS} hours`,
-        );
+        expect(() =>
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (tradeSimulator as any).validateTradingConstraints(
+            youngPairData,
+            "YOUNG_TOKEN",
+            mockConstraints,
+          ),
+        ).toThrow("Token pair is too young");
       });
 
       it("should fail validation for token with missing pairCreatedAt", () => {
@@ -156,18 +150,14 @@ describe("TradeSimulator - Trading Constraints", () => {
           fdv: 2000000,
         };
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const result = (tradeSimulator as any).validateTradingConstraints(
-          noPairTimeData,
-          "NOTIME_TOKEN",
-          mockConstraints,
-        );
-
-        expect(result.success).toBe(false);
-        expect(result.error).toContain("Cannot get token pair creation time");
-        expect(result.error).toContain(
-          `minimum age is: ${MINIMUM_PAIR_AGE_HOURS} hours`,
-        );
+        expect(() =>
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (tradeSimulator as any).validateTradingConstraints(
+            noPairTimeData,
+            "NOTIME_TOKEN",
+            mockConstraints,
+          ),
+        ).toThrow("Cannot get token pair creation time");
       });
 
       it("should fail validation for token with low 24h volume", () => {
@@ -184,19 +174,14 @@ describe("TradeSimulator - Trading Constraints", () => {
           fdv: 2000000,
         };
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const result = (tradeSimulator as any).validateTradingConstraints(
-          lowVolumeData,
-          "LOWVOL_TOKEN",
-          mockConstraints,
-        );
-
-        expect(result.success).toBe(false);
-        expect(result.error).toContain("Token has insufficient 24h volume");
-        expect(result.error).toContain("$50,000");
-        expect(result.error).toContain(
-          `minimum: $${MINIMUM_24H_VOLUME_USD.toLocaleString()}`,
-        );
+        expect(() =>
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (tradeSimulator as any).validateTradingConstraints(
+            lowVolumeData,
+            "LOWVOL_TOKEN",
+            mockConstraints,
+          ),
+        ).toThrow("Token has insufficient 24h volume");
       });
 
       it("should fail validation for token with missing volume data", () => {
@@ -213,15 +198,14 @@ describe("TradeSimulator - Trading Constraints", () => {
           fdv: 2000000,
         };
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const result = (tradeSimulator as any).validateTradingConstraints(
-          noVolumeData,
-          "NOVOL_TOKEN",
-          DEFAULT_CONSTRAINTS,
-        );
-
-        expect(result.success).toBe(false);
-        expect(result.error).toBe("Cannot get token 24h volume data");
+        expect(() =>
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (tradeSimulator as any).validateTradingConstraints(
+            noVolumeData,
+            "NOVOL_TOKEN",
+            DEFAULT_CONSTRAINTS,
+          ),
+        ).toThrow("Cannot get token 24h volume data");
       });
 
       it("should fail validation for token with low liquidity", () => {
@@ -238,19 +222,14 @@ describe("TradeSimulator - Trading Constraints", () => {
           fdv: 2000000,
         };
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const result = (tradeSimulator as any).validateTradingConstraints(
-          lowLiquidityData,
-          "NOLIQ_TOKEN",
-          mockConstraints,
-        );
-
-        expect(result.success).toBe(false);
-        expect(result.error).toContain("Token has insufficient liquidity");
-        expect(result.error).toContain("$50,000");
-        expect(result.error).toContain(
-          `minimum: $${MINIMUM_LIQUIDITY_USD.toLocaleString()}`,
-        );
+        expect(() =>
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (tradeSimulator as any).validateTradingConstraints(
+            lowLiquidityData,
+            "NOLIQ_TOKEN",
+            mockConstraints,
+          ),
+        ).toThrow("Token has insufficient liquidity");
       });
 
       it("should fail validation for token with missing liquidity data", () => {
@@ -275,15 +254,14 @@ describe("TradeSimulator - Trading Constraints", () => {
           minimumFdvUsd: MINIMUM_FDV_USD,
         };
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const result = (tradeSimulator as any).validateTradingConstraints(
-          noLiquidityData,
-          "LOWLIQ_TOKEN",
-          mockConstraints,
-        );
-
-        expect(result.success).toBe(false);
-        expect(result.error).toBe("Cannot get token liquidity");
+        expect(() =>
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (tradeSimulator as any).validateTradingConstraints(
+            noLiquidityData,
+            "LOWLIQ_TOKEN",
+            mockConstraints,
+          ),
+        ).toThrow("Cannot get token liquidity");
       });
 
       it("should fail validation for token with low FDV", () => {
@@ -300,19 +278,14 @@ describe("TradeSimulator - Trading Constraints", () => {
           fdv: 500000, // Below minimum
         };
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const result = (tradeSimulator as any).validateTradingConstraints(
-          lowFdvData,
-          "LOWFDV_TOKEN",
-          mockConstraints,
-        );
-
-        expect(result.success).toBe(false);
-        expect(result.error).toContain("Token has insufficient FDV");
-        expect(result.error).toContain("$500,000");
-        expect(result.error).toContain(
-          `minimum: $${MINIMUM_FDV_USD.toLocaleString()}`,
-        );
+        expect(() =>
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (tradeSimulator as any).validateTradingConstraints(
+            lowFdvData,
+            "LOWFDV_TOKEN",
+            mockConstraints,
+          ),
+        ).toThrow("Token has insufficient FDV");
       });
 
       it("should fail validation for token with missing FDV data", () => {
@@ -329,15 +302,14 @@ describe("TradeSimulator - Trading Constraints", () => {
           fdv: undefined,
         };
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const result = (tradeSimulator as any).validateTradingConstraints(
-          noFdvData,
-          "NOFDV_TOKEN",
-          mockConstraints,
-        );
-
-        expect(result.success).toBe(false);
-        expect(result.error).toBe("Cannot get token FDV");
+        expect(() =>
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (tradeSimulator as any).validateTradingConstraints(
+            noFdvData,
+            "NOFDV_TOKEN",
+            mockConstraints,
+          ),
+        ).toThrow("Cannot get token FDV");
       });
 
       it("should validate boundary conditions correctly", () => {
@@ -355,15 +327,14 @@ describe("TradeSimulator - Trading Constraints", () => {
           fdv: MINIMUM_FDV_USD, // Exactly minimum FDV
         };
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const result = (tradeSimulator as any).validateTradingConstraints(
-          boundaryData,
-          "BOUNDARY_TOKEN",
-          mockConstraints,
-        );
-
-        expect(result.success).toBe(true);
-        expect(result.error).toBeUndefined();
+        expect(() =>
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (tradeSimulator as any).validateTradingConstraints(
+            boundaryData,
+            "BOUNDARY_TOKEN",
+            mockConstraints,
+          ),
+        ).not.toThrow();
       });
 
       it("should handle edge case with zero values", () => {
@@ -380,16 +351,14 @@ describe("TradeSimulator - Trading Constraints", () => {
           fdv: 0,
         };
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const result = (tradeSimulator as any).validateTradingConstraints(
-          zeroData,
-          "ZERO_TOKEN",
-          mockConstraints,
-        );
-
-        expect(result.success).toBe(false);
-        // Should fail on the first zero value encountered (volume)
-        expect(result.error).toContain("insufficient 24h volume");
+        expect(() =>
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (tradeSimulator as any).validateTradingConstraints(
+            zeroData,
+            "ZERO_TOKEN",
+            mockConstraints,
+          ),
+        ).toThrow("insufficient 24h volume");
       });
 
       it("should handle edge case with null volume", () => {
@@ -407,16 +376,14 @@ describe("TradeSimulator - Trading Constraints", () => {
           fdv: 2000000,
         };
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const result = (tradeSimulator as any).validateTradingConstraints(
-          nullVolumeData,
-          "NULLVOL_TOKEN",
-          mockConstraints,
-        );
-
-        expect(result.success).toBe(false);
-        // Should fail on missing volume data check first
-        expect(result.error).toContain("Cannot get token 24h volume data");
+        expect(() =>
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (tradeSimulator as any).validateTradingConstraints(
+            nullVolumeData,
+            "NULLVOL_TOKEN",
+            mockConstraints,
+          ),
+        ).toThrow("Cannot get token 24h volume data");
       });
 
       it("should pass validation for FDV-exempt token (SOL) without FDV data", () => {
@@ -433,15 +400,14 @@ describe("TradeSimulator - Trading Constraints", () => {
           fdv: undefined, // No FDV data - but should pass due to exemption
         };
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const result = (tradeSimulator as any).validateTradingConstraints(
-          solTokenData,
-          "SOL_TOKEN",
-          mockConstraints,
-        );
-
-        expect(result.success).toBe(true);
-        expect(result.error).toBeUndefined();
+        expect(() =>
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (tradeSimulator as any).validateTradingConstraints(
+            solTokenData,
+            "SOL_TOKEN",
+            mockConstraints,
+          ),
+        ).not.toThrow();
       });
 
       it("should pass validation for FDV-exempt token (USDC) without FDV data", () => {
@@ -458,15 +424,14 @@ describe("TradeSimulator - Trading Constraints", () => {
           fdv: undefined, // No FDV data - but should pass due to exemption
         };
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const result = (tradeSimulator as any).validateTradingConstraints(
-          usdcTokenData,
-          "USDC_TOKEN",
-          mockConstraints,
-        );
-
-        expect(result.success).toBe(true);
-        expect(result.error).toBeUndefined();
+        expect(() =>
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (tradeSimulator as any).validateTradingConstraints(
+            usdcTokenData,
+            "USDC_TOKEN",
+            mockConstraints,
+          ),
+        ).not.toThrow();
       });
     });
 
@@ -506,18 +471,16 @@ describe("TradeSimulator - Trading Constraints", () => {
           .mockResolvedValueOnce(validFromPrice)
           .mockResolvedValueOnce(invalidToPrice);
 
-        const result = await tradeSimulator.executeTrade(
-          uuidv4(),
-          uuidv4(),
-          "0x1111111111111111111111111111111111111111",
-          "0x2222222222222222222222222222222222222222",
-          100,
-          "Test trade",
-        );
-
-        expect(result.success).toBe(false);
-        expect(result.error).toContain("Token pair is too young");
-        expect(result.trade).toBeUndefined();
+        await expect(
+          tradeSimulator.executeTrade(
+            uuidv4(),
+            uuidv4(),
+            "0x1111111111111111111111111111111111111111",
+            "0x2222222222222222222222222222222222222222",
+            100,
+            "Test trade",
+          ),
+        ).rejects.toThrow("Token pair is too young");
       });
 
       it("should skip constraints for burn tokens (price = 0)", async () => {
@@ -555,20 +518,28 @@ describe("TradeSimulator - Trading Constraints", () => {
           .mockResolvedValueOnce(validFromPrice)
           .mockResolvedValueOnce(burnTokenPrice);
 
-        const result = await tradeSimulator.executeTrade(
-          uuidv4(),
-          uuidv4(),
-          "0x1111111111111111111111111111111111111111",
-          "0x0000000000000000000000000000000000000000",
-          100,
-          "Burn trade",
-        );
-
-        // Should pass constraints validation but may fail later due to mocking limitations
+        // For burn tokens, constraints should be skipped, but the trade may still fail due to mocking limitations
         // The important thing is that constraints are skipped for burn tokens
-        expect(result.success).toBe(false);
-        expect(result.error).not.toContain("Token pair is too young");
-        expect(result.error).not.toContain("insufficient");
+        try {
+          await tradeSimulator.executeTrade(
+            uuidv4(),
+            uuidv4(),
+            "0x1111111111111111111111111111111111111111",
+            "0x0000000000000000000000000000000000000000",
+            100,
+            "Burn trade",
+          );
+          throw Error("trade should fail");
+        } catch (error) {
+          // The error should not be related to constraints validation
+          const errorMessage =
+            error instanceof Error ? error.message : String(error);
+          expect(errorMessage).not.toContain("Token pair is too young");
+          expect(errorMessage).not.toContain("insufficient");
+          expect(errorMessage).not.toContain("trade should fail");
+          // If we get here, the trade failed for a reason other than constraints
+          // which is expected due to mocking limitations
+        }
       });
     });
   });

--- a/apps/api/src/services/trade-simulator.service.ts
+++ b/apps/api/src/services/trade-simulator.service.ts
@@ -19,6 +19,8 @@ import { BlockchainType, PriceReport, SpecificChain } from "@/types/index.js";
 
 import { PriceTracker } from "./price-tracker.service.js";
 
+const MIN_TRADE_AMOUNT = 0.000001;
+
 // Interface for trading constraints
 interface TradingConstraints {
   minimumPairAgeHours: number;
@@ -100,321 +102,70 @@ export class TradeSimulator {
                 Chain Options: ${chainOptions ? JSON.stringify(chainOptions) : "none"}
             `);
 
-      // Validate minimum trade amount
-      if (fromAmount < 0.000001) {
-        serviceLogger.debug(
-          `[TradeSimulator] Trade amount too small: ${fromAmount}`,
-        );
-        throw new ApiError(400, "Trade amount too small (minimum: 0.000001)");
-      }
+      // Validate basic trade inputs
+      this.validateTradeInputs(fromToken, toToken, fromAmount, reason);
 
-      // Validate reason is provided
-      if (!reason) {
-        serviceLogger.debug(`[TradeSimulator] Trade reason is required`);
-        throw new ApiError(400, "Trade reason is required");
-      }
-
-      // Prevent trading between identical tokens
-      if (fromToken === toToken) {
-        serviceLogger.debug(
-          `[TradeSimulator] Cannot trade between identical tokens: ${fromToken}`,
-        );
-        throw new ApiError(400, "Cannot trade between identical tokens");
-      }
-
-      // Get prices with chain information for better performance
-      let fromTokenChain: BlockchainType, toTokenChain: BlockchainType;
-      let fromTokenSpecificChain: SpecificChain | undefined,
-        toTokenSpecificChain: SpecificChain | undefined;
-
-      // For the source token
-      if (chainOptions?.fromChain) {
-        fromTokenChain = chainOptions.fromChain;
-        fromTokenSpecificChain = chainOptions.fromSpecificChain;
-        serviceLogger.debug(
-          `[TradeSimulator] Using provided chain for fromToken: ${fromTokenChain}, specificChain: ${fromTokenSpecificChain || "none"}`,
-        );
-      } else {
-        fromTokenChain = this.priceTracker.determineChain(fromToken);
-        serviceLogger.debug(
-          `[TradeSimulator] Detected chain for fromToken: ${fromTokenChain}`,
-        );
-      }
-
-      // assign the specific chain if provided
-      if (chainOptions?.fromSpecificChain) {
-        fromTokenSpecificChain = chainOptions.fromSpecificChain;
-        serviceLogger.debug(
-          `[TradeSimulator] Using provided specific chain for fromToken: ${fromTokenSpecificChain}`,
-        );
-      }
-
-      // For the destination token
-      if (chainOptions?.toChain) {
-        toTokenChain = chainOptions.toChain;
-        toTokenSpecificChain = chainOptions.toSpecificChain;
-        serviceLogger.debug(
-          `[TradeSimulator] Using provided chain for toToken: ${toTokenChain}, specificChain: ${toTokenSpecificChain || "none"}`,
-        );
-      } else {
-        toTokenChain = this.priceTracker.determineChain(toToken);
-        serviceLogger.debug(
-          `[TradeSimulator] Detected chain for toToken: ${toTokenChain}`,
-        );
-      }
-
-      // assign the specific chain if provided
-      if (chainOptions?.toSpecificChain) {
-        toTokenSpecificChain = chainOptions.toSpecificChain;
-        serviceLogger.debug(
-          `[TradeSimulator] Using provided specific chain for toToken: ${toTokenSpecificChain}`,
-        );
-      }
-
-      // Get prices with chain information for better performance
-      const fromPrice = await this.priceTracker.getPrice(
+      // Resolve chain variables
+      const chainInfo = this.resolveChainVariables(
         fromToken,
-        fromTokenChain,
-        fromTokenSpecificChain,
-      );
-
-      const toPrice = await this.priceTracker.getPrice(
         toToken,
-        toTokenChain,
-        toTokenSpecificChain,
+        chainOptions,
       );
 
-      serviceLogger.debug("[TradeSimulator] Got prices:");
-      serviceLogger.debug(
-        `  From Token (${fromToken}): ${JSON.stringify(fromPrice, null, 4)} (${fromTokenChain})`,
+      // Validate cross-chain trading rules
+      this.validateCrossChainTrading(chainInfo);
+
+      // Fetch and validate prices
+      const { fromPrice, toPrice } = await this.fetchAndValidatePrices(
+        fromToken,
+        toToken,
+        chainInfo,
+        competitionId,
       );
-      serviceLogger.debug(
-        `  To Token (${toToken}): ${JSON.stringify(toPrice, null, 4)} (${toTokenChain})`,
-      );
-
-      if (
-        !fromPrice ||
-        !toPrice ||
-        fromPrice.price == null ||
-        toPrice.price == null
-      ) {
-        serviceLogger.debug(`[TradeSimulator] Missing price data:
-            From Token Price: ${fromPrice}
-            To Token Price: ${toPrice}
-        `);
-        throw new ApiError(400, "Unable to determine price for tokens");
-      }
-
-      // Validate trading constraints for non-burn tokens
-      // Trading constraints validation (only for 'to' token)
-      if (toPrice.price > 0) {
-        const constraints = await this.getTradingConstraints(competitionId);
-        this.validateTradingConstraints(
-          toPrice,
-          toToken,
-          constraints,
-        );
-      }
-
-      if (
-        !(fromPrice.specificChain !== null && toPrice.specificChain !== null)
-      ) {
-        serviceLogger.debug(`[TradeSimulator] Missing specific chain data:
-            From Token Specific Chain: ${fromPrice.specificChain}
-            To Token Specific Chain: ${toPrice.specificChain}
-        `);
-        throw new ApiError(
-          400,
-          "Unable to determine specific chain for tokens",
-        );
-      }
-
-      switch (features.CROSS_CHAIN_TRADING_TYPE) {
-        case "disallowXParent":
-          // Check if the tokens are on the same chain
-          if (fromTokenChain !== toTokenChain) {
-            serviceLogger.debug(
-              `[TradeSimulator] Cross-parent chain trading is disabled. Cannot trade between ${fromTokenChain} and ${toTokenChain}`,
-            );
-            throw new ApiError(
-              400,
-              "Cross-parent chain trading is disabled. Both tokens must be on the same parent blockchain.",
-            );
-          }
-          break;
-        case "disallowAll":
-          // Check if the tokens are on the same chain
-          if (
-            fromTokenChain !== toTokenChain ||
-            (fromTokenSpecificChain &&
-              toTokenSpecificChain &&
-              fromTokenSpecificChain !== toTokenSpecificChain)
-          ) {
-            serviceLogger.debug(
-              `[TradeSimulator] Cross-chain trading is disabled. Cannot trade between ${fromTokenChain}(${fromTokenSpecificChain || "none"}) and ${toTokenChain}(${toTokenSpecificChain || "none"})`,
-            );
-            throw new ApiError(
-              400,
-              "Cross-chain trading is disabled. Both tokens must be on the same blockchain.",
-            );
-          }
-          break;
-      }
 
       // Calculate the trade using USD values
       const fromValueUSD = fromAmount * fromPrice.price;
 
-      // Validate balances
+      // Get current balance for validation
       const currentBalance = await this.balanceManager.getBalance(
         agentId,
         fromToken,
       );
-      serviceLogger.debug(
-        `[TradeSimulator] Current balance of ${fromToken}: ${currentBalance}`,
-      );
 
-      if (currentBalance < fromAmount) {
-        serviceLogger.debug(
-          `[TradeSimulator] Insufficient balance: ${currentBalance} < ${fromAmount}`,
-        );
-        throw new ApiError(400, "Insufficient balance");
-      }
-
-      // Calculate portfolio value to check maximum trade size (configurable percentage of portfolio)
-      const portfolioValue = await this.calculatePortfolioValue(agentId);
-      // TODO: maxTradePercentage should probably be a setting per comp.
-      const maxTradeValue = portfolioValue * (this.maxTradePercentage / 100);
-      serviceLogger.debug(
-        `[TradeSimulator] Portfolio value: $${portfolioValue}, Max trade value: $${maxTradeValue}, Attempted trade value: $${fromValueUSD}`,
-      );
-
-      if (fromValueUSD > maxTradeValue) {
-        serviceLogger.debug(
-          `[TradeSimulator] Trade exceeds maximum size: $${fromValueUSD} > $${maxTradeValue} (${this.maxTradePercentage}% of portfolio)`,
-        );
-        throw new ApiError(
-          400,
-          `Trade exceeds maximum size (${this.maxTradePercentage}% of portfolio value)`,
-        );
-      }
-
-      // Handle burn address (price = 0) specially
-      let toAmount: number;
-      let exchangeRate: number;
-      let effectiveFromValueUSD: number;
-
-      if (toPrice.price === 0) {
-        // Burning tokens - toAmount is 0, no slippage calculation needed
-        toAmount = 0;
-        exchangeRate = 0;
-        effectiveFromValueUSD = fromValueUSD; // For accounting purposes, record the full USD value burned
-        serviceLogger.debug(
-          `[TradeSimulator] Burn transaction detected - tokens will be burned (toAmount = 0)`,
-        );
-      } else {
-        // Normal trade with slippage
-        const { effectiveFromValueUSD: calculatedEffectiveValue } =
-          calculateSlippage(fromValueUSD);
-        effectiveFromValueUSD = calculatedEffectiveValue;
-        toAmount = effectiveFromValueUSD / toPrice.price;
-        exchangeRate = toAmount / fromAmount;
-      }
-
-      // Debug logging for price calculations
-      if (toPrice.price === 0) {
-        serviceLogger.debug(`[TradeSimulator] Burn trade calculation details:
-                From Token (${fromToken}):
-                - Amount: ${fromAmount}
-                - Price: $${fromPrice.price}
-                - USD Value: $${fromValueUSD.toFixed(6)}
-
-                Burn Details:
-                - To Token (${toToken}): BURN ADDRESS
-                - Price: $${toPrice.price}
-                - Amount Burned: ${toAmount}
-                - USD Value Burned: $${effectiveFromValueUSD.toFixed(6)}
-
-                Exchange Rate: 1 ${fromToken} = ${exchangeRate} ${toToken} (BURN)
-            `);
-      } else {
-        serviceLogger.debug(`[TradeSimulator] Trade calculation details:
-                From Token (${fromToken}):
-                - Amount: ${fromAmount}
-                - Price: $${fromPrice.price}
-                - USD Value: $${fromValueUSD.toFixed(6)}
-
-                To Token (${toToken}):
-                - Price: $${toPrice.price}
-                - Calculated Amount: ${toAmount.toFixed(6)}
-
-                Exchange Rate: 1 ${fromToken} = ${exchangeRate.toFixed(6)} ${toToken}
-            `);
-      }
-
-      // Execute the trade
-      await this.balanceManager.subtractAmount(
+      // Validate balances and portfolio limits
+      await this.validateBalancesAndPortfolio(
         agentId,
         fromToken,
         fromAmount,
-        fromPrice.specificChain as SpecificChain,
-        fromPrice.symbol,
+        fromValueUSD,
+        currentBalance,
       );
 
-      // Only add balance for non-burn addresses (toAmount > 0)
-      if (toAmount > 0) {
-        await this.balanceManager.addAmount(
-          agentId,
-          toToken,
-          toAmount,
-          toPrice.specificChain as SpecificChain,
-          toPrice.symbol,
-        );
-      } else {
-        serviceLogger.debug(
-          `[TradeSimulator] Burn trade completed - no balance added for ${toToken}`,
-        );
-      }
+      // Calculate trade amounts and exchange rates
+      const { toAmount, exchangeRate } = this.calculateTradeAmounts(
+        fromAmount,
+        fromValueUSD,
+        toPrice.price,
+        fromToken,
+        toToken,
+      );
 
-      // Create trade record
-      const trade: InsertTrade = {
-        id: uuidv4(),
-        timestamp: new Date(),
+      // Execute the trade and update database
+      const result = await this.executeTradeAndUpdateDatabase(
+        agentId,
+        competitionId,
         fromToken,
         toToken,
         fromAmount,
         toAmount,
-        price: exchangeRate, // Exchange rate (0 for burns)
-        toTokenSymbol: toPrice.symbol,
-        fromTokenSymbol: fromPrice.symbol,
-        tradeAmountUsd: fromValueUSD, // Store the USD value of the trade
-        success: true,
-        agentId,
-        competitionId,
+        exchangeRate,
+        fromValueUSD,
+        fromPrice,
+        toPrice,
+        chainInfo,
         reason,
-        // Add chain information to the trade record
-        fromChain: fromTokenChain,
-        toChain: toTokenChain,
-        fromSpecificChain: fromPrice.specificChain,
-        toSpecificChain: toPrice.specificChain,
-      };
-
-      // Store the trade in database
-      const result = await createTrade(trade);
-
-      // Update cache
-      const cachedTrades = this.tradeCache.get(agentId) || [];
-      cachedTrades.unshift(result); // Add to beginning of array (newest first)
-      // Limit cache size to 100 trades per agent
-      if (cachedTrades.length > 100) {
-        cachedTrades.pop();
-      }
-      this.tradeCache.set(agentId, cachedTrades);
-
-      serviceLogger.debug(`[TradeSimulator] Trade executed successfully:
-                Initial ${fromToken} Balance: ${currentBalance}
-                New ${fromToken} Balance: ${await this.balanceManager.getBalance(agentId, fromToken)}
-                New ${toToken} Balance: ${await this.balanceManager.getBalance(agentId, toToken)}
-            `);
+        currentBalance,
+      );
 
       // Trigger a portfolio snapshot for the trading agent only
       // We run this asynchronously without awaiting to avoid delaying the trade response
@@ -445,6 +196,43 @@ export class TradeSimulator {
 
       // Otherwise, wrap it in an ApiError
       throw new ApiError(400, errorMessage);
+    }
+  }
+
+  /**
+   * Validates basic trade input parameters
+   * @param fromToken The source token address
+   * @param toToken The destination token address
+   * @param fromAmount The amount to trade
+   * @param reason The reason for the trade
+   * @throws ApiError if validation fails
+   */
+  private validateTradeInputs(
+    fromToken: string,
+    toToken: string,
+    fromAmount: number,
+    reason: string,
+  ): void {
+    // Validate minimum trade amount
+    if (fromAmount < MIN_TRADE_AMOUNT) {
+      serviceLogger.debug(
+        `[TradeSimulator] Trade amount too small: ${fromAmount}`,
+      );
+      throw new ApiError(400, "Trade amount too small (minimum: 0.000001)");
+    }
+
+    // Validate reason is provided
+    if (!reason) {
+      serviceLogger.debug(`[TradeSimulator] Trade reason is required`);
+      throw new ApiError(400, "Trade reason is required");
+    }
+
+    // Prevent trading between identical tokens
+    if (fromToken === toToken) {
+      serviceLogger.debug(
+        `[TradeSimulator] Cannot trade between identical tokens: ${fromToken}`,
+      );
+      throw new ApiError(400, "Cannot trade between identical tokens");
     }
   }
 
@@ -844,5 +632,386 @@ export class TradeSimulator {
         `Token has insufficient liquidity ($${priceData.liquidity.usd.toLocaleString()}, minimum: $${constraints.minimumLiquidityUsd.toLocaleString()})`,
       );
     }
+  }
+
+  /**
+   * Validates cross-chain trading rules.
+   * @param chainInfo The resolved chain and specific chain information.
+   * @throws ApiError if cross-chain trading is not allowed.
+   */
+  private validateCrossChainTrading(chainInfo: ChainOptions): void {
+    if (
+      features.CROSS_CHAIN_TRADING_TYPE === "disallowXParent" &&
+      chainInfo.fromChain !== chainInfo.toChain
+    ) {
+      serviceLogger.debug(
+        `[TradeSimulator] Cross-parent chain trading is disabled. Cannot trade between ${chainInfo.fromChain} and ${chainInfo.toChain}`,
+      );
+      throw new ApiError(
+        400,
+        "Cross-parent chain trading is disabled. Both tokens must be on the same parent blockchain.",
+      );
+    }
+
+    if (
+      features.CROSS_CHAIN_TRADING_TYPE === "disallowAll" &&
+      (chainInfo.fromChain !== chainInfo.toChain ||
+        (chainInfo.fromSpecificChain &&
+          chainInfo.toSpecificChain &&
+          chainInfo.fromSpecificChain !== chainInfo.toSpecificChain))
+    ) {
+      serviceLogger.debug(
+        `[TradeSimulator] Cross-chain trading is disabled. Cannot trade between ${chainInfo.fromChain}(${chainInfo.fromSpecificChain || "none"}) and ${chainInfo.toChain}(${chainInfo.toSpecificChain || "none"})`,
+      );
+      throw new ApiError(
+        400,
+        "Cross-chain trading is disabled. Both tokens must be on the same blockchain.",
+      );
+    }
+  }
+
+  /**
+   * Resolves chain variables for price fetching.
+   * Handles default chain detection and specific chain overrides.
+   * @param fromToken The source token address
+   * @param toToken The destination token address
+   * @param chainOptions Optional chain specification for performance optimization
+   * @returns An object containing resolved chain and specific chain variables.
+   */
+  private resolveChainVariables(
+    fromToken: string,
+    toToken: string,
+    chainOptions?: ChainOptions,
+  ): ChainOptions {
+    let fromChain: BlockchainType, toChain: BlockchainType;
+    let fromSpecificChain: SpecificChain | undefined,
+      toSpecificChain: SpecificChain | undefined;
+
+    // For the source token
+    if (chainOptions?.fromChain) {
+      fromChain = chainOptions.fromChain;
+      fromSpecificChain = chainOptions.fromSpecificChain;
+      serviceLogger.debug(
+        `[TradeSimulator] Using provided chain for fromToken: ${fromChain}, specificChain: ${fromSpecificChain || "none"}`,
+      );
+    } else {
+      fromChain = this.priceTracker.determineChain(fromToken);
+      serviceLogger.debug(
+        `[TradeSimulator] Detected chain for fromToken: ${fromChain}`,
+      );
+    }
+
+    // assign the specific chain if provided
+    if (chainOptions?.fromSpecificChain) {
+      fromSpecificChain = chainOptions.fromSpecificChain;
+      serviceLogger.debug(
+        `[TradeSimulator] Using provided specific chain for fromToken: ${fromSpecificChain}`,
+      );
+    }
+
+    // For the destination token
+    if (chainOptions?.toChain) {
+      toChain = chainOptions.toChain;
+      toSpecificChain = chainOptions.toSpecificChain;
+      serviceLogger.debug(
+        `[TradeSimulator] Using provided chain for toToken: ${toChain}, specificChain: ${toSpecificChain || "none"}`,
+      );
+    } else {
+      toChain = this.priceTracker.determineChain(toToken);
+      serviceLogger.debug(
+        `[TradeSimulator] Detected chain for toToken: ${toChain}`,
+      );
+    }
+
+    // assign the specific chain if provided
+    if (chainOptions?.toSpecificChain) {
+      toSpecificChain = chainOptions.toSpecificChain;
+      serviceLogger.debug(
+        `[TradeSimulator] Using provided specific chain for toToken: ${toSpecificChain}`,
+      );
+    }
+
+    return {
+      fromChain,
+      toChain,
+      fromSpecificChain,
+      toSpecificChain,
+    };
+  }
+
+  /**
+   * Fetches prices for both tokens and validates constraints.
+   * @param fromToken The source token address
+   * @param toToken The destination token address
+   * @param chainInfo The resolved chain and specific chain information
+   * @param competitionId The competition ID
+   * @returns An object containing fromPrice and toPrice.
+   * @throws ApiError if prices are missing or constraints are violated.
+   */
+  private async fetchAndValidatePrices(
+    fromToken: string,
+    toToken: string,
+    chainInfo: ChainOptions,
+    competitionId: string,
+  ): Promise<{ fromPrice: PriceReport; toPrice: PriceReport }> {
+    // Get prices with chain information for better performance
+    const fromPrice = await this.priceTracker.getPrice(
+      fromToken,
+      chainInfo.fromChain,
+      chainInfo.fromSpecificChain,
+    );
+
+    const toPrice = await this.priceTracker.getPrice(
+      toToken,
+      chainInfo.toChain,
+      chainInfo.toSpecificChain,
+    );
+
+    serviceLogger.debug("[TradeSimulator] Got prices:");
+    serviceLogger.debug(
+      `  From Token (${fromToken}): ${JSON.stringify(fromPrice, null, 4)} (${chainInfo.fromChain})`,
+    );
+    serviceLogger.debug(
+      `  To Token (${toToken}): ${JSON.stringify(toPrice, null, 4)} (${chainInfo.toChain})`,
+    );
+
+    if (
+      !fromPrice ||
+      !toPrice ||
+      fromPrice.price == null ||
+      toPrice.price == null
+    ) {
+      serviceLogger.debug(`[TradeSimulator] Missing price data:
+            From Token Price: ${fromPrice}
+            To Token Price: ${toPrice}
+        `);
+      throw new ApiError(400, "Unable to determine price for tokens");
+    }
+
+    // Validate trading constraints for non-burn tokens
+    // Trading constraints validation (only for 'to' token)
+    if (toPrice.price > 0) {
+      const constraints = await this.getTradingConstraints(competitionId);
+      this.validateTradingConstraints(toPrice, toToken, constraints);
+    }
+
+    if (!(fromPrice.specificChain !== null && toPrice.specificChain !== null)) {
+      serviceLogger.debug(`[TradeSimulator] Missing specific chain data:
+            From Token Specific Chain: ${fromPrice.specificChain}
+            To Token Specific Chain: ${toPrice.specificChain}
+        `);
+      throw new ApiError(400, "Unable to determine specific chain for tokens");
+    }
+
+    return { fromPrice, toPrice };
+  }
+
+  /**
+   * Validates balances and portfolio limits for a trade.
+   * @param agentId The agent ID
+   * @param fromToken The source token address
+   * @param fromAmount The amount to trade
+   * @param fromValueUSD The USD value of the trade
+   * @param currentBalance The current balance of the agent's fromToken
+   * @throws ApiError if validation fails
+   */
+  private async validateBalancesAndPortfolio(
+    agentId: string,
+    fromToken: string,
+    fromAmount: number,
+    fromValueUSD: number,
+    currentBalance: number,
+  ): Promise<void> {
+    // Validate balances
+    serviceLogger.debug(
+      `[TradeSimulator] Current balance of ${fromToken}: ${currentBalance}`,
+    );
+
+    if (currentBalance < fromAmount) {
+      serviceLogger.debug(
+        `[TradeSimulator] Insufficient balance: ${currentBalance} < ${fromAmount}`,
+      );
+      throw new ApiError(400, "Insufficient balance");
+    }
+
+    // Calculate portfolio value to check maximum trade size (configurable percentage of portfolio)
+    const portfolioValue = await this.calculatePortfolioValue(agentId);
+    // TODO: maxTradePercentage should probably be a setting per comp.
+    const maxTradeValue = portfolioValue * (this.maxTradePercentage / 100);
+    serviceLogger.debug(
+      `[TradeSimulator] Portfolio value: $${portfolioValue}, Max trade value: $${maxTradeValue}, Attempted trade value: $${fromValueUSD}`,
+    );
+
+    if (fromValueUSD > maxTradeValue) {
+      serviceLogger.debug(
+        `[TradeSimulator] Trade exceeds maximum size: $${fromValueUSD} > $${maxTradeValue} (${this.maxTradePercentage}% of portfolio)`,
+      );
+      throw new ApiError(
+        400,
+        `Trade exceeds maximum size (${this.maxTradePercentage}% of portfolio value)`,
+      );
+    }
+  }
+
+  /**
+   * Calculates the amount of tokens to receive and the exchange rate for a trade.
+   * Handles slippage and burn address scenarios.
+   * @param fromAmount The amount of tokens to send
+   * @param fromValueUSD The USD value of the trade
+   * @param toPrice The price of the token to receive
+   * @param fromToken The source token address
+   * @param toToken The destination token address
+   * @returns An object containing toAmount and exchangeRate.
+   */
+  private calculateTradeAmounts(
+    fromAmount: number,
+    fromValueUSD: number,
+    toPrice: number,
+    fromToken: string,
+    toToken: string,
+  ): { toAmount: number; exchangeRate: number } {
+    let toAmount: number;
+    let exchangeRate: number;
+    let effectiveFromValueUSD: number;
+
+    if (toPrice === 0) {
+      // Burning tokens - toAmount is 0, no slippage calculation needed
+      toAmount = 0;
+      exchangeRate = 0;
+      effectiveFromValueUSD = fromValueUSD; // For accounting purposes, record the full USD value burned
+      serviceLogger.debug(`[TradeSimulator] Burn transaction detected - tokens will be burned (toAmount = 0):
+          From Token (${fromToken}):
+          - Amount: ${fromAmount}
+          - USD Value: $${fromValueUSD.toFixed(6)}
+
+          Burn Details:
+          - To Token (${toToken}): BURN ADDRESS
+          - Price: $${toPrice}
+          - Amount Burned: ${toAmount}
+          - USD Value Burned: $${effectiveFromValueUSD.toFixed(6)}
+
+          Exchange Rate: 1 ${fromToken} = ${exchangeRate} ${toToken} (BURN)
+      `);
+    } else {
+      // Normal trade with slippage
+      const { effectiveFromValueUSD: calculatedEffectiveValue } =
+        calculateSlippage(fromValueUSD);
+      effectiveFromValueUSD = calculatedEffectiveValue;
+      toAmount = effectiveFromValueUSD / toPrice;
+      exchangeRate = toAmount / fromAmount;
+      serviceLogger.debug(`[TradeSimulator] Trade calculation details:
+          From Token (${fromToken}):
+          - Amount: ${fromAmount}
+          - USD Value: $${fromValueUSD.toFixed(6)}
+
+          To Token (${toToken}):
+          - Price: $${toPrice}
+          - Calculated Amount: ${toAmount.toFixed(6)}
+
+          Exchange Rate: 1 ${fromToken} = ${exchangeRate.toFixed(6)} ${toToken}
+      `);
+    }
+
+    return { toAmount, exchangeRate };
+  }
+
+  /**
+   * Executes a trade and updates the database.
+   * @param agentId The agent ID
+   * @param competitionId The competition ID
+   * @param fromToken The source token address
+   * @param toToken The destination token address
+   * @param fromAmount The amount to trade
+   * @param toAmount The amount to receive
+   * @param exchangeRate The exchange rate
+   * @param fromValueUSD The USD value of the trade
+   * @param fromPrice The price data for the source token
+   * @param toPrice The price data for the destination token
+   * @param chainInfo The resolved chain and specific chain information
+   * @param reason The reason for the trade
+   * @param currentBalance The current balance of the agent's fromToken
+   * @returns The created trade record
+   */
+  private async executeTradeAndUpdateDatabase(
+    agentId: string,
+    competitionId: string,
+    fromToken: string,
+    toToken: string,
+    fromAmount: number,
+    toAmount: number,
+    exchangeRate: number,
+    fromValueUSD: number,
+    fromPrice: PriceReport,
+    toPrice: PriceReport,
+    chainInfo: ChainOptions,
+    reason: string,
+    currentBalance: number,
+  ): Promise<SelectTrade> {
+    // Execute the trade
+    await this.balanceManager.subtractAmount(
+      agentId,
+      fromToken,
+      fromAmount,
+      fromPrice.specificChain as SpecificChain,
+      fromPrice.symbol,
+    );
+
+    // Only add balance for non-burn addresses (toAmount > 0)
+    if (toAmount > 0) {
+      await this.balanceManager.addAmount(
+        agentId,
+        toToken,
+        toAmount,
+        toPrice.specificChain as SpecificChain,
+        toPrice.symbol,
+      );
+    } else {
+      serviceLogger.debug(
+        `[TradeSimulator] Burn trade completed - no balance added for ${toToken}`,
+      );
+    }
+
+    // Create trade record
+    const trade: InsertTrade = {
+      id: uuidv4(),
+      timestamp: new Date(),
+      fromToken,
+      toToken,
+      fromAmount,
+      toAmount,
+      price: exchangeRate, // Exchange rate (0 for burns)
+      toTokenSymbol: toPrice.symbol,
+      fromTokenSymbol: fromPrice.symbol,
+      tradeAmountUsd: fromValueUSD, // Store the USD value of the trade
+      success: true,
+      agentId,
+      competitionId,
+      reason,
+      // Add chain information to the trade record
+      fromChain: chainInfo.fromChain,
+      toChain: chainInfo.toChain,
+      fromSpecificChain: fromPrice.specificChain,
+      toSpecificChain: toPrice.specificChain,
+    };
+
+    // Store the trade in database
+    const result = await createTrade(trade);
+
+    // Update cache
+    const cachedTrades = this.tradeCache.get(agentId) || [];
+    cachedTrades.unshift(result); // Add to beginning of array (newest first)
+    // Limit cache size to 100 trades per agent
+    if (cachedTrades.length > 100) {
+      cachedTrades.pop();
+    }
+    this.tradeCache.set(agentId, cachedTrades);
+
+    serviceLogger.debug(`[TradeSimulator] Trade executed successfully:
+                Initial ${fromToken} Balance: ${currentBalance}
+                New ${fromToken} Balance: ${await this.balanceManager.getBalance(agentId, fromToken)}
+                New ${toToken} Balance: ${await this.balanceManager.getBalance(agentId, toToken)}
+            `);
+
+    return result;
   }
 }


### PR DESCRIPTION
No functional changes, just code cleanups.

* Commit 1: small cleanup to PriceTracker.getPrice to use an early return
* Commit 2: change TradeSimulator.executeTrade to throw on error instead of returning an error object
* Commit 3: Break up TradeSimulator.executeTrade into many smaller helper functions
* Commit 4: Cursor rule to keep functions small