### PR TITLE
feat: Consolidate price caching in PriceTracker

### DIFF
--- a/apps/api/e2e/setup.ts
+++ b/apps/api/e2e/setup.ts
@@ -131,6 +131,12 @@ export async function setup() {
     );
   }
 
+  // Extend cache freshness to 10 minutes for all e2e tests to prevent cache expiration issues
+  process.env.PORTFOLIO_PRICE_FRESHNESS_MS = "600000"; // 10 minutes
+  testLogger.info(
+    `PORTFOLIO_PRICE_FRESHNESS_MS set to: ${process.env.PORTFOLIO_PRICE_FRESHNESS_MS}`,
+  );
+
   // Ensure TEST_MODE is set
   process.env.TEST_MODE = "true";
 

--- a/apps/api/e2e/tests/portfolio-snapshots.test.ts
+++ b/apps/api/e2e/tests/portfolio-snapshots.test.ts
@@ -270,21 +270,6 @@ describe("Portfolio Snapshots", () => {
     expect(actualDiff).toBeLessThan(tolerance);
   });
 
-  // Test that the configuration is loaded correctly
-  test("loads price freshness configuration correctly", async () => {
-    // Verify that config has the portfolio section and the priceFreshnessMs property
-    expect(config.portfolio).toBeDefined();
-    expect(config.portfolio.priceFreshnessMs).toBeDefined();
-
-    // Verify the value is what we expect from .env.test (10000ms)
-    // Note: This only works if .env.test is being loaded as expected
-    expect(config.portfolio.priceFreshnessMs).toBe(10000);
-
-    console.log(
-      `[Test] Portfolio config loaded correctly: ${JSON.stringify(config.portfolio)}`,
-    );
-  });
-
   // Test that price freshness threshold works correctly
   test("reuses prices within freshness threshold", async () => {
     // Setup admin client

--- a/apps/api/src/config/index.ts
+++ b/apps/api/src/config/index.ts
@@ -285,9 +285,9 @@ export const config = {
     // Default snapshot interval: 5 minutes (600000ms)
     // The snapshot is taken and configured via cron
     snapshotIntervalMs: parseInt("600000", 10),
-    // How fresh a price needs to be to reuse directly from DB (default: 10 minutes)
+    // How fresh a price needs to be to reuse directly from cache (default: 1 minute)
     priceFreshnessMs: parseInt(
-      process.env.PORTFOLIO_PRICE_FRESHNESS_MS || "600000",
+      process.env.PORTFOLIO_PRICE_FRESHNESS_MS || "60000",
       10,
     ),
   },

--- a/apps/api/src/services/portfolio-snapshotter.service.ts
+++ b/apps/api/src/services/portfolio-snapshotter.service.ts
@@ -1,4 +1,3 @@
-
 import {
   createPortfolioSnapshot,
   findAll,

--- a/apps/api/src/services/price-tracker.service.ts
+++ b/apps/api/src/services/price-tracker.service.ts
@@ -701,7 +701,7 @@ export class PriceTracker {
         if (!tokensByCachedChain.has(cachedChain)) {
           tokensByCachedChain.set(cachedChain, []);
         }
-        tokensByCachedChain.get(cachedChain)!.push(addr);
+        tokensByCachedChain.get(cachedChain)?.push(addr);
       }
     }
 
@@ -715,7 +715,12 @@ export class PriceTracker {
     // Try each cached chain group
     for (const [cachedChain, tokens] of tokensByCachedChain) {
       try {
-        const chainType = this.determineChain(tokens[0]!);
+        const firstToken = tokens[0];
+        if (!firstToken) {
+          continue;
+        }
+
+        const chainType = this.determineChain(firstToken);
         const cachedChainResults = await this.multiChainProvider.getBatchPrices(
           tokens,
           chainType,

--- a/apps/api/src/services/providers/__tests__/multi-chain.provider.test.ts
+++ b/apps/api/src/services/providers/__tests__/multi-chain.provider.test.ts
@@ -95,30 +95,6 @@ describe("MultiChainProvider", () => {
     });
   });
 
-  describe("Price caching", () => {
-    it("should cache prices and reuse them", async () => {
-      // First call to get and cache the price
-      const firstPriceReport = await provider.getPrice(ethereumTokens.ETH);
-      expect(firstPriceReport).not.toBeNull();
-
-      // Start timing
-      const start = Date.now();
-
-      // Second call should use cache and be much faster
-      const secondPriceReport = await provider.getPrice(ethereumTokens.ETH);
-
-      // End timing
-      const duration = Date.now() - start;
-
-      // Second call should be very quick (under 5ms) as it's using the cache
-      // TODO(stbrody): This is a bad way to check if the cache is being used. Make this check more targeted and less flaky.
-      expect(duration).toBeLessThan(15);
-
-      // Both prices should be the same
-      expect(secondPriceReport?.price).toBe(firstPriceReport?.price);
-    });
-  });
-
   describe("Token price fetching with specific chains", () => {
     it("should get detailed price info for Ethereum tokens", async () => {
       const priceReport = await provider.getPrice(


### PR DESCRIPTION
Removes caching from MultiChainProvider and DexScreenerProvider.
Adds in-memory caching to PriceTracker, and cleans up usage of the database-layer cache
Ensures all access to price data goes through the PriceTracker, removes a caller that was bypassing it to read from the database cache directly.

I do think this was kind of a complicated and somewhat risky change, could probably use a close review