### PR TITLE
feat(comps): agent handle tweaks

### DIFF
--- a/apps/comps/components/agents-table/index.tsx
+++ b/apps/comps/components/agents-table/index.tsx
@@ -131,7 +131,7 @@ export const AgentsTable: React.FC<AgentsTableProps> = ({
                 className="block w-full overflow-hidden"
               >
                 <span className="block w-full overflow-hidden text-ellipsis whitespace-nowrap font-semibold leading-tight">
-                  {row.original.name} (@{row.original.handle})
+                  {row.original.name}
                 </span>
               </Link>
               <span className="text-secondary-foreground block w-full overflow-hidden text-ellipsis whitespace-nowrap text-xs">

--- a/apps/comps/components/competitions-table.tsx
+++ b/apps/comps/components/competitions-table.tsx
@@ -94,7 +94,7 @@ export const CompetitionsTable: React.FC<CompetitionsTableProps> = ({
                 <div className="flex min-w-0 flex-1 flex-col">
                   <Link href={`/agents/${agent.id}`} className="truncate">
                     <span className="text-secondary-foreground font-semibold leading-tight">
-                      {agent.name} (@{agent.handle})
+                      {agent.name}
                     </span>
                   </Link>
                   <span className="text-secondary-foreground/70 block min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-xs">

--- a/apps/comps/components/featured-competition/top-leaders-list.tsx
+++ b/apps/comps/components/featured-competition/top-leaders-list.tsx
@@ -60,7 +60,7 @@ export const TopLeadersList: React.FC<TopLeadersListProps> = ({
                 className="text-secondary-foreground truncate font-semibold"
                 title={agent.name}
               >
-                {agent.name} (@{agent.handle})
+                {agent.name}
               </span>
             </Link>
             <div className="flex items-center gap-3">

--- a/apps/comps/components/leaderboard-table/index.tsx
+++ b/apps/comps/components/leaderboard-table/index.tsx
@@ -156,7 +156,7 @@ export function LeaderboardTable({
                         </div>
                         <div className="md:w-70 w-40 text-left text-sm">
                           <div className="text-secondary-foreground mb-2 truncate font-medium leading-none">
-                            {agent.name} (@{agent.handle})
+                            {agent.name}
                           </div>
                           {agent.description && (
                             <p className="truncate whitespace-nowrap text-xs font-light text-gray-500">

--- a/apps/comps/components/modals/choose-agent.tsx
+++ b/apps/comps/components/modals/choose-agent.tsx
@@ -70,7 +70,12 @@ export const ChooseAgentModal: React.FC<ChooseAgentModalProps> = ({
           <SelectContent>
             {agents.map((agent) => (
               <SelectItem key={agent.id} value={agent.id}>
-                {agent.name} (@{agent.handle})
+                <div className="flex items-center gap-1">
+                  {agent.name}
+                  <span className="text-secondary-foreground">
+                    (@{agent.handle})
+                  </span>
+                </div>
               </SelectItem>
             ))}
           </SelectContent>

--- a/apps/comps/components/user-vote.tsx
+++ b/apps/comps/components/user-vote.tsx
@@ -58,7 +58,7 @@ export const UserVote: React.FC<UserVoteProps> = ({
                       className="block w-full overflow-hidden"
                     >
                       <span className="block w-full overflow-hidden text-ellipsis whitespace-nowrap font-semibold leading-tight">
-                        {agent.name} (@{agent.handle})
+                        {agent.name}
                       </span>
                     </Link>
                     <span className="text-secondary-foreground block w-full overflow-hidden text-ellipsis whitespace-nowrap text-xs">

--- a/apps/comps/components/user-votes/votes-table.tsx
+++ b/apps/comps/components/user-votes/votes-table.tsx
@@ -91,7 +91,7 @@ export const VotesTable: React.FC<VotesTableProps> = ({
                 className="truncate"
               >
                 <span className="text-secondary-foreground font-semibold leading-tight">
-                  {row.original.agent.name} (@{row.original.agent.handle})
+                  {row.original.agent.name}
                 </span>
               </Link>
               <span className="text-secondary-foreground/70 block min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-xs">

--- a/packages/ui2/src/components/select.tsx
+++ b/packages/ui2/src/components/select.tsx
@@ -91,7 +91,7 @@ const SelectItem = React.forwardRef<
   <SelectPrimitive.Item
     ref={ref}
     className={cn(
-      "focus:bg-accent focus:text-accent-foreground relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "focus:bg-accent focus:text-accent-foreground relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none hover:cursor-pointer data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       className,
     )}
     {...props}


### PR DESCRIPTION
Remove the `@handle` from most places that _aren't_ the actual agent card, and only display the name