### PR TITLE
Fix voting display logic in UI

### DIFF
--- a/apps/comps/app/competitions/[id]/page.tsx
+++ b/apps/comps/app/competitions/[id]/page.tsx
@@ -195,6 +195,7 @@ export default function CompetitionPage({
               Voting begins in...
             </span>
             <CountdownClock
+              showDuration={true}
               targetDate={new Date(competition.votingStartDate)}
             />
           </div>


### PR DESCRIPTION
# Pull Request Overview

This PR fixes the voting countdown display logic to show time periods in days for longer durations, matching the existing pattern used for competition start countdowns.

Adds the showDuration prop to the voting countdown CountdownClock component

This was originally created by Cursor.

Linear Issue: [APP-71](https://linear.app/recall-labs/issue/APP-71/fix-poorly-displayed-voting-beings-in-logic-in-ui)