### PR TITLE
feat(api): contraints are returns via endpoints and always stored in db 

### DIFF
--- a/apps/api/e2e/tests/trading.test.ts
+++ b/apps/api/e2e/tests/trading.test.ts
@@ -624,7 +624,7 @@ describe("Trading API", () => {
       undefined,
       undefined,
       undefined,
-      looseTradingConstraints,
+      { ...looseTradingConstraints, minimumLiquidityUsd: 500 },
     );
 
     // Wait for balances to be properly initialized

--- a/apps/api/e2e/utils/api-types.ts
+++ b/apps/api/e2e/utils/api-types.ts
@@ -364,12 +364,7 @@ export interface Competition {
   // Join date constraint fields
   joinStartDate: string | null;
   joinEndDate: string | null;
-  tradingConstraints?: {
-    minimumPairAgeHours?: number;
-    minimum24hVolumeUsd?: number;
-    minimumLiquidityUsd?: number;
-    minimumFdvUsd?: number;
-  };
+  tradingConstraints?: TradingConstraints;
   rewards?: {
     rank: number;
     reward: number;
@@ -802,9 +797,9 @@ export interface GlobalLeaderboardResponse extends ApiResponse {
   };
 }
 
-// ===========================
+// ---------------------------
 // Vote-related types
-// ===========================
+// ---------------------------
 
 /**
  * Response type for casting a vote
@@ -938,5 +933,3 @@ export interface AdminAddAgentToCompetitionResponse extends ApiResponse {
     status: string;
   };
 }
-
-// ===========================

--- a/apps/api/e2e/utils/test-helpers.ts
+++ b/apps/api/e2e/utils/test-helpers.ts
@@ -14,6 +14,7 @@ import { ApiClient } from "./api-client.js";
 import {
   CreateCompetitionResponse,
   StartCompetitionResponse,
+  TradingConstraints,
 } from "./api-types.js";
 import { getBaseUrl } from "./server.js";
 import {
@@ -213,12 +214,7 @@ export async function startTestCompetition(
   sandboxMode?: boolean,
   externalUrl?: string,
   imageUrl?: string,
-  tradingConstraints?: {
-    minimumPairAgeHours?: number;
-    minimum24hVolumeUsd?: number;
-    minimumLiquidityUsd?: number;
-    minimumFdvUsd?: number;
-  },
+  tradingConstraints?: TradingConstraints,
 ): Promise<StartCompetitionResponse> {
   const result = await adminClient.startCompetition(
     name,

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -44,6 +44,7 @@
     "end:competition": "tsx scripts/end-competition.ts",
     "comp:status": "tsx scripts/competition-status.ts",
     "scripts:backfill-agent-score": "tsx scripts/backfill-agent-score.ts",
+    "scripts:backfill-constraints": "tsx scripts/backfill-comp-constraints.ts",
     "scripts:backfill-stats": "tsx scripts/backfill-stats.ts",
     "scripts:delete-competitions": "tsx scripts/delete-competitions.ts",
     "scripts:populate-agent-handles": "tsx scripts/populate-agent-handles.ts",

--- a/apps/api/scripts/backfill-comp-constraints.ts
+++ b/apps/api/scripts/backfill-comp-constraints.ts
@@ -1,0 +1,200 @@
+import chalk from "chalk";
+import * as readline from "readline";
+
+import { db } from "@/database/db.js";
+import { competitions } from "@/database/schema/core/defs.js";
+import { tradingConstraints } from "@/database/schema/trading/defs.js";
+
+const JULY_23_COMP = "99a8f533-b745-48c6-afb3-252a0c02e25b";
+
+/**
+ * Prompt user for confirmation
+ */
+async function promptConfirmation(message: string): Promise<boolean> {
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+
+  return new Promise((resolve) => {
+    rl.question(`${message} (y/n): `, (answer) => {
+      rl.close();
+      resolve(answer.toLowerCase() === "yes" || answer.toLowerCase() === "y");
+    });
+  });
+}
+
+/**
+ * Find competitions that don't have trading constraints
+ */
+async function findCompetitionsWithoutConstraints() {
+  console.log(
+    chalk.blue("Checking for competitions without trading constraints..."),
+  );
+
+  // Get all competitions
+  const allCompetitions = await db
+    .select({
+      id: competitions.id,
+      name: competitions.name,
+      type: competitions.type,
+      status: competitions.status,
+    })
+    .from(competitions);
+
+  console.log(chalk.gray(`Found ${allCompetitions.length} total competitions`));
+
+  // Get all competitions that already have trading constraints
+  const competitionsWithConstraints = await db
+    .select({
+      competitionId: tradingConstraints.competitionId,
+    })
+    .from(tradingConstraints);
+
+  const constraintCompetitionIds = new Set(
+    competitionsWithConstraints.map((c) => c.competitionId),
+  );
+
+  // Find competitions without constraints
+  const competitionsWithoutConstraints = allCompetitions.filter(
+    (comp) => !constraintCompetitionIds.has(comp.id),
+  );
+
+  return {
+    total: allCompetitions.length,
+    withConstraints: constraintCompetitionIds.size,
+    withoutConstraints: competitionsWithoutConstraints,
+  };
+}
+
+/**
+ * Create default trading constraints for competitions that don't have them
+ */
+async function backfillTradingConstraints(execute: boolean = false) {
+  // wait for db connection to improve log output
+  await new Promise((resolve) => setTimeout(() => resolve(null), 2000));
+  console.log(
+    chalk.bold("\n🔧  Competition Trading Constraints Backfill Script"),
+  );
+  console.log(
+    chalk.gray("========================================================\n"),
+  );
+
+  if (!execute) {
+    console.log(
+      chalk.yellow("⚠️  Running in DRY RUN mode - no changes will be made"),
+    );
+    console.log(
+      chalk.yellow("   Add --execute as argument to perform actual backfill\n"),
+    );
+  } else {
+    console.log(
+      chalk.red("⚠️  Running in EXECUTE mode - constraints WILL be created!\n"),
+    );
+  }
+
+  const analysis = await findCompetitionsWithoutConstraints();
+
+  console.log(chalk.blue("Analysis Results:"));
+  console.log(chalk.gray(`  Total competitions: ${analysis.total}`));
+  console.log(chalk.gray(`  With constraints: ${analysis.withConstraints}`));
+  console.log(
+    chalk.gray(`  Without constraints: ${analysis.withoutConstraints.length}`),
+  );
+
+  if (analysis.withoutConstraints.length === 0) {
+    console.log(
+      chalk.green("\n✅ All competitions already have trading constraints!"),
+    );
+    return;
+  }
+
+  console.log(chalk.yellow("\nCompetitions without trading constraints:"));
+  for (const comp of analysis.withoutConstraints) {
+    console.log(
+      chalk.gray(
+        `  • ${comp.id} - ${comp.name} (${comp.type}, ${comp.status})`,
+      ),
+    );
+  }
+
+  if (execute) {
+    const confirmed = await promptConfirmation(
+      `\nAre you sure you want to create trading constraints for ${analysis.withoutConstraints.length} competition(s)?`,
+    );
+
+    if (!confirmed) {
+      console.log(chalk.red("\n❌ Backfill cancelled"));
+      return;
+    }
+
+    console.log(chalk.blue("\nCreating trading constraints..."));
+
+    // Create constraints with all values set to 0
+    const constraintsToInsert = analysis.withoutConstraints.map((comp) => {
+      const constraints =
+        comp.id === JULY_23_COMP
+          ? {
+              minimumPairAgeHours: 168,
+              minimum24hVolumeUsd: 100000,
+              minimumLiquidityUsd: 100000,
+              minimumFdvUsd: 1000000,
+            }
+          : {
+              minimumPairAgeHours: 0,
+              minimum24hVolumeUsd: 0,
+              minimumLiquidityUsd: 0,
+              minimumFdvUsd: 0,
+            };
+      return {
+        competitionId: comp.id,
+        ...constraints,
+      };
+    });
+
+    await db.transaction(async (tx) => {
+      for (const constraint of constraintsToInsert) {
+        await tx.insert(tradingConstraints).values(constraint);
+        console.log(
+          chalk.gray(`  ✓ Created constraints for ${constraint.competitionId}`),
+        );
+      }
+    });
+
+    console.log(
+      chalk.green(
+        `\n✅ Successfully created trading constraints for ${analysis.withoutConstraints.length} competitions!`,
+      ),
+    );
+  } else {
+    console.log(
+      chalk.yellow(
+        `\nTo execute the backfill, run: pnpm --filter api tsx scripts/backfill-comp-constraints.ts --execute`,
+      ),
+    );
+  }
+}
+
+/**
+ * Main script execution
+ */
+async function main() {
+  const args = process.argv.slice(2);
+  const execute = args.includes("--execute");
+
+  try {
+    await backfillTradingConstraints(execute);
+  } catch (error) {
+    console.error(chalk.red("\n❌ Script failed:"), error);
+    process.exit(1);
+  }
+
+  // Clean exit
+  process.exit(0);
+}
+
+// Execute the script
+main().catch((error) => {
+  console.error(chalk.red("\n❌ Script failed:"), error);
+  process.exit(1);
+});

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -63,10 +63,8 @@ if (process.env.NODE_ENV !== "production") {
     apiLogger.info("Database connection and schema verification completed");
     databaseInitialized = true;
   } catch (error) {
-    apiLogger.error("Database initialization error:", error);
-    apiLogger.error(
-      "Failed to start server due to database initialization error. Exiting...",
-    );
+    apiLogger.error(`Database initialization error: ${error}`);
+    apiLogger.error("Exiting...");
     process.exit(1);
   }
 } else {

--- a/apps/api/src/routes/admin.routes.ts
+++ b/apps/api/src/routes/admin.routes.ts
@@ -188,6 +188,22 @@ export function configureAdminRoutes(
    *                             type: number
    *                             description: Reward amount for the given rank
    *                             example: 1000
+   *                     tradingConstraints:
+   *                       type: object
+   *                       description: Trading constraints for the competition
+   *                       properties:
+   *                         minimumPairAgeHours:
+   *                           type: number
+   *                           description: Minimum age of trading pairs in hours
+   *                         minimum24hVolumeUsd:
+   *                           type: number
+   *                           description: Minimum 24-hour volume in USD
+   *                         minimumLiquidityUsd:
+   *                           type: number
+   *                           description: Minimum liquidity in USD
+   *                         minimumFdvUsd:
+   *                           type: number
+   *                           description: Minimum fully diluted valuation in USD
    *       400:
    *         description: |-
    *           Bad Request - Various validation errors:
@@ -384,6 +400,22 @@ export function configureAdminRoutes(
    *                             description: Reward amount for the given rank
    *                             example: 1000
    *                         description: Reward amount for the given rank
+   *                     tradingConstraints:
+   *                       type: object
+   *                       description: Trading constraints for the competition
+   *                       properties:
+   *                         minimumPairAgeHours:
+   *                           type: number
+   *                           description: Minimum age of trading pairs in hours
+   *                         minimum24hVolumeUsd:
+   *                           type: number
+   *                           description: Minimum 24-hour volume in USD
+   *                         minimumLiquidityUsd:
+   *                           type: number
+   *                           description: Minimum liquidity in USD
+   *                         minimumFdvUsd:
+   *                           type: number
+   *                           description: Minimum fully diluted valuation in USD
    *                 initializedAgents:
    *                   type: array
    *                   items:

--- a/apps/api/src/services/competition-manager.service.ts
+++ b/apps/api/src/services/competition-manager.service.ts
@@ -165,16 +165,6 @@ export class CompetitionManager {
 
     await createCompetition(competition);
 
-    // Create trading constraints if provided
-    if (tradingConstraints) {
-      await this.tradingConstraintsService.createConstraints({
-        competitionId: id,
-        ...tradingConstraints,
-      });
-      serviceLogger.debug(
-        `[CompetitionManager] Created trading constraints for competition ${id}`,
-      );
-    }
     let createdRewards: SelectCompetitionReward[] = [];
     if (rewards) {
       createdRewards = await this.competitionRewardService.createRewards(
@@ -187,6 +177,15 @@ export class CompetitionManager {
         )}`,
       );
     }
+
+    // Always create trading constraints (with defaults if not provided)
+    await this.tradingConstraintsService.createConstraints({
+      competitionId: id,
+      ...tradingConstraints,
+    });
+    serviceLogger.debug(
+      `[CompetitionManager] Created trading constraints for competition ${id}`,
+    );
 
     serviceLogger.debug(
       `[CompetitionManager] Created competition: ${name} (${id}), crossChainTradingType: ${tradingType}, type: ${type}}`,
@@ -283,15 +282,24 @@ export class CompetitionManager {
       `[CompetitionManager] Participating agents: ${agentIds.join(", ")}`,
     );
 
-    // Create trading constraints if provided
-    if (tradingConstraints) {
-      await this.tradingConstraintsService.upsertConstraints({
+    const existingConstraints =
+      await this.tradingConstraintsService.getConstraints(competitionId);
+    if (tradingConstraints && existingConstraints) {
+      // If the caller provided constraints and the already exist, we update
+      await this.tradingConstraintsService.updateConstraints(
+        competitionId,
+        tradingConstraints,
+      );
+      serviceLogger.debug(
+        `[CompetitionManager] Updating trading constraints for competition ${competitionId}`,
+      );
+    } else if (!existingConstraints) {
+      // if the constraints don't exist, we create them with defaults and
+      // (optionally) caller provided values.
+      await this.tradingConstraintsService.createConstraints({
         competitionId,
         ...tradingConstraints,
       });
-      serviceLogger.debug(
-        `[CompetitionManager] Upserted trading constraints for competition ${competitionId}`,
-      );
     }
 
     // Take initial portfolio snapshots


### PR DESCRIPTION
fixes #969 

Work also described here: https://linear.app/recall-labs/issue/REC-44/backend-follow-ups-for-trading-constraints-table-and-liquidity-rules