### PR TITLE
fix(api): remove full table scan query methods

### DIFF
--- a/apps/api/scripts/competition-status.ts
+++ b/apps/api/scripts/competition-status.ts
@@ -1,6 +1,7 @@
 import * as dotenv from "dotenv";
 import * as path from "path";
 
+import { findAll as findAllAgents } from "@/database/repositories/agent-repository.js";
 import {
   findAll,
   getAgentPortfolioSnapshots,
@@ -127,8 +128,12 @@ async function showCompetitionStatus() {
     // Get agents participating in the competition
     const participatingAgentIds = await getCompetitionAgents(competition.id);
 
-    // Get all agents (for mapping IDs to names)
-    const allAgents = await services.agentManager.getAllAgents();
+    // Get all agents (for mapping IDs to names) - direct DB access for script
+    const allAgents = await findAllAgents({
+      limit: 1000000,
+      offset: 0,
+      sort: "createdAt:desc",
+    });
     const agentMap = new Map(allAgents.map((agent) => [agent.id, agent]));
 
     // Map participating agent IDs to agent objects

--- a/apps/api/scripts/competition-status.ts
+++ b/apps/api/scripts/competition-status.ts
@@ -132,7 +132,7 @@ async function showCompetitionStatus() {
     const allAgents = await findAllAgents({
       limit: 1000000,
       offset: 0,
-      sort: "createdAt:desc",
+      sort: "-createdAt",
     });
     const agentMap = new Map(allAgents.map((agent) => [agent.id, agent]));
 

--- a/apps/api/scripts/delete-agent.ts
+++ b/apps/api/scripts/delete-agent.ts
@@ -44,7 +44,7 @@ async function listAllAgents() {
     const agents = await findAllAgents({
       limit: 1000000,
       offset: 0,
-      sort: "createdAt:desc",
+      sort: "-createdAt",
     });
 
     if (agents.length === 0) {

--- a/apps/api/scripts/delete-agent.ts
+++ b/apps/api/scripts/delete-agent.ts
@@ -2,6 +2,7 @@ import * as dotenv from "dotenv";
 import * as path from "path";
 import * as readline from "readline";
 
+import { findAll as findAllAgents } from "@/database/repositories/agent-repository.js";
 import { ServiceRegistry } from "@/services/index.js";
 
 const services = new ServiceRegistry();
@@ -39,7 +40,12 @@ const colors = {
  */
 async function listAllAgents() {
   try {
-    const agents = await services.agentManager.getAllAgents();
+    // Get all agents - direct DB access for script
+    const agents = await findAllAgents({
+      limit: 1000000,
+      offset: 0,
+      sort: "createdAt:desc",
+    });
 
     if (agents.length === 0) {
       console.log(

--- a/apps/api/scripts/end-competition.ts
+++ b/apps/api/scripts/end-competition.ts
@@ -99,7 +99,7 @@ async function endCompetition() {
     const agents = await findAllAgents({
       limit: 1000000,
       offset: 0,
-      sort: "createdAt:desc",
+      sort: "-createdAt",
     });
 
     // Map agent IDs to names

--- a/apps/api/scripts/end-competition.ts
+++ b/apps/api/scripts/end-competition.ts
@@ -2,6 +2,7 @@ import * as dotenv from "dotenv";
 import * as path from "path";
 import * as readline from "readline";
 
+import { findAll as findAllAgents } from "@/database/repositories/agent-repository.js";
 import { ServiceRegistry } from "@/services/index.js";
 
 const services = new ServiceRegistry();
@@ -94,8 +95,12 @@ async function endCompetition() {
       activeCompetition.id,
     );
 
-    // Get all agents
-    const agents = await services.agentManager.getAllAgents();
+    // Get all agents - direct DB access for script
+    const agents = await findAllAgents({
+      limit: 1000000,
+      offset: 0,
+      sort: "createdAt:desc",
+    });
 
     // Map agent IDs to names
     const agentMap = new Map(agents.map((agent) => [agent.id, agent.name]));

--- a/apps/api/scripts/list-agents.ts
+++ b/apps/api/scripts/list-agents.ts
@@ -1,9 +1,7 @@
 import * as dotenv from "dotenv";
 import * as path from "path";
 
-import { ServiceRegistry } from "@/services/index.js";
-
-const services = new ServiceRegistry();
+import { findAll as findAllAgents } from "@/database/repositories/agent-repository.js";
 
 // Load environment variables
 dotenv.config({ path: path.resolve(process.cwd(), ".env") });
@@ -34,7 +32,12 @@ async function listAllAgents() {
       `${colors.cyan}╚════════════════════════════════════════════════════════════════╝${colors.reset}`,
     );
 
-    const agents = await services.agentManager.getAllAgents();
+    // Get all agents - direct DB access for script
+    const agents = await findAllAgents({
+      limit: 1000000,
+      offset: 0,
+      sort: "createdAt:desc",
+    });
 
     if (agents.length === 0) {
       console.log(

--- a/apps/api/scripts/list-agents.ts
+++ b/apps/api/scripts/list-agents.ts
@@ -36,7 +36,7 @@ async function listAllAgents() {
     const agents = await findAllAgents({
       limit: 1000000,
       offset: 0,
-      sort: "createdAt:desc",
+      sort: "-createdAt",
     });
 
     if (agents.length === 0) {

--- a/apps/api/scripts/reset-all-agent-api-keys.ts
+++ b/apps/api/scripts/reset-all-agent-api-keys.ts
@@ -232,7 +232,7 @@ async function resetAllAgentApiKeys(): Promise<void> {
     const agents = await findAllAgents({
       limit: 1000000,
       offset: 0,
-      sort: "createdAt:desc",
+      sort: "-createdAt",
     });
 
     if (agents.length === 0) {

--- a/apps/api/scripts/reset-all-agent-api-keys.ts
+++ b/apps/api/scripts/reset-all-agent-api-keys.ts
@@ -17,6 +17,7 @@ import * as dotenv from "dotenv";
 import * as path from "path";
 import * as readline from "readline";
 
+import { findAll as findAllAgents } from "@/database/repositories/agent-repository.js";
 import { ServiceRegistry } from "@/services/index.js";
 
 // Load environment variables
@@ -227,7 +228,12 @@ async function resetAllAgentApiKeys(): Promise<void> {
     console.log(
       `\n${colors.blue}${colors.bold}Loading agents from database...${colors.reset}`,
     );
-    const agents = await services.agentManager.getAllAgents();
+    // Get all agents - direct DB access for script
+    const agents = await findAllAgents({
+      limit: 1000000,
+      offset: 0,
+      sort: "createdAt:desc",
+    });
 
     if (agents.length === 0) {
       console.log(

--- a/apps/api/scripts/setup-competition.ts
+++ b/apps/api/scripts/setup-competition.ts
@@ -2,6 +2,7 @@ import * as dotenv from "dotenv";
 import * as path from "path";
 import * as readline from "readline";
 
+import { findAll as findAllAgents } from "@/database/repositories/agent-repository.js";
 import { ServiceRegistry } from "@/services/index.js";
 
 const services = new ServiceRegistry();
@@ -42,7 +43,7 @@ const colors = {
  */
 function parseSelectionInput(
   input: string,
-  agents: Awaited<ReturnType<typeof services.agentManager.getAllAgents>>,
+  agents: Array<{ id: string; name: string; handle?: string }>,
 ) {
   try {
     const maxIndex = agents.length;
@@ -91,8 +92,12 @@ function parseSelectionInput(
  */
 async function selectAgents() {
   try {
-    // Get all agents
-    const agents = await services.agentManager.getAllAgents();
+    // Get all agents - direct DB access for script
+    const agents = await findAllAgents({
+      limit: 1000000,
+      offset: 0,
+      sort: "createdAt:desc",
+    });
 
     if (agents.length === 0) {
       console.log(

--- a/apps/api/scripts/setup-competition.ts
+++ b/apps/api/scripts/setup-competition.ts
@@ -96,7 +96,7 @@ async function selectAgents() {
     const agents = await findAllAgents({
       limit: 1000000,
       offset: 0,
-      sort: "createdAt:desc",
+      sort: "-createdAt",
     });
 
     if (agents.length === 0) {

--- a/apps/api/src/controllers/admin.controller.ts
+++ b/apps/api/src/controllers/admin.controller.ts
@@ -1170,7 +1170,7 @@ export function makeAdminController(services: ServiceRegistry) {
         const {
           limit = 50,
           offset = 0,
-          sort = "createdAt:desc",
+          sort = "-createdAt",
         } = queryResult.data;
 
         // Get agents from the database with pagination

--- a/apps/api/src/controllers/admin.schema.ts
+++ b/apps/api/src/controllers/admin.schema.ts
@@ -266,7 +266,7 @@ export const AdminListAllAgentsQuerySchema = z.object({
     .describe("Number of agents to skip for pagination"),
   sort: z
     .string()
-    .default("createdAt:desc")
+    .default("-createdAt")
     .optional()
-    .describe("Sort order (e.g., 'createdAt:desc', 'name:asc')"),
+    .describe("Sort order (e.g., '-createdAt' for desc, 'name' for asc)"),
 });

--- a/apps/api/src/controllers/admin.schema.ts
+++ b/apps/api/src/controllers/admin.schema.ts
@@ -246,3 +246,27 @@ export const AdminUpdateAgentBodySchema = z.object({
   email: z.email("Invalid email format").optional(),
   metadata: z.record(z.string(), z.unknown()).optional(),
 });
+
+/**
+ * Admin list all agents query schema
+ */
+export const AdminListAllAgentsQuerySchema = z.object({
+  limit: z.coerce
+    .number()
+    .min(1)
+    .max(1000)
+    .default(50)
+    .optional()
+    .describe("Number of agents to return (default: 50, max: 1000)"),
+  offset: z.coerce
+    .number()
+    .min(0)
+    .default(0)
+    .optional()
+    .describe("Number of agents to skip for pagination"),
+  sort: z
+    .string()
+    .default("createdAt:desc")
+    .optional()
+    .describe("Sort order (e.g., 'createdAt:desc', 'name:asc')"),
+});

--- a/apps/api/src/controllers/competition.controller.ts
+++ b/apps/api/src/controllers/competition.controller.ts
@@ -103,8 +103,13 @@ export function makeCompetitionController(services: ServiceRegistry) {
             competitionId,
           );
 
-        // Get all agents for mapping IDs to names
-        const agents = await services.agentManager.getAllAgents();
+        // Get only the agents that are in this competition
+        const competitionAgentIds = [
+          ...leaderboardData.activeAgents.map((entry) => entry.agentId),
+          ...leaderboardData.inactiveAgents.map((entry) => entry.agentId),
+        ];
+        const agents =
+          await services.agentManager.getAgentsByIds(competitionAgentIds);
         const agentMap = new Map(agents.map((agent) => [agent.id, agent]));
 
         // Build active leaderboard with ranks

--- a/apps/api/src/database/repositories/agent-repository.ts
+++ b/apps/api/src/database/repositories/agent-repository.ts
@@ -296,6 +296,29 @@ async function findByIdImpl(id: string): Promise<SelectAgent | undefined> {
 }
 
 /**
+ * Find multiple agents by their IDs
+ * @param ids Array of agent IDs to search for
+ * @returns Array of agents matching the provided IDs
+ */
+async function findByIdsImpl(ids: string[]): Promise<SelectAgent[]> {
+  try {
+    if (ids.length === 0) {
+      return [];
+    }
+
+    const results = await db
+      .select()
+      .from(agents)
+      .where(inArray(agents.id, ids));
+
+    return results;
+  } catch (error) {
+    console.error("[AgentRepository] Error in findByIds:", error);
+    throw error;
+  }
+}
+
+/**
  * Find agents by owner ID
  * @param ownerId Owner ID to search for
  */
@@ -990,6 +1013,12 @@ export const findById = createTimedRepositoryFunction(
   findByIdImpl,
   "AgentRepository",
   "findById",
+);
+
+export const findByIds = createTimedRepositoryFunction(
+  findByIdsImpl,
+  "AgentRepository",
+  "findByIds",
 );
 
 export const findByOwnerId = createTimedRepositoryFunction(

--- a/apps/api/src/routes/admin.routes.ts
+++ b/apps/api/src/routes/admin.routes.ts
@@ -1190,9 +1190,9 @@ export function configureAdminRoutes(
    *         name: sort
    *         schema:
    *           type: string
-   *           default: createdAt:desc
+   *           default: -createdAt
    *         required: false
-   *         description: Sort order (e.g., 'createdAt:desc', 'name:asc')
+   *         description: Sort order (e.g., '-createdAt' for desc, 'name' for asc)
    *     responses:
    *       200:
    *         description: List of agents

--- a/apps/api/src/routes/admin.routes.ts
+++ b/apps/api/src/routes/admin.routes.ts
@@ -1165,9 +1165,34 @@ export function configureAdminRoutes(
    *     tags:
    *       - Admin
    *     summary: List all agents
-   *     description: Get a list of all agents in the system
+   *     description: Get a paginated list of all agents in the system
    *     security:
    *       - BearerAuth: []
+   *     parameters:
+   *       - in: query
+   *         name: limit
+   *         schema:
+   *           type: integer
+   *           minimum: 1
+   *           maximum: 1000
+   *           default: 50
+   *         required: false
+   *         description: Number of agents to return (default 50, max 1000)
+   *       - in: query
+   *         name: offset
+   *         schema:
+   *           type: integer
+   *           minimum: 0
+   *           default: 0
+   *         required: false
+   *         description: Number of agents to skip for pagination
+   *       - in: query
+   *         name: sort
+   *         schema:
+   *           type: string
+   *           default: createdAt:desc
+   *         required: false
+   *         description: Sort order (e.g., 'createdAt:desc', 'name:asc')
    *     responses:
    *       200:
    *         description: List of agents
@@ -1223,6 +1248,22 @@ export function configureAdminRoutes(
    *                         type: string
    *                         format: date-time
    *                         description: Agent update timestamp
+   *                 pagination:
+   *                   type: object
+   *                   description: Pagination metadata
+   *                   properties:
+   *                     limit:
+   *                       type: integer
+   *                       description: Number of items per page
+   *                     offset:
+   *                       type: integer
+   *                       description: Number of items skipped
+   *                     total:
+   *                       type: integer
+   *                       description: Total number of agents
+   *                     hasMore:
+   *                       type: boolean
+   *                       description: Whether more agents are available
    *       401:
    *         description: Unauthorized - Admin authentication required
    *       500:

--- a/apps/api/src/services/agent-manager.service.ts
+++ b/apps/api/src/services/agent-manager.service.ts
@@ -18,6 +18,7 @@ import {
   findByApiKeyHash,
   findByCompetition,
   findById,
+  findByIds,
   findByName,
   findByOwnerId,
   findByWallet,
@@ -276,14 +277,21 @@ export class AgentManager {
   }
 
   /**
-   * Get all agents
-   * @returns Array of all agents
+   * Get multiple agents by their IDs
+   * @param agentIds Array of agent IDs to retrieve
+   * @returns Array of agents matching the provided IDs
    */
-  async getAllAgents() {
+  async getAgentsByIds(agentIds: string[]) {
     try {
-      return await findAll();
+      if (agentIds.length === 0) {
+        return [];
+      }
+      return await findByIds(agentIds);
     } catch (error) {
-      serviceLogger.error("[AgentManager] Error retrieving all agents:", error);
+      serviceLogger.error(
+        "[AgentManager] Error retrieving agents by IDs:",
+        error,
+      );
       return [];
     }
   }


### PR DESCRIPTION
## Overview

After the issues with the competition today, I went ahead and removed any attempts to get all agents with a single database query (`select * from agents;`).  
The exception is the scripts.  For scripts I replaced the get all agents with the new get agents with pagination, but the pagination allows for 1M agents, so the script still gets all the agents.


## Summary from Claude:

**Performance Optimization:** Replaced `getAllAgents()` method that was fetching all 145,000 agents from the database with targeted queries:

1. **Competition Controller** (`getLeaderboard`): Now only fetches agents participating in the specific competition using `getAgentsByIds()`

2. **Admin Controller**: 
   - Competition leaderboard: Only fetches competition participants
   - `listAllAgents` endpoint: Added pagination (default 50, max 1000) instead of fetching 100,000+ agents

3. **Scripts**: Replaced service layer calls with direct database queries using `findAll()` since scripts run independently

4. **New Repository Function**: Added `findByIds()` to efficiently fetch multiple agents by their IDs using SQL `IN` clause

**Result:** Dramatically reduced database load and memory usage, especially in production with 145,000 agents.