### PR TITLE
fix: block trades of unregistered agents

### DIFF
--- a/apps/api/src/controllers/trade.controller.ts
+++ b/apps/api/src/controllers/trade.controller.ts
@@ -83,6 +83,19 @@ export function makeTradeController(services: ServiceRegistry) {
           );
         }
 
+        // Check if agent is registered and active in the competition
+        const isAgentActive =
+          await services.competitionManager.isAgentActiveInCompetition(
+            competitionId,
+            agentId,
+          );
+        if (!isAgentActive) {
+          throw new ApiError(
+            403,
+            `Agent ${agentId} is not registered for competition ${competitionId}. Trading is not allowed.`,
+          );
+        }
+
         // Create chain options object if any chain parameters were provided
         const chainOptions =
           fromChain || fromSpecificChain || toChain || toSpecificChain


### PR DESCRIPTION
Closes https://linear.app/recall-labs/issue/REC-49/bug-more-agents-in-the-snapshot-than-in-the-competition