### PR TITLE
fix: chart skeleton and invalid dates

### DIFF
--- a/apps/comps/app/competitions/[id]/chart/page.tsx
+++ b/apps/comps/app/competitions/[id]/chart/page.tsx
@@ -92,7 +92,7 @@ export default function CompetitionChartPage({
           currentPage={1}
           onPageChange={handlePageChange}
           className="shadow-2xl"
-          suppressInternalLoading={true}
+          suppressInternalLoading={false}
         />
 
         <div className="my-8 text-center">

--- a/apps/comps/components/timeline-chart/timeline-chart.tsx
+++ b/apps/comps/components/timeline-chart/timeline-chart.tsx
@@ -500,44 +500,45 @@ export const TimelineChart: React.FC<PortfolioChartProps> = ({
         </div>
       ) : (
         <>
-          {competition.status !== CompetitionStatus.Ended && (
-            <div className="flex w-full items-center justify-end px-6 py-4">
-              <div className="text-secondary-foreground flex items-center gap-3 text-sm">
-                <Button
-                  onClick={handlePrevRange}
-                  disabled={dateRangeIndex <= 0}
-                  variant="outline"
-                  className="hover:text-primary-foreground border-none p-0 hover:bg-black"
-                >
-                  <ChevronLeft strokeWidth={1.5} />
-                </Button>
-                <div className="flex items-center gap-2">
-                  <span>
-                    {filteredData[0]?.originalTimestamp
-                      ? formatDateShort(filteredData[0].originalTimestamp)
-                      : formatDateShort(filteredData[0]?.timestamp as string)}
-                  </span>
-                  <span className="text-secondary-foreground">/</span>
-                  <span>
-                    {(() => {
-                      const lastItem = filteredData[filteredData.length - 1];
-                      return lastItem?.originalTimestamp
-                        ? formatDateShort(lastItem.originalTimestamp)
-                        : formatDateShort(lastItem?.timestamp as string);
-                    })()}
-                  </span>
+          {competition.status !== CompetitionStatus.Ended &&
+            filteredData.length > 0 && (
+              <div className="flex w-full items-center justify-end px-6 py-4">
+                <div className="text-secondary-foreground flex items-center gap-3 text-sm">
+                  <Button
+                    onClick={handlePrevRange}
+                    disabled={dateRangeIndex <= 0}
+                    variant="outline"
+                    className="hover:text-primary-foreground border-none p-0 hover:bg-black"
+                  >
+                    <ChevronLeft strokeWidth={1.5} />
+                  </Button>
+                  <div className="flex items-center gap-2">
+                    <span>
+                      {filteredData[0]?.originalTimestamp
+                        ? formatDateShort(filteredData[0].originalTimestamp)
+                        : formatDateShort(filteredData[0]?.timestamp as string)}
+                    </span>
+                    <span className="text-secondary-foreground">/</span>
+                    <span>
+                      {(() => {
+                        const lastItem = filteredData[filteredData.length - 1];
+                        return lastItem?.originalTimestamp
+                          ? formatDateShort(lastItem.originalTimestamp)
+                          : formatDateShort(lastItem?.timestamp as string);
+                      })()}
+                    </span>
+                  </div>
+                  <Button
+                    onClick={handleNextRange}
+                    disabled={dateRangeIndex >= parsedData.length - 1}
+                    variant="outline"
+                    className="hover:text-primary-foreground border-none p-0 hover:bg-black"
+                  >
+                    <ChevronRight strokeWidth={1.5} />
+                  </Button>
                 </div>
-                <Button
-                  onClick={handleNextRange}
-                  disabled={dateRangeIndex >= parsedData.length - 1}
-                  variant="outline"
-                  className="hover:text-primary-foreground border-none p-0 hover:bg-black"
-                >
-                  <ChevronRight strokeWidth={1.5} />
-                </Button>
               </div>
-            </div>
-          )}
+            )}
 
           <div className="h-120 relative">
             <HoverContext.Provider

--- a/apps/comps/components/timeline-chart/utils.ts
+++ b/apps/comps/components/timeline-chart/utils.ts
@@ -7,18 +7,11 @@ import { DateArr } from "./types";
 /**
  * Format date to "Month dayth" style (e.g., "Jun 1st", "May 23rd")
  */
-export const formatDateShort = (dateStr: string | Date) => {
-  // Return fallback for null/undefined input
-  if (!dateStr) {
-    return "Loading...";
-  }
+export const formatDateShort = (dateStr: string | Date): string => {
+  if (!dateStr) return "";
 
   const date = new Date(dateStr);
-
-  // Check if the date is valid
-  if (isNaN(date.getTime())) {
-    return "Invalid Date";
-  }
+  if (isNaN(date.getTime())) return "";
 
   const month = date.toLocaleDateString("en-US", { month: "short" });
   const day = date.getDate();

--- a/apps/comps/components/timeline-chart/utils.ts
+++ b/apps/comps/components/timeline-chart/utils.ts
@@ -8,7 +8,18 @@ import { DateArr } from "./types";
  * Format date to "Month dayth" style (e.g., "Jun 1st", "May 23rd")
  */
 export const formatDateShort = (dateStr: string | Date) => {
+  // Return fallback for null/undefined input
+  if (!dateStr) {
+    return "Loading...";
+  }
+
   const date = new Date(dateStr);
+
+  // Check if the date is valid
+  if (isNaN(date.getTime())) {
+    return "Invalid Date";
+  }
+
   const month = date.toLocaleDateString("en-US", { month: "short" });
   const day = date.getDate();
 


### PR DESCRIPTION
Fix non-skeleton render and 'Invalid Date' display on the competition chart page (APP-206).

The chart previously showed a brief empty state because its internal loading was suppressed, and 'Invalid Date' appeared when date formatting functions received invalid inputs. This PR ensures the chart's skeleton persists until all data is ready and adds robust handling for invalid date values.

---
Linear Issue: [APP-206](https://linear.app/recall-labs/issue/APP-206/fix-non-skeleton-render-invalid-date-in-competitionsidchart-page)

<a href="https://cursor.com/background-agent?bcId=bc-179ace17-eb3d-4e69-a958-9a0f4ef5d5b1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-179ace17-eb3d-4e69-a958-9a0f4ef5d5b1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

