### PR TITLE
feat: Implement getAgentMetrics in terms of getBulkAgentMetrics

### DIFF
--- a/apps/api/e2e/tests/logging-metrics.test.ts
+++ b/apps/api/e2e/tests/logging-metrics.test.ts
@@ -587,8 +587,6 @@ describe("Logging and Metrics API", () => {
       { pattern: 'method="getRewardsByEpoch"', expectedOp: "SELECT" },
       { pattern: 'method="getLatestPortfolioSnapshots"', expectedOp: "SELECT" },
 
-      { pattern: 'method="countAgentTrades"', expectedOp: "SELECT" },
-      { pattern: 'method="countTotalVotes"', expectedOp: "SELECT" },
       { pattern: 'method="count"', expectedOp: "SELECT" },
 
       // These should be classified as UPDATE (state change methods)

--- a/apps/api/e2e/tests/total-roi-calculation.test.ts
+++ b/apps/api/e2e/tests/total-roi-calculation.test.ts
@@ -282,7 +282,7 @@ describe("Total ROI Calculation Tests", () => {
     expect(agentData?.stats?.totalRoi).toBeCloseTo(expectedRoiStat, 4);
   });
 
-  test("should return null totalRoi when agent has no ended competitions", async () => {
+  test("should return undefined totalRoi when agent has no ended competitions", async () => {
     // Setup admin client
     const adminClient = createTestClient();
     await adminClient.loginAsAdmin(adminApiKey);
@@ -321,7 +321,8 @@ describe("Total ROI Calculation Tests", () => {
     const agentData = agentsResponse.agents.find((a) => a.id === agent.id);
     expect(agentData).toBeDefined();
 
-    // Should return null when no ended competitions
-    expect(agentData?.stats?.totalRoi).toBeNull();
+    // Should return undefined when no ended competitions
+    // (AgentStats schema uses .optional() which omits fields from JSON responses)
+    expect(agentData?.stats?.totalRoi).toBeUndefined();
   });
 });

--- a/apps/api/src/database/repositories/agent-repository.ts
+++ b/apps/api/src/database/repositories/agent-repository.ts
@@ -24,7 +24,6 @@ import {
   AgentCompetitionsParams,
   AgentSearchParams,
   COMPETITION_AGENT_STATUS,
-  CompetitionStatus,
   PagingParams,
 } from "@/types/index.js";
 import { AgentQueryParams } from "@/types/sort/agent.js";
@@ -666,34 +665,6 @@ async function countByNameImpl(name: string): Promise<number> {
 }
 
 /**
- * Count competitions for a given agent
- */
-async function countAgentCompetitionsForStatusImpl(
-  agentId: string,
-  status: CompetitionStatus[],
-): Promise<number> {
-  try {
-    const [result] = await db
-      .select({ count: drizzleCount() })
-      .from(competitionAgents)
-      .leftJoin(
-        competitions,
-        eq(competitionAgents.competitionId, competitions.id),
-      )
-      .where(
-        and(
-          eq(competitionAgents.agentId, agentId),
-          inArray(competitions.status, status),
-        ),
-      );
-    return result?.count ?? 0;
-  } catch (error) {
-    repositoryLogger.error("Error in countAgentCompetitions:", error);
-    throw error;
-  }
-}
-
-/**
  * Find all inactive agents
  */
 async function findInactiveAgentsImpl(): Promise<SelectAgent[]> {
@@ -1103,12 +1074,6 @@ export const countByName = createTimedRepositoryFunction(
   countByNameImpl,
   "AgentRepository",
   "countByName",
-);
-
-export const countAgentCompetitionsForStatus = createTimedRepositoryFunction(
-  countAgentCompetitionsForStatusImpl,
-  "AgentRepository",
-  "countAgentCompetitionsForStatus",
 );
 
 export const findInactiveAgents = createTimedRepositoryFunction(

--- a/apps/api/src/database/repositories/agentscore-repository.ts
+++ b/apps/api/src/database/repositories/agentscore-repository.ts
@@ -93,57 +93,6 @@ async function getAllAgentRanksImpl(
  * @param competitionId The competition ID to associate with the rank history
  * @returns Array of updated agent rank records
  */
-/**
- * Fetches the current rank for a specific agent by ID
- * @param agentId The ID of the agent to get the rank for
- * @returns The agent's simplified rank information (id, rank, score) or null if not found
- */
-async function getAgentRankByIdImpl(agentId: string): Promise<{
-  id: string;
-  rank: number;
-  score: number;
-} | null> {
-  repositoryLogger.debug(`getAgentRankById called for agent ${agentId}`);
-
-  try {
-    const result = await db.execute(sql`
-      WITH ranked_agents AS (
-        SELECT
-          agent_id as id,
-          ordinal as score,
-          row_number() OVER (ORDER BY ordinal DESC) as rank
-        FROM agent_score
-      )
-      SELECT id, rank, score
-      FROM ranked_agents
-      WHERE id = ${agentId}
-    `);
-
-    if (!result.rows || result.rows.length === 0) {
-      repositoryLogger.debug(`No rank found for agent ${agentId}`);
-      return null;
-    }
-
-    const agentRow = result.rows[0];
-    if (!agentRow) {
-      repositoryLogger.debug(`No rank data found for agent ${agentId}`);
-      return null;
-    }
-
-    return {
-      id: String(agentRow.id),
-      rank: Number(agentRow.rank),
-      score: Number(agentRow.score),
-    };
-  } catch (error) {
-    repositoryLogger.error(
-      `Error in getAgentRankById for agent ${agentId}:`,
-      error,
-    );
-    throw error;
-  }
-}
-
 async function batchUpdateAgentRanksImpl(
   dataArray: Array<Omit<InsertAgentScore, "id" | "createdAt" | "updatedAt">>,
   competitionId: string,
@@ -299,12 +248,6 @@ export const getAllAgentRanks = createTimedRepositoryFunction(
   getAllAgentRanksImpl,
   "AgentScoreRepository",
   "getAllAgentRanks",
-);
-
-export const getAgentRankById = createTimedRepositoryFunction(
-  getAgentRankByIdImpl,
-  "AgentScoreRepository",
-  "getAgentRankById",
 );
 
 export const batchUpdateAgentRanks = createTimedRepositoryFunction(

--- a/apps/api/src/database/repositories/leaderboard-repository.ts
+++ b/apps/api/src/database/repositories/leaderboard-repository.ts
@@ -24,6 +24,7 @@ import {
 } from "@/database/schema/trading/defs.js";
 import { repositoryLogger } from "@/lib/logger.js";
 import { createTimedRepositoryFunction } from "@/lib/repository-timing.js";
+import type { RawAgentMetricsQueryResult } from "@/types/agent-metrics.js";
 import {
   COMPETITION_AGENT_STATUS,
   COMPETITION_STATUS,
@@ -34,67 +35,6 @@ import {
  * Leaderboard Repository
  * Handles database operations for leaderboards
  */
-
-/**
- * Get the total ROI as percentage (decimal format) for a single agent across all finished competitions
- * @param agentId The agent ID to get ROI for
- * @returns The total ROI as percentage in decimal format (e.g., 0.37 for 37%) or null if no completed competitions
- */
-export async function getAgentTotalRoi(
-  agentId: string,
-): Promise<number | null> {
-  try {
-    const result = await dbRead
-      .select({
-        totalPnl: sum(tradingCompetitionsLeaderboard.pnl).as("totalPnl"),
-        totalStartingValue: sum(
-          tradingCompetitionsLeaderboard.startingValue,
-        ).as("totalStartingValue"),
-      })
-      .from(competitionsLeaderboard)
-      .innerJoin(
-        tradingCompetitionsLeaderboard,
-        eq(
-          tradingCompetitionsLeaderboard.competitionsLeaderboardId,
-          competitionsLeaderboard.id,
-        ),
-      )
-      .innerJoin(
-        competitions,
-        eq(competitionsLeaderboard.competitionId, competitions.id),
-      )
-      .where(
-        and(
-          eq(competitionsLeaderboard.agentId, agentId),
-          eq(competitions.status, "ended"),
-        ),
-      )
-      .groupBy(competitionsLeaderboard.agentId);
-
-    if (!result[0]) {
-      return null;
-    }
-
-    const totalPnl = Number(result[0].totalPnl);
-    const totalStartingValue = Number(result[0].totalStartingValue);
-
-    if (
-      typeof totalPnl !== "number" ||
-      typeof totalStartingValue !== "number" ||
-      isNaN(totalPnl) ||
-      isNaN(totalStartingValue) ||
-      totalStartingValue <= 0
-    ) {
-      return null;
-    }
-
-    // Calculate ROI as percentage in decimal format (e.g., 0.37 for 37%)
-    return totalPnl / totalStartingValue;
-  } catch (error) {
-    console.error("[LeaderboardRepository] Error in getAgentBestRoi:", error);
-    return null;
-  }
-}
 
 /**
  * Get global statistics for a specific competition type across all relevant competitions.
@@ -180,35 +120,25 @@ async function getGlobalStatsImpl(type: CompetitionType): Promise<{
 /**
  * Get bulk agent metrics for multiple agents using optimized queries
  * This replaces N+1 query patterns in attachAgentMetrics
- * Uses exactly 4 queries regardless of the number of agents
+ * Returns raw query results for processing in the service layer
  *
  * @param agentIds Array of agent IDs to get metrics for
- * @returns Array of agent metrics with all required data
+ * @returns Raw query results from database
  */
-async function getBulkAgentMetricsImpl(agentIds: string[]): Promise<
-  Array<{
-    agentId: string;
-    name: string;
-    description: string | null;
-    imageUrl: string | null;
-    metadata: unknown;
-    globalRank: number | null;
-    globalScore: number | null;
-    completedCompetitions: number;
-    totalVotes: number;
-    totalTrades: number;
-    bestPlacement: {
-      competitionId: string;
-      rank: number;
-      score: number;
-      totalAgents: number;
-    } | null;
-    bestPnl: number | null;
-    totalRoi: number | null;
-  }>
-> {
+async function getBulkAgentMetricsImpl(
+  agentIds: string[],
+): Promise<RawAgentMetricsQueryResult> {
   if (agentIds.length === 0) {
-    return [];
+    return {
+      agentRanks: [],
+      competitionCounts: [],
+      voteCounts: [],
+      tradeCounts: [],
+      bestPlacements: [],
+      bestPnls: [],
+      totalRois: [],
+      allAgentScores: [],
+    };
   }
 
   repositoryLogger.debug(
@@ -348,15 +278,25 @@ async function getBulkAgentMetricsImpl(agentIds: string[]): Promise<
       )
       .groupBy(competitionsLeaderboard.agentId);
 
+    // Query 8: Get all agent scores for rank calculation in service layer
+    const allAgentScoresQuery = dbRead
+      .select({
+        agentId: agentScore.agentId,
+        ordinal: agentScore.ordinal,
+      })
+      .from(agentScore)
+      .orderBy(agentScore.ordinal);
+
     // Execute all queries in parallel
     const [
-      agentRanksResult,
-      competitionCountsResult,
-      voteCountsResult,
-      tradeCountsResult,
-      bestPlacementResult,
-      bestPnlResult,
-      totalRoiResult,
+      agentRanks,
+      competitionCounts,
+      voteCounts,
+      tradeCounts,
+      bestPlacements,
+      bestPnls,
+      totalRois,
+      allAgentScores,
     ] = await Promise.all([
       agentRanksQuery,
       competitionCountsQuery,
@@ -365,122 +305,24 @@ async function getBulkAgentMetricsImpl(agentIds: string[]): Promise<
       bestPlacementsQuery,
       bestPnlQuery,
       totalRoiQuery,
+      allAgentScoresQuery,
     ]);
 
-    // Query 6: Get actual ranks - need to get all ranks first then calculate
-    const allRanksQuery = dbRead
-      .select({
-        agentId: agentScore.agentId,
-        ordinal: agentScore.ordinal,
-      })
-      .from(agentScore)
-      .orderBy(agentScore.ordinal);
-
-    const allRanksResult = await allRanksQuery;
-
-    // Calculate ranks
-    const ranksMap = new Map<string, number>();
-    allRanksResult
-      .sort((a, b) => (b.ordinal || 0) - (a.ordinal || 0)) // Sort by ordinal DESC
-      .forEach((rank, index) => {
-        if (agentIds.includes(rank.agentId)) {
-          ranksMap.set(rank.agentId, index + 1);
-        }
-      });
-
-    // Create lookup maps for efficient joining
-    const agentRanksMap = new Map(
-      agentRanksResult.map((row) => [row.agentId, row]),
-    );
-    const competitionCountsMap = new Map(
-      competitionCountsResult.map((row) => [
-        row.agentId,
-        row.completedCompetitions,
-      ]),
-    );
-    const voteCountsMap = new Map(
-      voteCountsResult.map((row) => [row.agentId, row.totalVotes]),
-    );
-    const tradeCountsMap = new Map(
-      tradeCountsResult.map((row) => [row.agentId, row.totalTrades]),
-    );
-    const bestPlacementMap = new Map(
-      bestPlacementResult.map((row) => [
-        row.agentId,
-        {
-          competitionId: row.competitionId,
-          rank: row.rank,
-          score: row.score,
-          totalAgents: row.totalAgents,
-        },
-      ]),
-    );
-
-    const bestPnlMap = new Map(
-      bestPnlResult.map((row) => [
-        row.agentId,
-        {
-          competitionId: row.competitionId,
-          pnl: row.pnl,
-        },
-      ]),
-    );
-
-    const totalRoiMap = new Map(
-      totalRoiResult.map((row) => {
-        const totalPnl = row.totalPnl ? Number(row.totalPnl) : null;
-        const totalStartingValue = row.totalStartingValue
-          ? Number(row.totalStartingValue)
-          : null;
-
-        if (
-          typeof totalPnl !== "number" ||
-          typeof totalStartingValue !== "number" ||
-          isNaN(totalPnl) ||
-          isNaN(totalStartingValue) ||
-          totalStartingValue <= 0
-        ) {
-          return [row.agentId, null];
-        }
-
-        // Calculate ROI as percentage in decimal format (e.g., 0.37 for 37%)
-        const roiPercent = totalPnl / totalStartingValue;
-        return [row.agentId, roiPercent];
-      }),
-    );
-
-    // Combine all data
-    const result = agentIds.map((agentId) => {
-      const agentData = agentRanksMap.get(agentId);
-      const completedCompetitions = competitionCountsMap.get(agentId) ?? 0;
-      const totalVotes = voteCountsMap.get(agentId) ?? 0;
-      const totalTrades = tradeCountsMap.get(agentId) ?? 0;
-      const bestPlacement = bestPlacementMap.get(agentId) ?? null;
-      const bestPnl = bestPnlMap.get(agentId)?.pnl ?? null;
-      const globalRank = ranksMap.get(agentId) ?? null;
-      const totalRoi = totalRoiMap.get(agentId) ?? null;
-
-      return {
-        agentId,
-        name: agentData?.name ?? "Unknown",
-        description: agentData?.description ?? null,
-        imageUrl: agentData?.imageUrl ?? null,
-        metadata: agentData?.metadata ?? null,
-        globalScore: agentData?.globalScore ?? null,
-        globalRank,
-        completedCompetitions,
-        totalVotes,
-        totalTrades,
-        bestPlacement,
-        bestPnl,
-        totalRoi,
-      };
-    });
-
+    // Return raw query results for processing in service layer
     repositoryLogger.debug(
-      `Successfully retrieved bulk metrics for ${result.length} agents`,
+      `Successfully retrieved bulk metrics data for ${agentIds.length} agents`,
     );
-    return result;
+
+    return {
+      agentRanks,
+      competitionCounts,
+      voteCounts,
+      tradeCounts,
+      bestPlacements,
+      bestPnls,
+      totalRois,
+      allAgentScores,
+    };
   } catch (error) {
     repositoryLogger.error("Error in getBulkAgentMetrics:", error);
     throw error;

--- a/apps/api/src/database/repositories/trade-repository.ts
+++ b/apps/api/src/database/repositories/trade-repository.ts
@@ -167,24 +167,6 @@ async function getCompetitionTradesImpl(
 }
 
 /**
- * Count trades for an agent
- * @param agentId Agent ID
- */
-async function countAgentTradesImpl(agentId: string) {
-  try {
-    const [result] = await db
-      .select({ count: drizzleCount() })
-      .from(trades)
-      .where(eq(trades.agentId, agentId));
-
-    return result?.count ?? 0;
-  } catch (error) {
-    repositoryLogger.error("Error in countAgentTrades:", error);
-    throw error;
-  }
-}
-
-/**
  * Count trades for an agent across multiple competitions in bulk
  * @param agentId Agent ID
  * @param competitionIds Array of competition IDs
@@ -347,12 +329,6 @@ export const getCompetitionTrades = createTimedRepositoryFunction(
   getCompetitionTradesImpl,
   "TradeRepository",
   "getCompetitionTrades",
-);
-
-export const countAgentTrades = createTimedRepositoryFunction(
-  countAgentTradesImpl,
-  "TradeRepository",
-  "countAgentTrades",
 );
 
 export const countBulkAgentTradesInCompetitions = createTimedRepositoryFunction(

--- a/apps/api/src/lib/repository-timing.ts
+++ b/apps/api/src/lib/repository-timing.ts
@@ -179,7 +179,7 @@ function getOperationFromMethod(methodName: string): string {
     name.includes("confirm") ||
     name.includes("ensure") ||
     name.includes("test") ||
-    name.includes("count") || // countAgentTrades, countTotalVotes
+    name.includes("count") ||
     name.includes("sum") ||
     name.includes("avg") ||
     name.includes("average") ||

--- a/apps/api/src/services/agent-manager.service.ts
+++ b/apps/api/src/services/agent-manager.service.ts
@@ -8,7 +8,6 @@ import { config } from "@/config/index.js";
 import * as agentNonceRepo from "@/database/repositories/agent-nonce-repository.js";
 import {
   count,
-  countAgentCompetitionsForStatus,
   countByName,
   countByWallet,
   create,
@@ -29,7 +28,6 @@ import {
   searchAgents,
   update,
 } from "@/database/repositories/agent-repository.js";
-import { getAgentRankById } from "@/database/repositories/agentscore-repository.js";
 import {
   findBestPlacementForAgent,
   getAgentRankingsInCompetitions,
@@ -38,16 +36,9 @@ import {
   getBulkBoundedSnapshots,
 } from "@/database/repositories/competition-repository.js";
 import { createEmailVerificationToken } from "@/database/repositories/email-verification-repository.js";
-import {
-  getAgentTotalRoi,
-  getBulkAgentMetrics,
-} from "@/database/repositories/leaderboard-repository.js";
-import {
-  countAgentTrades,
-  countBulkAgentTradesInCompetitions,
-} from "@/database/repositories/trade-repository.js";
+import { getBulkAgentMetrics } from "@/database/repositories/leaderboard-repository.js";
+import { countBulkAgentTradesInCompetitions } from "@/database/repositories/trade-repository.js";
 import { findByWalletAddress as findUserByWalletAddress } from "@/database/repositories/user-repository.js";
-import { countTotalVotesForAgent } from "@/database/repositories/vote-repository.js";
 import {
   InsertAgent,
   SelectAgent,
@@ -55,9 +46,10 @@ import {
 } from "@/database/schema/core/types.js";
 import { decryptApiKey, hashApiKey } from "@/lib/api-key-utils.js";
 import { serviceLogger } from "@/lib/logger.js";
-import { transformToTrophy } from "@/lib/trophy-utils.js";
 import { ApiError } from "@/middleware/errorHandler.js";
+import { AgentMetricsHelper } from "@/services/agent-metrics-helper.js";
 import { EmailService } from "@/services/email.service.js";
+import type { AgentWithMetrics } from "@/types/agent-metrics.js";
 import {
   ACTOR_STATUS,
   AgentCompetitionsParams,
@@ -65,8 +57,6 @@ import {
   AgentPublic,
   AgentPublicSchema,
   AgentSearchParams,
-  AgentStats,
-  AgentTrophy,
   ApiAuth,
   EnhancedCompetition,
   PagingParams,
@@ -1416,7 +1406,7 @@ export class AgentManager {
    * @param agent The agent object to sanitize
    * @returns The sanitized agent object
    */
-  sanitizeAgent(agent: SelectAgent) {
+  sanitizeAgent(agent: SelectAgent): AgentPublic {
     return AgentPublicSchema.parse({
       ...agent,
       isVerified: !!agent.walletAddress,
@@ -1429,64 +1419,23 @@ export class AgentManager {
    * @returns The agent object with metrics attached
    */
   async attachAgentMetrics(
-    sanitizedAgent: ReturnType<AgentManager["sanitizeAgent"]>,
-  ) {
-    const metadata = sanitizedAgent.metadata as AgentMetadata;
-    const completedCompetitions = await countAgentCompetitionsForStatus(
-      sanitizedAgent.id,
-      ["ended"], // Only get completed competitions
-    );
-    const totalVotes = await countTotalVotesForAgent(sanitizedAgent.id);
-    const totalTrades = await countAgentTrades(sanitizedAgent.id);
-    const bestPlacement =
-      (await this.getAgentBestPlacement(sanitizedAgent.id)) || undefined;
-    const totalRoi = await getAgentTotalRoi(sanitizedAgent.id);
-
-    const agentRank = await getAgentRankById(sanitizedAgent.id);
-    const rank = agentRank?.rank;
-    const score = agentRank?.score;
-
-    // Get trophies by reusing existing competition logic, filtered for ended competitions
-    const endedCompetitions = await this.getCompetitionsForAgent(
-      sanitizedAgent.id,
-      { status: "ended", sort: "", limit: 10, offset: 0 }, // Filter + minimal paging defaults
-      { sort: "-endDate", limit: 100, offset: 0 }, // Actual paging to override defaults
-    );
-
-    // Transform competition data to trophy format
-    const trophies: AgentTrophy[] = endedCompetitions.competitions.map((comp) =>
-      transformToTrophy({
-        competitionId: comp.id,
-        name: comp.name,
-        rank: comp.bestPlacement?.rank,
-        imageUrl: comp.imageUrl,
-        endDate: comp.endDate,
-        createdAt: comp.createdAt,
-      }),
-    );
-
+    sanitizedAgent: AgentPublic,
+  ): Promise<AgentWithMetrics> {
     serviceLogger.debug(
-      `[AgentManager] Generated ${trophies.length} trophies for agent ${sanitizedAgent.id}:`,
-      trophies,
+      `[AgentManager] Attaching metrics for single agent ${sanitizedAgent.id}`,
     );
 
-    const stats = {
-      completedCompetitions,
-      totalVotes,
-      totalTrades,
-      bestPlacement,
-      rank,
-      score,
-      totalRoi,
-    } as AgentStats;
+    // Delegate to bulk method for consistency and to avoid code duplication
+    const results = await this.attachBulkAgentMetrics([sanitizedAgent]);
 
-    return {
-      ...sanitizedAgent,
-      stats,
-      trophies, // Now returns AgentTrophy[] instead of string[]
-      skills: metadata?.skills || [],
-      hasUnclaimedRewards: metadata?.hasUnclaimedRewards || false,
-    };
+    // This should never happen since we pass exactly one agent, but TypeScript needs the check
+    if (!results[0]) {
+      throw new Error(
+        `Failed to attach metrics for agent ${sanitizedAgent.id}`,
+      );
+    }
+
+    return results[0];
   }
 
   /**
@@ -1497,8 +1446,8 @@ export class AgentManager {
    * @returns Array of agents with attached metrics
    */
   async attachBulkAgentMetrics(
-    sanitizedAgents: ReturnType<AgentManager["sanitizeAgent"]>[],
-  ) {
+    sanitizedAgents: AgentPublic[],
+  ): Promise<AgentWithMetrics[]> {
     if (sanitizedAgents.length === 0) {
       return [];
     }
@@ -1508,60 +1457,44 @@ export class AgentManager {
     );
 
     try {
-      // Get all metrics in bulk using optimized queries
       const agentIds = sanitizedAgents.map((agent) => agent.id);
-      const bulkMetrics = await getBulkAgentMetrics(agentIds);
+
+      // Get raw metrics and trophies in parallel
+      const [rawMetrics, bulkTrophies] = await Promise.all([
+        getBulkAgentMetrics(agentIds),
+        getBulkAgentTrophies(agentIds),
+      ]);
+
+      // Transform raw metrics using the helper
+      const metricsArray = AgentMetricsHelper.transformRawMetricsToAgentMetrics(
+        agentIds,
+        rawMetrics,
+      );
 
       // Create lookup maps for efficient access
       const metricsMap = new Map(
-        bulkMetrics.map((metrics) => [metrics.agentId, metrics]),
+        metricsArray.map((metrics) => [metrics.agentId, metrics]),
+      );
+      const trophiesMap = new Map(
+        bulkTrophies.map((trophy) => [trophy.agentId, trophy.trophies]),
       );
 
-      // Get bulk trophies using optimized single query approach with error handling
-      let trophiesMap = new Map();
-      try {
-        const bulkTrophies = await getBulkAgentTrophies(agentIds);
-        trophiesMap = new Map(
-          bulkTrophies.map((trophy) => [trophy.agentId, trophy.trophies]),
-        );
-      } catch (error) {
-        serviceLogger.error(
-          "[AgentManager] Error fetching bulk trophies:",
-          error,
-        );
-        serviceLogger.error(
-          "[AgentManager] Proceeding with empty trophies map",
-        );
-      }
-
-      // Process agents synchronously with O(1) trophy lookups
-      return sanitizedAgents.map((sanitizedAgent) => {
-        const metadata = sanitizedAgent.metadata as AgentMetadata;
-        const metrics = metricsMap.get(sanitizedAgent.id);
-        const trophies = trophiesMap.get(sanitizedAgent.id) || [];
+      // Process agents using helper
+      return sanitizedAgents.map((agent) => {
+        const metrics =
+          metricsMap.get(agent.id) ||
+          AgentMetricsHelper.createEmptyMetrics(agent.id);
+        const trophies = trophiesMap.get(agent.id) || [];
 
         serviceLogger.debug(
-          `[AgentManager] Using bulk trophies: ${trophies.length} trophies for agent ${sanitizedAgent.id}`,
+          `[AgentManager] Using bulk trophies: ${trophies.length} trophies for agent ${agent.id}`,
         );
 
-        const stats = {
-          completedCompetitions: metrics?.completedCompetitions ?? 0,
-          totalVotes: metrics?.totalVotes ?? 0,
-          totalTrades: metrics?.totalTrades ?? 0,
-          bestPlacement: metrics?.bestPlacement ?? undefined,
-          bestPnl: metrics?.bestPnl ?? undefined,
-          rank: metrics?.globalRank ?? undefined,
-          score: metrics?.globalScore ?? undefined,
-          totalRoi: metrics?.totalRoi ?? null,
-        } as AgentStats;
-
-        return {
-          ...sanitizedAgent,
-          stats,
-          trophies, // Use bulk-fetched database trophies
-          skills: metadata?.skills || [],
-          hasUnclaimedRewards: metadata?.hasUnclaimedRewards || false,
-        };
+        return AgentMetricsHelper.attachMetricsToAgent(
+          agent,
+          metrics,
+          trophies,
+        );
       });
     } catch (error) {
       serviceLogger.error(

--- a/apps/api/src/services/agent-metrics-helper.ts
+++ b/apps/api/src/services/agent-metrics-helper.ts
@@ -1,0 +1,214 @@
+import type {
+  AgentMetricsData,
+  AgentPublic,
+  AgentWithMetrics,
+  RawAgentMetricsQueryResult,
+} from "@/types/agent-metrics.js";
+import type { AgentMetadata, AgentStats, AgentTrophy } from "@/types/index.js";
+
+/**
+ * Helper class for transforming and processing agent metrics
+ * Encapsulates business logic for metrics calculations and transformations
+ *
+ * This class handles the conversion between different representations of agent metrics:
+ * 1. RawAgentMetricsQueryResult - Raw database query results
+ * 2. AgentMetricsData - Internal service layer representation (uses null for missing values)
+ * 3. AgentStats - Public API schema (uses undefined for optional fields)
+ *
+ * The separation allows us to follow database conventions internally while
+ * providing clean, minimal JSON responses to API clients.
+ */
+export class AgentMetricsHelper {
+  /**
+   * Transform raw database query results into structured agent metrics data
+   * @param agentIds List of agent IDs to process
+   * @param rawResults Raw query results from repository layer
+   * @returns Array of transformed agent metrics
+   */
+  static transformRawMetricsToAgentMetrics(
+    agentIds: string[],
+    rawResults: RawAgentMetricsQueryResult,
+  ): AgentMetricsData[] {
+    // Create lookup maps for efficient access
+    const agentRanksMap = new Map(
+      rawResults.agentRanks.map((row) => [row.agentId, row]),
+    );
+
+    const competitionCountsMap = new Map(
+      rawResults.competitionCounts.map((row) => [
+        row.agentId,
+        row.completedCompetitions,
+      ]),
+    );
+
+    const voteCountsMap = new Map(
+      rawResults.voteCounts.map((row) => [row.agentId, row.totalVotes]),
+    );
+
+    const tradeCountsMap = new Map(
+      rawResults.tradeCounts.map((row) => [row.agentId, row.totalTrades]),
+    );
+
+    const bestPlacementMap = new Map(
+      rawResults.bestPlacements.map((row) => [
+        row.agentId,
+        {
+          competitionId: row.competitionId,
+          rank: row.rank,
+          score: row.score,
+          totalAgents: row.totalAgents,
+        },
+      ]),
+    );
+
+    const bestPnlMap = new Map(
+      rawResults.bestPnls.map((row) => [
+        row.agentId,
+        {
+          competitionId: row.competitionId,
+          pnl: row.pnl,
+        },
+      ]),
+    );
+
+    // Calculate global ranks from all agent scores
+    const globalRanksMap = new Map<string, number>();
+
+    // Sort all agents by ordinal (descending) to determine ranks
+    const sortedAgents = [...rawResults.allAgentScores].sort(
+      (a, b) => (b.ordinal || 0) - (a.ordinal || 0),
+    );
+
+    // Assign ranks to requested agents based on their position in sorted list
+    sortedAgents.forEach((agent, index) => {
+      if (agentIds.includes(agent.agentId)) {
+        globalRanksMap.set(agent.agentId, index + 1);
+      }
+    });
+
+    // Calculate total ROI with business logic
+    const totalRoiMap = new Map(
+      rawResults.totalRois.map((row) => {
+        const totalPnl = row.totalPnl ? Number(row.totalPnl) : null;
+        const totalStartingValue = row.totalStartingValue
+          ? Number(row.totalStartingValue)
+          : null;
+
+        if (!this.isValidRoiData(totalPnl, totalStartingValue)) {
+          return [row.agentId, null];
+        }
+
+        // Calculate ROI as percentage in decimal format (e.g., 0.37 for 37%)
+        const roiPercent = totalPnl! / totalStartingValue!;
+        return [row.agentId, roiPercent];
+      }),
+    );
+
+    // Combine all data for each agent
+    return agentIds.map((agentId) => {
+      const agentData = agentRanksMap.get(agentId);
+
+      return {
+        agentId,
+        completedCompetitions: competitionCountsMap.get(agentId) ?? 0,
+        totalVotes: voteCountsMap.get(agentId) ?? 0,
+        totalTrades: tradeCountsMap.get(agentId) ?? 0,
+        bestPlacement: bestPlacementMap.get(agentId) ?? null,
+        bestPnl: bestPnlMap.get(agentId)?.pnl ?? null,
+        totalRoi: totalRoiMap.get(agentId) ?? null,
+        globalRank: globalRanksMap.get(agentId) ?? null,
+        globalScore: agentData?.globalScore ?? null,
+      };
+    });
+  }
+
+  /**
+   * Validate ROI data for calculation
+   * @param totalPnl Total profit/loss value
+   * @param totalStartingValue Total starting value
+   * @returns True if data is valid for ROI calculation
+   */
+  private static isValidRoiData(
+    totalPnl: number | null,
+    totalStartingValue: number | null,
+  ): boolean {
+    return (
+      typeof totalPnl === "number" &&
+      typeof totalStartingValue === "number" &&
+      !isNaN(totalPnl) &&
+      !isNaN(totalStartingValue) &&
+      totalStartingValue > 0
+    );
+  }
+
+  /**
+   * Transform raw metrics data into AgentStats format
+   *
+   * This method converts between two similar but intentionally different types:
+   * - AgentMetricsData: Internal service layer type that uses `null` for missing values
+   *   (following database conventions where NULL represents absence of data)
+   * - AgentStats: Public API schema that uses `undefined` for optional fields
+   *   (following REST/JSON best practices where missing fields are omitted)
+   *
+   * The transformation from null -> undefined ensures that API responses don't include
+   * null-valued fields, keeping payloads smaller and cleaner for clients.
+   *
+   * @param metrics Processed metrics data from the service layer
+   * @returns AgentStats object conforming to the public API schema
+   */
+  static transformToStats(metrics: AgentMetricsData): AgentStats {
+    return {
+      completedCompetitions: metrics.completedCompetitions,
+      totalVotes: metrics.totalVotes,
+      totalTrades: metrics.totalTrades,
+      bestPlacement: metrics.bestPlacement ?? undefined,
+      rank: metrics.globalRank ?? undefined,
+      score: metrics.globalScore ?? undefined,
+      totalRoi: metrics.totalRoi ?? undefined,
+      bestPnl: metrics.bestPnl ?? undefined,
+    };
+  }
+
+  /**
+   * Attach metrics to a single agent
+   * @param agent Sanitized agent data
+   * @param metricsData Processed metrics data
+   * @param trophies Agent trophies
+   * @returns Agent with attached metrics
+   */
+  static attachMetricsToAgent(
+    agent: AgentPublic,
+    metricsData: AgentMetricsData,
+    trophies: AgentTrophy[],
+  ): AgentWithMetrics {
+    const metadata = agent.metadata as AgentMetadata;
+
+    return {
+      ...agent,
+      stats: this.transformToStats(metricsData),
+      trophies,
+      skills: metadata?.skills || [],
+      hasUnclaimedRewards: metadata?.hasUnclaimedRewards || false,
+    };
+  }
+
+  /**
+   * Create empty metrics data for an agent
+   * Used as fallback when no metrics are found
+   * @param agentId Agent ID
+   * @returns Empty metrics data
+   */
+  static createEmptyMetrics(agentId: string): AgentMetricsData {
+    return {
+      agentId,
+      completedCompetitions: 0,
+      totalVotes: 0,
+      totalTrades: 0,
+      bestPlacement: null,
+      bestPnl: null,
+      totalRoi: null,
+      globalRank: null,
+      globalScore: null,
+    };
+  }
+}

--- a/apps/api/src/types/agent-metrics.ts
+++ b/apps/api/src/types/agent-metrics.ts
@@ -1,0 +1,112 @@
+import type { AgentPublic, AgentStats, AgentTrophy } from "./index.js";
+
+// Re-export for convenience
+export type { AgentPublic } from "./index.js";
+
+/**
+ * Raw query results from repository layer for bulk agent metrics
+ * This represents the unprocessed data returned from database queries
+ */
+export interface RawAgentMetricsQueryResult {
+  /** Basic agent information with global scores */
+  agentRanks: Array<{
+    agentId: string;
+    name: string;
+    description: string | null;
+    imageUrl: string | null;
+    metadata: unknown;
+    globalScore: number | null;
+  }>;
+
+  /** Competition participation counts per agent */
+  competitionCounts: Array<{
+    agentId: string;
+    completedCompetitions: number;
+  }>;
+
+  /** Vote counts per agent */
+  voteCounts: Array<{
+    agentId: string;
+    totalVotes: number;
+  }>;
+
+  /** Trade counts per agent */
+  tradeCounts: Array<{
+    agentId: string;
+    totalTrades: number;
+  }>;
+
+  /** Best placement data per agent */
+  bestPlacements: Array<{
+    agentId: string;
+    competitionId: string;
+    rank: number;
+    score: number;
+    totalAgents: number;
+  }>;
+
+  /** Best PnL data per agent */
+  bestPnls: Array<{
+    agentId: string;
+    competitionId: string;
+    pnl: number;
+  }>;
+
+  /** Total ROI raw data per agent */
+  totalRois: Array<{
+    agentId: string;
+    totalPnl: string | null;
+    totalStartingValue: string | null;
+  }>;
+
+  /** All agent scores for rank calculation - raw data from agentScore table */
+  allAgentScores: Array<{
+    agentId: string;
+    ordinal: number | null;
+  }>;
+}
+
+/**
+ * Transformed agent metrics data ready for service layer consumption
+ * This is the processed version of RawAgentMetricsQueryResult
+ *
+ * Note: This type uses `null` for missing values following database conventions,
+ * where NULL represents the absence of data. This differs from the public API
+ * schema (AgentStats) which uses `undefined` for optional fields to minimize
+ * JSON payload size and follow REST best practices.
+ */
+export interface AgentMetricsData {
+  agentId: string;
+  completedCompetitions: number;
+  totalVotes: number;
+  totalTrades: number;
+  bestPlacement: {
+    competitionId: string;
+    rank: number;
+    score: number;
+    totalAgents: number;
+  } | null;
+  bestPnl: number | null;
+  totalRoi: number | null;
+  globalRank: number | null;
+  globalScore: number | null;
+}
+
+/**
+ * Enhanced agent with all metrics attached
+ * This is the final output format for API responses
+ */
+export interface AgentWithMetrics extends AgentPublic {
+  stats: AgentStats;
+  trophies: AgentTrophy[];
+  skills: string[];
+  hasUnclaimedRewards: boolean;
+}
+
+/**
+ * Raw trophy query result from repository layer
+ */
+export interface RawAgentTrophyResult {
+  agentId: string;
+  trophies: AgentTrophy[];
+}

--- a/apps/api/src/types/index.ts
+++ b/apps/api/src/types/index.ts
@@ -257,6 +257,7 @@ export const AgentStatsSchema = z.object({
   rank: z.number().optional(),
   score: z.number().optional(),
   totalRoi: z.number().optional(),
+  bestPnl: z.number().optional(),
 });
 
 export type AgentStats = z.infer<typeof AgentStatsSchema>;


### PR DESCRIPTION
They currently have wildly different implementations which creates a ton of code duplication and introduces the potential for bugs to arise from subtle differences between the two.

This does mean now that loading the metrics for a single agent will use an "in" statement in the underlying SQL query, but I'd like to be believe that the postgres query optimizer is smart enough that there's no perf overhead for an "in" query with only a single entry in the "in" statement...

Also includes some general code cleanups to the bulk query path to improve layering separation and add more explicit type information