### PR TITLE
feat(comps): frontend cleanups

### DIFF
--- a/apps/comps/components/agent-avatar.tsx
+++ b/apps/comps/components/agent-avatar.tsx
@@ -9,6 +9,7 @@ import { UserAgentCompetition } from "@/types/competition";
 interface AgentAvatarProps {
   agent: Agent | UserAgentCompetition | AgentCompetition;
   showRank?: boolean;
+  showBorder?: boolean;
   rank?: number;
   className?: string;
   size?: number;
@@ -17,18 +18,20 @@ interface AgentAvatarProps {
 export function AgentAvatar({
   agent,
   showRank = false,
+  showBorder = true,
   rank,
   className,
   size = 32,
 }: AgentAvatarProps) {
   const commonClasses = cn(
     "group relative h-8 w-8 transition-transform duration-200 hover:z-10 hover:scale-110",
-    showRank && "h-9 w-9 rounded-full border-2 bg-gray-700",
+    (showRank || showBorder) && "border-1 h-9 w-9 rounded-full bg-gray-700",
     showRank &&
       rank && {
-        "border-yellow-800": rank === 1,
-        "border-gray-700": rank === 2 || rank > 3,
-        "border-[#1A0E05]": rank === 3,
+        "border-trophy-first": rank === 1,
+        "border-trophy-second": rank === 2,
+        "border-trophy-third": rank === 3,
+        "border-gray-700": rank > 3,
       },
     className,
   );
@@ -56,7 +59,35 @@ export function AgentAvatar({
     );
   }
 
-  const identicon = (
+  const hasBorder = showRank || showBorder;
+
+  if (hasBorder) {
+    // When there's a border, wrap the identicon to handle padding
+    return (
+      <div
+        className={cn(
+          "relative flex items-center justify-center overflow-hidden",
+          commonClasses,
+        )}
+        style={{
+          width: size,
+          height: size,
+          minWidth: size,
+          minHeight: size,
+        }}
+      >
+        <Identicon
+          address={agent.id}
+          className="rounded-full"
+          size={size - 6} // Reduce size to account for border and padding
+          title={agent.name}
+        />
+      </div>
+    );
+  }
+
+  // No border, render identicon directly
+  return (
     <Identicon
       address={agent.id}
       className={cn("", commonClasses)}
@@ -64,6 +95,4 @@ export function AgentAvatar({
       title={agent.name}
     />
   );
-
-  return identicon;
 }

--- a/apps/comps/components/agent-profile/credentials.tsx
+++ b/apps/comps/components/agent-profile/credentials.tsx
@@ -126,7 +126,7 @@ const ApiKeyLocked = ({
       <div className="text-center sm:text-left">
         <span className="text-secondary-foreground block text-sm font-bold">
           Your API keys are
-          <span className="ml-1 text-red-300">locked</span>.
+          <span className="ml-1 text-red-500">locked</span>.
         </span>
       </div>
 

--- a/apps/comps/components/agents-table/award-icon.tsx
+++ b/apps/comps/components/agents-table/award-icon.tsx
@@ -23,9 +23,9 @@ export const AwardIcon: React.FunctionComponent<AwardIconProps> = ({
         "flex items-center font-semibold text-gray-400",
         className,
         {
-          "text-yellow-400": place === "first",
-          "text-gray-400": place === "second",
-          "text-red-400": place === "third",
+          "text-trophy-first": place === "first",
+          "text-trophy-second": place === "second",
+          "text-trophy-third": place === "third",
         },
       )}
     >

--- a/apps/comps/components/agents-table/index.tsx
+++ b/apps/comps/components/agents-table/index.tsx
@@ -11,7 +11,7 @@ import {
 } from "@tanstack/react-table";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { ArrowUp, Search } from "lucide-react";
-import Link from "next/link";
+import { useRouter } from "next/navigation";
 import React, { useEffect, useMemo, useRef, useState } from "react";
 
 import { IconButton } from "@recallnet/ui2/components/icon-button";
@@ -66,6 +66,7 @@ export const AgentsTable: React.FC<AgentsTableProps> = ({
   ref,
 }) => {
   const session = useUserSession();
+  const router = useRouter();
   const tableContainerRef = useRef<HTMLDivElement>(null);
   const [sorting, setSorting] = useState<SortingState>([]);
   const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({
@@ -126,14 +127,10 @@ export const AgentsTable: React.FC<AgentsTableProps> = ({
           <div className="flex min-w-0 items-center gap-3">
             <AgentAvatar agent={row.original} size={32} />
             <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
-              <Link
-                href={`/agents/${row.original.id}`}
-                className="block w-full overflow-hidden"
-              >
-                <span className="block w-full overflow-hidden text-ellipsis whitespace-nowrap font-semibold leading-tight">
-                  {row.original.name}
-                </span>
-              </Link>
+              <span className="block w-full overflow-hidden text-ellipsis whitespace-nowrap font-semibold leading-tight">
+                {row.original.name}
+              </span>
+
               <span className="text-secondary-foreground block w-full overflow-hidden text-ellipsis whitespace-nowrap text-xs">
                 {row.original.description}
               </span>
@@ -382,9 +379,21 @@ export const AgentsTable: React.FC<AgentsTableProps> = ({
                     width: "100%",
                     transform: `translateY(${virtualRow.start}px)`,
                     display: "flex",
+                    cursor: "pointer",
                   }}
                   ref={(el) => rowVirtualizer.measureElement(el)}
                   data-index={virtualRow.index}
+                  onClick={(e) => {
+                    // Don't navigate if clicking on the "Vote" button
+                    const target = e.target as HTMLElement;
+                    const isInteractive = target.closest(
+                      'button, [type="button"]',
+                    );
+                    if (!isInteractive) {
+                      router.push(`/agents/${row.original.id}`);
+                    }
+                  }}
+                  className="hover:bg-muted/50 transition-colors"
                 >
                   {row.getVisibleCells().map((cell) => (
                     <TableCell

--- a/apps/comps/components/agents-table/index.tsx
+++ b/apps/comps/components/agents-table/index.tsx
@@ -164,7 +164,7 @@ export const AgentsTable: React.FC<AgentsTableProps> = ({
         header: () => "P&L",
         cell: ({ row }) => {
           const pnlColor =
-            row.original.pnlPercent >= 0 ? "text-green-400" : "text-red-400";
+            row.original.pnlPercent >= 0 ? "text-green-500" : "text-red-500";
           return (
             <div className="flex flex-col">
               <span className={`text-secondary-foreground font-semibold`}>
@@ -195,7 +195,7 @@ export const AgentsTable: React.FC<AgentsTableProps> = ({
               ? "text-green-500"
               : "text-red-500";
           return (
-            <div className="flex flex-col">
+            <div className="flex flex-col font-semibold">
               <span className={`text-xs ${percentColor}`}>
                 {row.original.change24hPercent >= 0 ? "+" : ""}
                 {row.original.change24hPercent.toFixed(2)}%

--- a/apps/comps/components/agents-table/rank-badge.tsx
+++ b/apps/comps/components/agents-table/rank-badge.tsx
@@ -14,9 +14,10 @@ export const RankBadge: React.FC<RankBadgeProps> = ({ rank }) => {
       className={cn(
         "min-w-19 flex items-center justify-center rounded py-2 font-semibold",
         {
-          "bg-yellow-800": rank === 1,
-          "bg-gray-700": rank === 2 || rank > 3,
-          "bg-[#1A0E05]": rank === 3,
+          "bg-trophy-first-bg": rank === 1,
+          "bg-trophy-second-bg": rank === 2,
+          "bg-trophy-third-bg": rank === 3,
+          "bg-gray-700": rank > 3,
         },
       )}
     >

--- a/apps/comps/components/competition-voting-banner.tsx
+++ b/apps/comps/components/competition-voting-banner.tsx
@@ -52,7 +52,7 @@ export const CompetitionVotingBanner: React.FC<
         // Full-width positioning using negative margins
         "ml-[calc(-50vw+50%)] w-screen",
         // Color variants
-        displayConfig.variant === "green" && "bg-green-600",
+        displayConfig.variant === "green" && "bg-green-500",
         displayConfig.variant === "blue" && "bg-blue-600",
         displayConfig.variant === "gray" && "bg-gray-600",
         className,

--- a/apps/comps/components/create-agent/agent-created.tsx
+++ b/apps/comps/components/create-agent/agent-created.tsx
@@ -165,7 +165,7 @@ export function AgentCreated({ agent }: AgentCreatedProps) {
               <>
                 <span>
                   Your email is already{" "}
-                  <span className="text-green-400">verified.</span>
+                  <span className="text-green-500">verified.</span>
                 </span>
                 <span>Please proceed to the next step.</span>
               </>
@@ -173,7 +173,7 @@ export function AgentCreated({ agent }: AgentCreatedProps) {
               <>
                 <span>
                   Your email is{" "}
-                  <span className="text-red-400">not verified.</span>
+                  <span className="text-red-500">not verified.</span>
                 </span>
                 <span>
                   {" "}

--- a/apps/comps/components/featured-competition.tsx
+++ b/apps/comps/components/featured-competition.tsx
@@ -29,9 +29,6 @@ export const FeaturedCompetition: React.FC<FeaturedCompetitionProps> = ({
 }) => {
   const session = useUserSession();
   const { data: topLeaders, isLoading } = useCompetitionAgents(competition.id, {
-    // TODO: we have to make sure all agents are included in the results
-    //  because rank is calculated "on-the-fly".
-    limit: 50,
     sort: "rank",
   });
 
@@ -61,7 +58,7 @@ export const FeaturedCompetition: React.FC<FeaturedCompetitionProps> = ({
           {formatCompetitionType(competition.type)}
         </Badge>
 
-        <p className="text-secondary-foreground mb-8 max-w-3xl">
+        <p className="text-secondary-foreground mb-4 max-w-3xl">
           {competition.description}
         </p>
       </div>
@@ -114,7 +111,9 @@ export const FeaturedCompetition: React.FC<FeaturedCompetitionProps> = ({
                   agents={competition.agents}
                 />
               ) : (
-                <span className="text-sm">-</span>
+                <div className="flex justify-center">
+                  <span className="text-sm">-</span>
+                </div>
               )}
             </>
           )}

--- a/apps/comps/components/featured-competition/top-leaders-list.tsx
+++ b/apps/comps/components/featured-competition/top-leaders-list.tsx
@@ -67,7 +67,7 @@ export const TopLeadersList: React.FC<TopLeadersListProps> = ({
               <span className="text-sm text-gray-400">P&L</span>
               <span
                 className={`font-semibold ${
-                  agent.pnlPercent >= 0 ? "text-green-400" : "text-red-400"
+                  agent.pnlPercent >= 0 ? "text-green-500" : "text-red-500"
                 }`}
               >
                 ({agent.pnlPercent >= 0 ? "+" : ""}

--- a/apps/comps/components/footer-section/index.tsx
+++ b/apps/comps/components/footer-section/index.tsx
@@ -18,46 +18,34 @@ interface FooterSectionProps {
 export const FooterSection: React.FC<FooterSectionProps> = ({ className }) => {
   const linkBlock1 = [
     {
-      text: "COMPETITIONS",
-      link: "https://docs.recall.network/competitions",
+      text: "DOCS",
+      link: "https://docs.recall.network/",
     },
     {
       text: "POINTS",
       link: "https://points.recall.network/",
     },
     {
-      text: "DOCS",
-      link: "https://docs.recall.network/",
-    },
-    {
-      text: "PORTAL",
-      link: "/",
-    },
-    {
-      text: "LITEPAPER",
-      link: "https://docs.recall.network/",
-    },
-  ];
-  const linkBlock2 = [
-    {
-      text: "CAREERS",
-      link: "https://job-boards.greenhouse.io/recall",
-    },
-    {
       text: "BLOG",
       link: "https://paragraph.com/@recall",
     },
     {
-      text: "MEDIA KIT",
-      link: "https://flat-agustinia-3f3.notion.site/Recall-Launch-Media-Kit-196dfc9427de80de9d96e1dd85a8b036",
+      text: "CAREERS",
+      link: "https://job-boards.greenhouse.io/recall",
     },
+  ];
+  const linkBlock2 = [
     {
       text: "PRIVACY POLICY",
       link: "https://recall.network/privacy",
     },
     {
-      text: "COOKIES",
-      link: "https://recall.network/privacy",
+      text: "TERMS OF SERVICE",
+      link: "https://recall.network/terms",
+    },
+    {
+      text: "MEDIA KIT",
+      link: "https://flat-agustinia-3f3.notion.site/Recall-Launch-Media-Kit-196dfc9427de80de9d96e1dd85a8b036",
     },
   ];
   const socialLinks = [
@@ -67,12 +55,11 @@ export const FooterSection: React.FC<FooterSectionProps> = ({ className }) => {
       icon: FaYoutube,
       url: "https://www.youtube.com/channel/UCpFqp6DtxvXaP7LUjxT3KpA",
     },
-    //{icon: FaReddit, url: "/"},
   ];
 
   return (
     <footer className={cn("mt-10", className)}>
-      <div className="xs:grid-cols-5 grid grid-cols-3 content-center gap-8 border-y py-10">
+      <div className="xs:grid-cols-5 grid grid-cols-3 content-center gap-8 border-y py-10 font-bold">
         <Image
           src="/logo_white.svg"
           alt="recallnet"
@@ -80,7 +67,7 @@ export const FooterSection: React.FC<FooterSectionProps> = ({ className }) => {
           width={63}
           className="h-[72px] w-[63px]"
         />
-        <div className="flex flex-col justify-center">
+        <div className="flex flex-col">
           {linkBlock1.map(({ text, link }, i) => (
             <a
               key={i}
@@ -94,7 +81,7 @@ export const FooterSection: React.FC<FooterSectionProps> = ({ className }) => {
             </a>
           ))}
         </div>
-        <div className="flex flex-col justify-center">
+        <div className="flex flex-col">
           {linkBlock2.map(({ text, link }, i) => (
             <a
               key={i}
@@ -125,7 +112,7 @@ export const FooterSection: React.FC<FooterSectionProps> = ({ className }) => {
         </div>
       </div>
       <span className="text-secondary-foreground block py-4 text-center text-xs">
-        Copyright 2025 / Textile / All rights reserved.
+        Copyright 2025 / Recall Labs / All rights reserved.
       </span>
     </footer>
   );

--- a/apps/comps/components/identicon/index.tsx
+++ b/apps/comps/components/identicon/index.tsx
@@ -29,7 +29,11 @@ export function Identicon({
   return (
     <div
       dangerouslySetInnerHTML={{ __html: svg }}
-      className={cn("h-10 w-10 rounded-full bg-gray-700", className)}
+      className={cn("rounded-full bg-gray-700", className)}
+      style={{
+        width: size,
+        height: size,
+      }}
       title={title}
     />
   );

--- a/apps/comps/components/leaderboard-table/index.tsx
+++ b/apps/comps/components/leaderboard-table/index.tsx
@@ -46,11 +46,11 @@ export function LeaderboardTable({
 
   return (
     <div className="w-full overflow-x-auto">
-      <div className="min-w-[900px]">
+      <div className="min-[940px]:min-w-[900px]">
         <div className="flex flex-col items-end">
           <Table className="w-full">
             <TableHeader className="bg-card">
-              <TableRow className="grid w-full grid-cols-[1fr_1fr_3fr_1fr_1fr]">
+              <TableRow className="grid w-full grid-cols-[1fr_1fr_2fr] min-[940px]:grid-cols-[1fr_1fr_3fr_1fr_1fr]">
                 <SortableTableHeader
                   className="pl-6 text-white"
                   onToggleSort={() => handleSortChange("rank")}
@@ -72,14 +72,14 @@ export function LeaderboardTable({
                   Agent
                 </SortableTableHeader>
                 <SortableTableHeader
-                  className="flex justify-end text-white"
+                  className="hidden justify-end text-white min-[940px]:flex"
                   onToggleSort={() => handleSortChange("competitions")}
                   sortState={sortState["competitions"]}
                 >
                   Competitions
                 </SortableTableHeader>
                 <SortableTableHeader
-                  className="flex justify-end pr-6 text-white"
+                  className="hidden justify-end pr-6 text-white min-[940px]:flex"
                   onToggleSort={() => handleSortChange("votes")}
                   sortState={sortState["votes"]}
                 >
@@ -96,7 +96,7 @@ export function LeaderboardTable({
                 return (
                   <TableRow
                     key={agent.id}
-                    className="grid cursor-pointer grid-cols-[1fr_1fr_3fr_1fr_1fr]"
+                    className="grid cursor-pointer grid-cols-[1fr_1fr_2fr] min-[940px]:grid-cols-[1fr_1fr_3fr_1fr_1fr]"
                     onClick={(e) => {
                       // Don't navigate if clicking on some arbitrary inline button
                       const target = e.target as HTMLElement;
@@ -175,11 +175,11 @@ export function LeaderboardTable({
                       </div>
                     </TableCell>
 
-                    <TableCell className="text-secondary-foreground flex items-center justify-end">
+                    <TableCell className="text-secondary-foreground hidden items-center justify-end min-[940px]:flex">
                       {agent.numCompetitions}
                     </TableCell>
 
-                    <TableCell className="text-secondary-foreground flex items-center justify-end pr-6">
+                    <TableCell className="text-secondary-foreground hidden items-center justify-end pr-6 min-[940px]:flex">
                       {agent.voteCount || 0}
                     </TableCell>
                   </TableRow>

--- a/apps/comps/components/leaderboard-table/index.tsx
+++ b/apps/comps/components/leaderboard-table/index.tsx
@@ -1,6 +1,6 @@
-import { AwardIcon, ExternalLink, Trophy } from "lucide-react";
+import { AwardIcon, Trophy } from "lucide-react";
 import Image from "next/image";
-import Link from "next/link";
+import { useRouter } from "next/navigation";
 
 import {
   SortState,
@@ -8,7 +8,6 @@ import {
   Table,
   TableBody,
   TableCell,
-  TableHead,
   TableHeader,
   TableRow,
 } from "@recallnet/ui2/components/table";
@@ -38,6 +37,8 @@ export function LeaderboardTable({
   pagination?: PaginationResponse;
   onPageChange: (page: number) => void;
 }) {
+  const router = useRouter();
+
   const page =
     pagination.limit > 0
       ? Math.floor(pagination.offset / pagination.limit) + 1
@@ -49,9 +50,9 @@ export function LeaderboardTable({
         <div className="flex flex-col items-end">
           <Table className="w-full">
             <TableHeader className="bg-card">
-              <TableRow className="grid w-full grid-cols-[1fr_1fr_2fr_150px_1fr_1fr]">
+              <TableRow className="grid w-full grid-cols-[1fr_1fr_3fr_1fr_1fr]">
                 <SortableTableHeader
-                  className="mr-15 pl-[24px] text-white"
+                  className="pl-6 text-white"
                   onToggleSort={() => handleSortChange("rank")}
                   sortState={sortState["rank"]}
                 >
@@ -64,29 +65,26 @@ export function LeaderboardTable({
                   Score
                 </SortableTableHeader>
                 <SortableTableHeader
-                  className="pl-10 text-white"
+                  className="text-white"
                   onToggleSort={() => handleSortChange("name")}
                   sortState={sortState["name"]}
                 >
                   Agent
                 </SortableTableHeader>
                 <SortableTableHeader
-                  className="flex w-full justify-end truncate text-white"
+                  className="flex justify-end text-white"
                   onToggleSort={() => handleSortChange("competitions")}
                   sortState={sortState["competitions"]}
                 >
                   Competitions
                 </SortableTableHeader>
                 <SortableTableHeader
-                  className="flex justify-end text-white"
+                  className="flex justify-end pr-6 text-white"
                   onToggleSort={() => handleSortChange("votes")}
                   sortState={sortState["votes"]}
                 >
                   Votes
                 </SortableTableHeader>
-                <TableHead className="flex justify-end pr-[24px] text-white">
-                  Profile
-                </TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
@@ -98,13 +96,23 @@ export function LeaderboardTable({
                 return (
                   <TableRow
                     key={agent.id}
-                    className="grid grid-cols-[1fr_1fr_2fr_150px_1fr_1fr]"
+                    className="grid cursor-pointer grid-cols-[1fr_1fr_3fr_1fr_1fr]"
+                    onClick={(e) => {
+                      // Don't navigate if clicking on some arbitrary inline button
+                      const target = e.target as HTMLElement;
+                      const isInteractive = target.closest(
+                        'button, [type="button"]',
+                      );
+                      if (!isInteractive) {
+                        router.push(`/agents/${agent.id}`);
+                      }
+                    }}
                   >
-                    <TableCell className="xs:flex-row mr-10 flex flex-col items-center gap-2 pl-[24px]">
+                    <TableCell className="xs:flex-row flex flex-col items-center gap-2 pl-6">
                       {agent.rank === 1 ? (
                         <div
                           className={cn(
-                            "flex w-20 items-center justify-center gap-1 rounded bg-[#594100] p-2 text-yellow-500",
+                            "bg-trophy-first-bg text-trophy-first flex w-20 items-center justify-center gap-1 rounded p-2",
                           )}
                         >
                           <Trophy size={17} />
@@ -113,7 +121,7 @@ export function LeaderboardTable({
                       ) : agent.rank === 2 ? (
                         <div
                           className={cn(
-                            "flex w-20 items-center justify-center gap-1 rounded bg-gray-700 p-2 text-gray-300",
+                            "bg-trophy-second-bg text-trophy-second flex w-20 items-center justify-center gap-1 rounded p-2",
                           )}
                         >
                           <AwardIcon size={17} />
@@ -122,20 +130,20 @@ export function LeaderboardTable({
                       ) : agent.rank === 3 ? (
                         <div
                           className={cn(
-                            "flex w-20 items-center justify-center gap-1 rounded bg-[#1A0E05] p-2 text-[#C76E29]",
+                            "bg-trophy-third-bg text-trophy-third flex w-20 items-center justify-center gap-1 rounded p-2",
                           )}
                         >
                           <AwardIcon size={17} />
                           <span>3rd</span>
                         </div>
                       ) : (
-                        <div className="flex w-20 items-center justify-center rounded bg-gray-800 p-2">
+                        <div className="flex w-20 items-center justify-center rounded bg-gray-700 p-2">
                           {agent.rank}
                         </div>
                       )}
                     </TableCell>
 
-                    <TableCell className="flex items-center justify-start pr-10 text-gray-500">
+                    <TableCell className="flex items-center justify-start text-gray-500">
                       <BigNumberDisplay
                         decimals={scoreSize}
                         value={agent.score.toString()}
@@ -144,8 +152,8 @@ export function LeaderboardTable({
                       />
                     </TableCell>
 
-                    <TableCell className="flex items-center justify-center pl-10">
-                      <div className="flex items-center gap-2">
+                    <TableCell className="flex items-center justify-start overflow-hidden">
+                      <div className="flex w-full items-center gap-2">
                         <div className="relative h-[35px] w-[35px] overflow-hidden rounded-full border">
                           <Image
                             src={agent.imageUrl || "/agent-placeholder.png"}
@@ -154,7 +162,7 @@ export function LeaderboardTable({
                             className="object-cover"
                           />
                         </div>
-                        <div className="md:w-70 w-40 text-left text-sm">
+                        <div className="min-w-0 flex-1 text-left text-sm">
                           <div className="text-secondary-foreground mb-2 truncate font-medium leading-none">
                             {agent.name}
                           </div>
@@ -171,14 +179,8 @@ export function LeaderboardTable({
                       {agent.numCompetitions}
                     </TableCell>
 
-                    <TableCell className="text-secondary-foreground flex items-center justify-end">
+                    <TableCell className="text-secondary-foreground flex items-center justify-end pr-6">
                       {agent.voteCount || 0}
-                    </TableCell>
-
-                    <TableCell className="text-secondary-foreground flex items-center justify-end pr-[32px]">
-                      <Link href={`/agents/${agent.id}`}>
-                        <ExternalLink />
-                      </Link>
                     </TableCell>
                   </TableRow>
                 );

--- a/apps/comps/components/navbar/index.tsx
+++ b/apps/comps/components/navbar/index.tsx
@@ -12,8 +12,6 @@ import { cn } from "@recallnet/ui2/lib/utils";
 
 import { SIWEButton } from "@/components/siwe";
 
-const ACTIVE_BORDER_STYLE = "border-b-2 border-b-yellow-500";
-
 export const Navbar: React.FunctionComponent = () => {
   const pathname = usePathname();
   const navItems = [
@@ -47,8 +45,8 @@ export const Navbar: React.FunctionComponent = () => {
                   href={item.href}
                   key={item.href}
                   className={cn(
-                    "px-15 flex h-14 items-center justify-center border-r",
-                    isActive ? ACTIVE_BORDER_STYLE : "",
+                    "px-15 flex h-14 items-center justify-center border-b-2 border-r",
+                    isActive ? "border-b-yellow-500" : "border-b-transparent",
                   )}
                 >
                   <span
@@ -95,9 +93,12 @@ export const Navbar: React.FunctionComponent = () => {
         </div>
 
         <div
-          className={cn("flex h-full items-center", {
-            [ACTIVE_BORDER_STYLE]: pathname === "/profile",
-          })}
+          className={cn(
+            "flex h-full items-center border-b-2",
+            pathname === "/profile"
+              ? "border-b-yellow-500"
+              : "border-b-transparent",
+          )}
         >
           <SIWEButton />
         </div>

--- a/apps/comps/components/participants-avatars.tsx
+++ b/apps/comps/components/participants-avatars.tsx
@@ -12,6 +12,7 @@ interface ParticipantsAvatarsProps {
   maxDisplay?: number;
   className?: string;
   showRank?: boolean;
+  showBorder?: boolean;
 }
 
 export function ParticipantsAvatars({
@@ -20,6 +21,7 @@ export function ParticipantsAvatars({
   className,
   compId,
   showRank = false,
+  showBorder = true,
 }: ParticipantsAvatarsProps) {
   const displayAgents = agents.slice(0, maxDisplay);
   const remainingCount = Math.max(0, agents.length - maxDisplay);
@@ -39,6 +41,7 @@ export function ParticipantsAvatars({
             key={agent.id}
             agent={agent}
             showRank={showRank}
+            showBorder={showBorder}
             rank={showRank ? getRank(agent, index) : undefined}
             size={32}
           />

--- a/apps/comps/components/register-agent-block.tsx
+++ b/apps/comps/components/register-agent-block.tsx
@@ -2,7 +2,8 @@
 
 import { zodResolver } from "@hookform/resolvers/zod";
 import Image from "next/image";
-import React from "react";
+import { usePathname } from "next/navigation";
+import React, { useState } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 
@@ -17,6 +18,11 @@ import {
 } from "@recallnet/ui2/components/form";
 import { Input } from "@recallnet/ui2/components/input";
 
+import { useUserSession } from "@/hooks/useAuth";
+
+import { ConnectWalletModal } from "./modals/connect-wallet";
+import { SetupAgentModal } from "./modals/setup-agent";
+
 const formSchema = z.object({
   email: z.string().email(),
 });
@@ -24,12 +30,32 @@ const formSchema = z.object({
 type FormData = z.infer<typeof formSchema>;
 
 export const RegisterAgentBlock: React.FC = () => {
+  const pathname = usePathname();
+  const session = useUserSession();
+  const [activeModal, setActiveModal] = useState<
+    "connectWallet" | "setupAgent" | null
+  >(null);
+
   const form = useForm<FormData>({
     resolver: zodResolver(formSchema),
     defaultValues: {
       email: "",
     },
   });
+
+  const handleAddAgent = () => {
+    if (!session.isInitialized) {
+      return;
+    }
+
+    if (!session.isAuthenticated) {
+      setActiveModal("connectWallet");
+      return;
+    }
+
+    // If user is authenticated, show the setup agent modal
+    setActiveModal("setupAgent");
+  };
 
   const onSubmit = () => {};
 
@@ -52,9 +78,12 @@ export const RegisterAgentBlock: React.FC = () => {
           <h2 className="text-3xl font-semibold text-white">Add your agent</h2>
           <div className="flex flex-col justify-between">
             <span className="w-1/2 text-gray-400">
-              Register your own agent, win rewards
+              Register your agent, win rewards
             </span>
-            <Button className="mt-5 w-1/3 bg-white px-8 py-6 text-black hover:bg-gray-200">
+            <Button
+              onClick={handleAddAgent}
+              className="mt-5 w-1/3 bg-white px-8 py-6 text-black hover:bg-gray-200"
+            >
               ADD AGENT
             </Button>
           </div>
@@ -67,7 +96,7 @@ export const RegisterAgentBlock: React.FC = () => {
           <Card
             corner="bottom-left"
             cropSize={50}
-            className="pb-15 relative flex h-80 h-[298px] w-[498px] w-full flex-col justify-between bg-gray-900 px-10 pt-10"
+            className="pb-15 relative flex h-80 w-full flex-col justify-between bg-gray-900 px-10 pt-10"
           >
             <h2 className="text-3xl font-semibold text-white">
               Never miss a competition
@@ -108,6 +137,17 @@ export const RegisterAgentBlock: React.FC = () => {
           </Card>
         </Card>
       </div>
+
+      {/* Modals */}
+      <ConnectWalletModal
+        isOpen={activeModal === "connectWallet"}
+        onClose={() => setActiveModal(null)}
+      />
+      <SetupAgentModal
+        isOpen={activeModal === "setupAgent"}
+        onClose={() => setActiveModal(null)}
+        redirectTo={pathname}
+      />
     </div>
   );
 };

--- a/apps/comps/components/rewards.tsx
+++ b/apps/comps/components/rewards.tsx
@@ -70,7 +70,7 @@ export const Rewards: React.FC<RewardsProps> = ({
             {total.toLocaleString(undefined, {
               minimumFractionDigits: 0,
               maximumFractionDigits: 2,
-            })}
+            })}{" "}
             in rewards!
           </>
         ) : (

--- a/apps/comps/components/siwe/index.tsx
+++ b/apps/comps/components/siwe/index.tsx
@@ -181,7 +181,7 @@ export const SIWEButton: React.FunctionComponent = () => {
 
             {/* Error message - only show when connected and there's an error */}
             {(isConnected || ckIsConnected) && address && authError && (
-              <p className="text-center text-sm text-red-400">{authError}</p>
+              <p className="text-center text-sm text-red-500">{authError}</p>
             )}
           </div>
         );

--- a/apps/comps/components/trophy-badge/index.tsx
+++ b/apps/comps/components/trophy-badge/index.tsx
@@ -23,9 +23,9 @@ interface TrophyBadgeProps {
 }
 
 const rankColors: Record<number, string> = {
-  1: "bg-[#FBD362]",
-  2: "bg-[#93A5BA]",
-  3: "bg-[#C76E29]",
+  1: "bg-trophy-first",
+  2: "bg-trophy-second",
+  3: "bg-trophy-third",
 };
 
 export const TrophyBadge: React.FC<TrophyBadgeProps> = ({ trophy, size }) => {

--- a/apps/comps/components/user-vote.tsx
+++ b/apps/comps/components/user-vote.tsx
@@ -88,7 +88,7 @@ export const UserVote: React.FC<UserVoteProps> = ({
                   </span>
                   <span
                     className={`text-xs ${
-                      agent.pnlPercent >= 0 ? "text-green-400" : "text-red-400"
+                      agent.pnlPercent >= 0 ? "text-green-500" : "text-red-500"
                     }`}
                   >
                     ({agent.pnlPercent >= 0 ? "+" : ""}

--- a/packages/ui2/src/components/button.tsx
+++ b/packages/ui2/src/components/button.tsx
@@ -3,24 +3,24 @@ import { type VariantProps, cva } from "class-variance-authority";
 
 import { cn } from "@recallnet/ui2/lib/utils";
 
-// This is just an example of a component that uses the cva utility and Tailwind CSS classes.
-
 const buttonVariants = cva(
-  "inline-flex items-center justify-center text-sm font-medium transition-all duration-300 ease-in-out focus-visible:outline-none focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-50",
+  "inline-flex items-center justify-center text-sm font-medium transition-all duration-300 ease-in-out focus-visible:outline-none focus-visible:ring-2 disabled:cursor-not-allowed disabled:opacity-50",
   {
     variants: {
       variant: {
         default:
-          "bg-blue-600 font-semibold uppercase text-white hover:bg-[#003D7A]",
+          "bg-blue-600 font-semibold uppercase text-white hover:bg-[#003D7A] disabled:hover:bg-blue-600",
         destructive:
-          "bg-destructive text-destructive-foreground hover:bg-destructive/90",
+          "bg-destructive text-destructive-foreground hover:bg-destructive/90 disabled:hover:bg-destructive",
         outline:
-          "bg-background text-secondary-foreground border border-gray-400 hover:bg-blue-700 hover:text-white",
+          "bg-background text-secondary-foreground disabled:hover:bg-background disabled:hover:text-secondary-foreground border border-gray-400 hover:bg-blue-700 hover:text-white",
         secondary:
-          "bg-secondary hover:bg-secondary/90 font-semibold uppercase text-[#e9edf1]",
-        ghost: "bg-white text-black hover:bg-blue-700 hover:text-white",
-        link: "text-primary underline-offset-4 hover:underline",
-        modal: "border bg-white text-black hover:bg-gray-300",
+          "bg-secondary hover:bg-secondary/90 disabled:hover:bg-secondary font-semibold uppercase text-[#e9edf1]",
+        ghost:
+          "bg-white text-black hover:bg-blue-700 hover:text-white disabled:hover:bg-white disabled:hover:text-black",
+        link: "text-primary underline-offset-4 hover:underline disabled:hover:no-underline",
+        modal:
+          "border bg-white text-black hover:bg-gray-300 disabled:hover:bg-white",
       },
       size: {
         default: "h-10 px-4 py-2 text-sm",

--- a/packages/ui2/src/styles/globals.css
+++ b/packages/ui2/src/styles/globals.css
@@ -29,9 +29,9 @@
   --trophy-first: oklch(0.8799 0.1379 89.79);
   --trophy-second: oklch(0.7149 0.0368 252.35);
   --trophy-third: oklch(0.628 0.1378 54);
-  --trophy-first-bg: oklch(39.106% 0.08014 84.742);
-  --trophy-second-bg: oklch(24.283% 0.02314 277.171);
-  --trophy-third-bg: oklch(17.779% 0.02751 59.528);
+  --trophy-first-bg: oklch(0.3911 0.080176 84.7396);
+  --trophy-second-bg: oklch(0.2428 0.0231 277.17);
+  --trophy-third-bg: oklch(0.1778 0.0275 59.55);
 }
 
 @theme inline {

--- a/packages/ui2/src/styles/globals.css
+++ b/packages/ui2/src/styles/globals.css
@@ -26,6 +26,11 @@
   --input: oklch(1 0 0 / 15%);
   --ring: oklch(0.556 0 0);
 
+  /* Custom colors */
+  --color-green-500: oklch(0.6337 0.182 142.13);
+  --color-red-500: oklch(0.6032 0.214 28.67);
+
+  /* Trophy and rank colors */
   --trophy-first: oklch(0.8799 0.1379 89.79);
   --trophy-second: oklch(0.7149 0.0368 252.35);
   --trophy-third: oklch(0.628 0.1378 54);

--- a/packages/ui2/src/styles/globals.css
+++ b/packages/ui2/src/styles/globals.css
@@ -29,6 +29,7 @@
   /* Custom colors */
   --color-green-500: oklch(0.6337 0.182 142.13);
   --color-red-500: oklch(0.6032 0.214 28.67);
+  --color-yellow-500: oklch(0.8188 0.1686 82.31);
 
   /* Trophy and rank colors */
   --trophy-first: oklch(0.8799 0.1379 89.79);

--- a/packages/ui2/src/styles/globals.css
+++ b/packages/ui2/src/styles/globals.css
@@ -29,6 +29,9 @@
   --trophy-first: oklch(0.8799 0.1379 89.79);
   --trophy-second: oklch(0.7149 0.0368 252.35);
   --trophy-third: oklch(0.628 0.1378 54);
+  --trophy-first-bg: oklch(39.106% 0.08014 84.742);
+  --trophy-second-bg: oklch(24.283% 0.02314 277.171);
+  --trophy-third-bg: oklch(17.779% 0.02751 59.528);
 }
 
 @theme inline {
@@ -53,6 +56,9 @@
   --color-trophy-first: var(--trophy-first);
   --color-trophy-second: var(--trophy-second);
   --color-trophy-third: var(--trophy-third);
+  --color-trophy-first-bg: var(--trophy-first-bg);
+  --color-trophy-second-bg: var(--trophy-second-bg);
+  --color-trophy-third-bg: var(--trophy-third-bg);
 
   --breakpoint-*: initial;
   --breakpoint-xs: 42rem;


### PR DESCRIPTION
- Fixed the comp rewards card not having a space between a word.
- Fixed colors to make sure trophies/ranks are consistent, and green / red / yellow use the figma colors.
- Made all of the agent rows in the global leaderboard and per-comp results clickable, vs a dedicated column for the agent profile.
- Global leaderboard tweaks to account for better spacing and responsiveness (i.e., hide the final 2 cols on smaller viewports).
- Fixed "jumpy" nav that shifted text upward upon clicking.
- Footer section updates.
- Fixed "add agent" button to prompt for wallet connection or agent creation, depending on user state.
- Fixed buttons being unable to have the "disable" cursor upon hover.