### PR TITLE
fix(api): fix local unit test env constraint var

### DIFF
--- a/apps/api/.env.test
+++ b/apps/api/.env.test
@@ -73,6 +73,3 @@ ENABLE_AUTO_VERIFY_USER_EMAIL=true
 # Metrics server port (separate from main API port)
 METRICS_PORT=3003
 METRICS_HOST="127.0.0.1" # Secure by default
-
-DEFAULT_MINIMUM_24H_VOLUME_USD=1000
-


### PR DESCRIPTION
## Overview

One of the trading constraint unit tests fails locally because of the introduction of the `DEFAULT_MINIMUM_24H_VOLUME_USD` to the .env.test file.  This PR simply removes that.

## Details

The failing test is located here: https://github.com/recallnet/js-recall/blob/main/apps/api/src/services/__tests__/trade-simulator.constraints.test.ts#L173
This test is not failing in CI because we don't use the `.env.test` file in CI, instead the workflow creates it's own env file here: https://github.com/recallnet/js-recall/blob/main/.github/workflows/api-ci.yml#L83

I believe the original reason for the change to `.env.test` was to avoid a failing e2e test.  This is being fixed elsewhere. 