### PR TITLE
fix(api): agent service performance gains

### DIFF
--- a/apps/api/src/database/repositories/trade-repository.ts
+++ b/apps/api/src/database/repositories/trade-repository.ts
@@ -1,4 +1,4 @@
-import { and, desc, count as drizzleCount, eq } from "drizzle-orm";
+import { and, desc, count as drizzleCount, eq, sql } from "drizzle-orm";
 
 import { db } from "@/database/db.js";
 import {
@@ -213,6 +213,70 @@ async function countAgentTradesInCompetitionImpl(
 }
 
 /**
+ * Count trades for an agent across multiple competitions in bulk
+ * @param agentId Agent ID
+ * @param competitionIds Array of competition IDs
+ * @returns Map of competition ID to trade count
+ */
+async function countBulkAgentTradesInCompetitionsImpl(
+  agentId: string,
+  competitionIds: string[],
+): Promise<Map<string, number>> {
+  if (competitionIds.length === 0) {
+    return new Map();
+  }
+
+  try {
+    repositoryLogger.debug(
+      `countBulkAgentTradesInCompetitions called for agent ${agentId} in ${competitionIds.length} competitions`,
+    );
+
+    // Get trade counts for all competitions in one query
+    const results = await db
+      .select({
+        competitionId: trades.competitionId,
+        count: drizzleCount(),
+      })
+      .from(trades)
+      .where(
+        and(
+          eq(trades.agentId, agentId),
+          sql`${trades.competitionId} IN (${sql.join(
+            competitionIds.map((id) => sql`${id}`),
+            sql`, `,
+          )})`,
+        ),
+      )
+      .groupBy(trades.competitionId);
+
+    // Create map with results
+    const countMap = new Map<string, number>();
+
+    // Initialize all competitions with 0
+    for (const competitionId of competitionIds) {
+      countMap.set(competitionId, 0);
+    }
+
+    // Update with actual counts
+    for (const result of results) {
+      countMap.set(result.competitionId, result.count);
+    }
+
+    repositoryLogger.debug(
+      `Found trades in ${results.length}/${competitionIds.length} competitions`,
+    );
+
+    return countMap;
+  } catch (error) {
+    repositoryLogger.error(
+      "Error in countBulkAgentTradesInCompetitions:",
+      error,
+    );
+    throw error;
+  }
+}
+
+/**
  * Get trades for an agent in a competition
  * @param competitionId Competition ID
  * @param agentId Agent ID
@@ -323,6 +387,12 @@ export const countAgentTradesInCompetition = createTimedRepositoryFunction(
   countAgentTradesInCompetitionImpl,
   "TradeRepository",
   "countAgentTradesInCompetition",
+);
+
+export const countBulkAgentTradesInCompetitions = createTimedRepositoryFunction(
+  countBulkAgentTradesInCompetitionsImpl,
+  "TradeRepository",
+  "countBulkAgentTradesInCompetitions",
 );
 
 export const count = createTimedRepositoryFunction(

--- a/apps/api/src/types/index.ts
+++ b/apps/api/src/types/index.ts
@@ -1196,3 +1196,13 @@ export const BucketParamSchema = z.coerce
   .default(30);
 
 export type BucketParam = z.infer<typeof BucketParamSchema>;
+
+export const TimestampSchema = z.coerce.date();
+
+export const SnapshotSchema = z.object({
+  id: z.number(),
+  competitionId: UuidSchema,
+  agentId: UuidSchema,
+  timestamp: TimestampSchema,
+  totalValue: z.number(),
+});


### PR DESCRIPTION
part of https://github.com/recallnet/js-recall/issues/1053

This creates a few "bulk" lookup functions that generally reduce the number of queries being sent to the Database.

- `getBulkBoundedSnapshots`  Gets all snapshots for an agent across multiple competitions in one query 
- `countBulkAgentTradesInCompetitions`  Counts trades across all competitions in one query  
- `getAgentRankingsInCompetitions`  Gets rankings across all competitions with minimal queries

See inline comments for more detail.
