### PR TITLE
feat(comps): chart cleanups

### DIFF
--- a/apps/comps/app/competitions/[id]/chart/page.tsx
+++ b/apps/comps/app/competitions/[id]/chart/page.tsx
@@ -9,6 +9,7 @@ import { Button } from "@recallnet/ui2/components/button";
 import { Skeleton } from "@recallnet/ui2/components/skeleton";
 
 import { ChartSkeleton, TimelineChart } from "@/components/timeline-chart";
+import { LIMIT_AGENTS_PER_PAGE } from "@/components/timeline-chart/constants";
 import { useCompetition } from "@/hooks/useCompetition";
 import { useCompetitionAgents } from "@/hooks/useCompetitionAgents";
 
@@ -87,7 +88,7 @@ export default function CompetitionChartPage({
         <TimelineChart
           competition={competition}
           agents={agentsData?.agents || []}
-          totalAgents={agentsData?.pagination?.total || 0}
+          totalAgents={LIMIT_AGENTS_PER_PAGE} // Only show the top 10 agents (no pagination)
           currentPage={1}
           onPageChange={handlePageChange}
           className="shadow-2xl"

--- a/apps/comps/components/agent-avatar.tsx
+++ b/apps/comps/components/agent-avatar.tsx
@@ -12,6 +12,7 @@ interface AgentAvatarProps {
   showBorder?: boolean;
   rank?: number;
   className?: string;
+  style?: React.CSSProperties;
   size?: number;
 }
 
@@ -21,11 +22,12 @@ export function AgentAvatar({
   showBorder = true,
   rank,
   className,
+  style,
   size = 32,
 }: AgentAvatarProps) {
   const commonClasses = cn(
     "group relative h-8 w-8 transition-transform duration-200 hover:z-10 hover:scale-110",
-    (showRank || showBorder) && "border-1 h-9 w-9 rounded-full bg-gray-700",
+    (showRank || showBorder) && "h-9 w-9 rounded-full border-2 bg-gray-700",
     showRank &&
       rank && {
         "border-trophy-first": rank === 1,
@@ -45,6 +47,7 @@ export function AgentAvatar({
           height: size,
           minWidth: size,
           minHeight: size,
+          ...style,
         }}
       >
         <Image
@@ -74,6 +77,7 @@ export function AgentAvatar({
           height: size,
           minWidth: size,
           minHeight: size,
+          ...style,
         }}
       >
         <Identicon

--- a/apps/comps/components/agent-avatar.tsx
+++ b/apps/comps/components/agent-avatar.tsx
@@ -8,8 +8,10 @@ import { UserAgentCompetition } from "@/types/competition";
 
 interface AgentAvatarProps {
   agent: Agent | UserAgentCompetition | AgentCompetition;
+  imageUrl?: string;
   showRank?: boolean;
   showBorder?: boolean;
+  showHover?: boolean;
   rank?: number;
   className?: string;
   style?: React.CSSProperties;
@@ -18,15 +20,18 @@ interface AgentAvatarProps {
 
 export function AgentAvatar({
   agent,
+  imageUrl,
   showRank = false,
   showBorder = true,
+  showHover = true,
   rank,
   className,
   style,
   size = 32,
 }: AgentAvatarProps) {
   const commonClasses = cn(
-    "group relative h-8 w-8 transition-transform duration-200 hover:z-10 hover:scale-110",
+    "group relative h-8 w-8 transition-transform duration-200",
+    showHover && "hover:z-10 hover:scale-110",
     (showRank || showBorder) && "h-9 w-9 rounded-full border-2 bg-gray-700",
     showRank &&
       rank && {
@@ -38,7 +43,7 @@ export function AgentAvatar({
     className,
   );
 
-  if (agent.imageUrl) {
+  if (imageUrl || agent.imageUrl) {
     return (
       <div
         className={cn("relative", commonClasses)}
@@ -51,7 +56,7 @@ export function AgentAvatar({
         }}
       >
         <Image
-          src={agent.imageUrl || "/default_agent.png"}
+          src={imageUrl || agent.imageUrl || "/default_agent.png"}
           alt={agent.name}
           fill
           sizes={`${size}px`}

--- a/apps/comps/components/leaderboard-table/index.tsx
+++ b/apps/comps/components/leaderboard-table/index.tsx
@@ -1,5 +1,4 @@
 import { AwardIcon, Trophy } from "lucide-react";
-import Image from "next/image";
 import { useRouter } from "next/navigation";
 
 import {
@@ -17,6 +16,7 @@ import { Pagination } from "@/components/pagination/index";
 import { LeaderboardAgent } from "@/types/agent";
 import { PaginationResponse } from "@/types/api";
 
+import { AgentAvatar } from "../agent-avatar";
 import BigNumberDisplay from "../bignumber/index";
 
 export function LeaderboardTable({
@@ -154,14 +154,13 @@ export function LeaderboardTable({
 
                     <TableCell className="flex items-center justify-start overflow-hidden">
                       <div className="flex w-full items-center gap-2">
-                        <div className="relative h-[35px] w-[35px] overflow-hidden rounded-full border">
-                          <Image
-                            src={agent.imageUrl || "/agent-placeholder.png"}
-                            alt="avatar"
-                            fill
-                            className="object-cover"
-                          />
-                        </div>
+                        <AgentAvatar
+                          agent={agent}
+                          imageUrl={agent.imageUrl || "/agent-placeholder.png"}
+                          size={35}
+                          showHover={false}
+                        />
+
                         <div className="min-w-0 flex-1 text-left text-sm">
                           <div className="text-secondary-foreground mb-2 truncate font-medium leading-none">
                             {agent.name}

--- a/apps/comps/components/timeline-chart/constants.ts
+++ b/apps/comps/components/timeline-chart/constants.ts
@@ -4,15 +4,15 @@ import { createContext } from "react";
  * Constants for TimelineChart components
  */
 
-export const colors = [
-  "#FF6B35", // Orange
-  "#4ECDC4", // Teal
-  "#45B7D1", // Blue
-  "#96CEB4", // Light Green
-  "#FFEAA7", // Yellow
-  "#DDA0DD", // Plum
-  "#98D8C8", // Mint
-  "#F7DC6F", // Light Yellow
+export const CHART_COLORS = [
+  "#cc66ff", // Purple
+  "#14f195", // Green
+  "#ff4d4d", // Red
+  "#ffcc00", // Yellow
+  "#b3ff66", // Light Green
+  "#6366f1", // Indigo
+  "#ff9933", // Orange
+  "#00ffff", // Cyan
 ];
 
 export const LIMIT_AGENTS_PER_PAGE = 10;

--- a/apps/comps/components/timeline-chart/custom-legend.tsx
+++ b/apps/comps/components/timeline-chart/custom-legend.tsx
@@ -1,11 +1,11 @@
 "use client";
 
 import { Search } from "lucide-react";
-import Image from "next/image";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 
 import { Input } from "@recallnet/ui2/components/input";
 
+import { AgentAvatar } from "../agent-avatar";
 import { Pagination } from "../pagination";
 import { CHART_COLORS, LIMIT_AGENTS_PER_PAGE } from "./constants";
 import { CustomLegendProps } from "./types";
@@ -132,25 +132,23 @@ export const CustomLegend = ({
 
       <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
         {displayAgents.map((agent) => {
+          console.log(colorMap[agent.name], agent.name);
           return (
             <div
               key={agent.name}
-              className="flex min-w-0 cursor-default items-center gap-2 rounded-lg p-2 transition-all duration-200 hover:scale-105"
+              className="flex min-w-0 cursor-default items-center gap-2 rounded-lg p-2 transition-all duration-200 hover:scale-110"
               onMouseEnter={() => onAgentHover?.(agent.name)}
               onMouseLeave={() => onAgentHover?.(null)}
             >
-              <div
-                className="h-8 w-8 flex-shrink-0 overflow-hidden rounded-full border-2"
-                style={{ borderColor: colorMap[agent.name] || CHART_COLORS[0] }}
-              >
-                <Image
-                  src={agent.imageUrl || `/default_agent_2.png`}
-                  alt={agent.name}
-                  width={15}
-                  height={15}
-                  className="h-full w-full"
-                />
-              </div>
+              <AgentAvatar
+                agent={agent}
+                size={32}
+                className="hover:scale-100 hover:transform-none"
+                style={{
+                  borderColor: colorMap[agent.name] || CHART_COLORS[0],
+                }}
+              />
+
               <span
                 className="min-w-0 flex-1 truncate text-sm font-medium"
                 style={{ color: colorMap[agent.name] || CHART_COLORS[0] }}

--- a/apps/comps/components/timeline-chart/custom-legend.tsx
+++ b/apps/comps/components/timeline-chart/custom-legend.tsx
@@ -7,7 +7,7 @@ import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { Input } from "@recallnet/ui2/components/input";
 
 import { Pagination } from "../pagination";
-import { LIMIT_AGENTS_PER_PAGE, colors } from "./constants";
+import { CHART_COLORS, LIMIT_AGENTS_PER_PAGE } from "./constants";
 import { CustomLegendProps } from "./types";
 
 /**
@@ -141,7 +141,7 @@ export const CustomLegend = ({
             >
               <div
                 className="h-8 w-8 flex-shrink-0 overflow-hidden rounded-full border-2"
-                style={{ borderColor: colorMap[agent.name] || colors[0] }}
+                style={{ borderColor: colorMap[agent.name] || CHART_COLORS[0] }}
               >
                 <Image
                   src={agent.imageUrl || `/default_agent_2.png`}
@@ -153,7 +153,7 @@ export const CustomLegend = ({
               </div>
               <span
                 className="min-w-0 flex-1 truncate text-sm font-medium"
-                style={{ color: colorMap[agent.name] || colors[0] }}
+                style={{ color: colorMap[agent.name] || CHART_COLORS[0] }}
               >
                 {agent.name}
               </span>

--- a/apps/comps/components/timeline-chart/index.tsx
+++ b/apps/comps/components/timeline-chart/index.tsx
@@ -11,6 +11,7 @@
  * - custom-legend.tsx: Legend component with search and pagination
  * - chart-wrapper.tsx: Chart rendering and line components
  * - timeline-chart.tsx: Main component logic and state management
+ * - chart-skeleton.tsx: Skeleton component for loading state
  */
 
 export { TimelineChart } from "./timeline-chart";
@@ -24,5 +25,5 @@ export type {
   ChartLinesProps,
 } from "./types";
 
-export { colors, LIMIT_AGENTS_PER_PAGE, HoverContext } from "./constants";
+export { CHART_COLORS, LIMIT_AGENTS_PER_PAGE, HoverContext } from "./constants";
 export { formatDateShort, datesByWeek } from "./utils";

--- a/apps/comps/components/timeline-chart/timeline-chart.tsx
+++ b/apps/comps/components/timeline-chart/timeline-chart.tsx
@@ -20,7 +20,7 @@ import { formatDate } from "@/utils/format";
 import { ShareModal } from "../share-modal";
 import { ChartSkeleton } from "./chart-skeleton";
 import { ChartWrapper } from "./chart-wrapper";
-import { HoverContext, LIMIT_AGENTS_PER_PAGE, colors } from "./constants";
+import { CHART_COLORS, HoverContext, LIMIT_AGENTS_PER_PAGE } from "./constants";
 import { CustomLegend } from "./custom-legend";
 import { PortfolioChartProps, TimelineViewRecord } from "./types";
 import { datesByWeek, formatDateShort } from "./utils";
@@ -440,7 +440,7 @@ export const TimelineChart: React.FC<PortfolioChartProps> = ({
   const agentColorMap = useMemo(() => {
     const map: Record<string, string> = {};
     chartVisibleAgentKeys.forEach((agentName, index) => {
-      map[agentName] = colors[index % colors.length]!;
+      map[agentName] = CHART_COLORS[index % CHART_COLORS.length]!;
     });
     return map;
   }, [chartVisibleAgentKeys]);

--- a/apps/comps/components/timeline-chart/timeline-chart.tsx
+++ b/apps/comps/components/timeline-chart/timeline-chart.tsx
@@ -14,7 +14,7 @@ import { Button } from "@recallnet/ui2/components/button";
 import { cn } from "@recallnet/ui2/lib/utils";
 
 import { useCompetitionTimeline } from "@/hooks/useCompetitionTimeline";
-import { CompetitionStatus } from "@/types";
+import { AgentCompetition, CompetitionStatus } from "@/types";
 import { formatDate } from "@/utils/format";
 
 import { ShareModal } from "../share-modal";
@@ -348,14 +348,10 @@ export const TimelineChart: React.FC<PortfolioChartProps> = ({
       agentNames.add(agentTimeline.agentName);
     });
 
-    // Map timeline agents to our format, trying to get imageUrl from agents prop when possible
-    return Array.from(agentNames).map((agentName) => {
-      const agentWithImage = agents?.find((agent) => agent.name === agentName);
-      return {
-        name: agentName,
-        imageUrl: agentWithImage?.imageUrl || `/default_agent_2.png`,
-      };
-    });
+    // Map timeline agents to our format, only including agents that exist in the agents prop
+    return Array.from(agentNames)
+      .map((agentName) => agents?.find((agent) => agent.name === agentName))
+      .filter((agent): agent is AgentCompetition => agent !== undefined);
   }, [timelineRaw, agents]);
 
   // Current page agents with data - only show agents from the current pagination page when NOT searching
@@ -363,20 +359,15 @@ export const TimelineChart: React.FC<PortfolioChartProps> = ({
     // If searching, use all timeline agents for filtering
     if (debouncedSearchQuery) {
       return allTimelineAgents.filter((agent) =>
-        allDataKeys.some((agentName) => agentName === agent.name),
+        allDataKeys.some((agentName) => agentName === agent?.name),
       );
     }
 
     // If not searching, use current page agents
     if (!agents || agents.length === 0) return [];
-    return agents
-      .filter((agent) =>
-        allDataKeys.some((agentName) => agentName === agent.name),
-      )
-      .map((agent) => ({
-        name: agent.name,
-        imageUrl: agent.imageUrl || `/default_agent_2.png`,
-      }));
+    return agents.filter((agent) =>
+      allDataKeys.some((agentName) => agentName === agent.name),
+    );
   }, [agents, allDataKeys, allTimelineAgents, debouncedSearchQuery]);
 
   // Filtered agents for the legend (based on search query)
@@ -410,7 +401,7 @@ export const TimelineChart: React.FC<PortfolioChartProps> = ({
       // When searching, show agents from current search page
       const startIndex = (currentLegendPage - 1) * LIMIT_AGENTS_PER_PAGE;
       const endIndex = startIndex + LIMIT_AGENTS_PER_PAGE;
-      return filteredAgentsForLegend.slice(startIndex, endIndex);
+      return filteredAgentsForLegend.slice(startIndex, endIndex) || [];
     }
   }, [
     allAgentsWithData,
@@ -566,9 +557,7 @@ export const TimelineChart: React.FC<PortfolioChartProps> = ({
           </div>
           <div className="border-t-1 my-2 w-full"></div>
           <CustomLegend
-            agents={
-              filteredAgentsForLegend as { name: string; imageUrl: string }[]
-            }
+            agents={filteredAgentsForLegend}
             colorMap={agentColorMap}
             currentValues={hoveredDataPoint || latestValues}
             currentOrder={hoveredOrder}

--- a/apps/comps/components/timeline-chart/types.ts
+++ b/apps/comps/components/timeline-chart/types.ts
@@ -16,7 +16,7 @@ export interface TooltipProps {
 }
 
 export interface CustomLegendProps {
-  agents: { name: string; imageUrl: string }[];
+  agents: AgentCompetition[];
   colorMap: Record<string, string>;
   currentValues?: Record<string, number>;
   currentOrder?: string[];
@@ -31,7 +31,7 @@ export interface CustomLegendProps {
 
 export interface PortfolioChartProps {
   competition: Competition;
-  agents?: AgentCompetition[]; // Current page agents from parent pagination
+  agents: AgentCompetition[]; // Current page agents from parent pagination
   className?: string;
   totalAgents?: number; // Total number of agents for pagination
   currentPage?: number; // Current page from parent


### PR DESCRIPTION
- Use `AgentAvatar` instead of re-creating the wheel
- Small fix for pagination on the shareable "/competitions/:id/chart` page