### PR TITLE
chore: Don't deconstruct every field when passing the full object will suffice

### DIFF
--- a/apps/api/src/controllers/competition.controller.ts
+++ b/apps/api/src/controllers/competition.controller.ts
@@ -398,13 +398,7 @@ export function makeCompetitionController(services: ServiceRegistry) {
           rateLimits,
           availableChains,
           slippageFormula,
-          tradingConstraints: {
-            minimumPairAgeHours: tradingConstraints.minimumPairAgeHours,
-            minimum24hVolumeUsd: tradingConstraints.minimum24hVolumeUsd,
-            minimumLiquidityUsd: tradingConstraints.minimumLiquidityUsd,
-            minimumFdvUsd: tradingConstraints.minimumFdvUsd,
-            minTradesPerDay: tradingConstraints.minTradesPerDay,
-          },
+          tradingConstraints,
         };
 
         res.status(200).json({
@@ -1168,13 +1162,7 @@ export function makeCompetitionController(services: ServiceRegistry) {
           rateLimits,
           availableChains,
           slippageFormula,
-          tradingConstraints: {
-            minimumPairAgeHours: tradingConstraints.minimumPairAgeHours,
-            minimum24hVolumeUsd: tradingConstraints.minimum24hVolumeUsd,
-            minimumLiquidityUsd: tradingConstraints.minimumLiquidityUsd,
-            minimumFdvUsd: tradingConstraints.minimumFdvUsd,
-            minTradesPerDay: tradingConstraints.minTradesPerDay,
-          },
+          tradingConstraints,
         };
 
         res.status(200).json({


### PR DESCRIPTION
AI seems to really like to spell out every field in an object, which bloats the code and makes it harder to follow.  Please if possible add some checks into your workflow to keep things simple when possible