### PR TITLE
Truncate agent description in vote table

### DIFF
--- a/apps/comps/components/user-vote.tsx
+++ b/apps/comps/components/user-vote.tsx
@@ -58,7 +58,7 @@ export const UserVote: React.FC<UserVoteProps> = ({
                         {agent.name}
                       </span>
                     </Link>
-                    <span className="text-secondary-foreground/70 block min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-xs">
+                    <span className="text-secondary-foreground/70 block min-w-0 flex-1 truncate text-xs">
                       {agent.description}
                     </span>
                   </div>

--- a/apps/comps/components/user-vote.tsx
+++ b/apps/comps/components/user-vote.tsx
@@ -52,16 +52,16 @@ export const UserVote: React.FC<UserVoteProps> = ({
               <TableCell className="flex flex-1 items-center">
                 <div className="flex min-w-0 items-center gap-3">
                   <AgentAvatar agent={agent} size={32} />
-                  <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
+                  <div className="flex min-w-0 flex-1 flex-col">
                     <Link
                       href={`/agents/${agent.id}`}
-                      className="block w-full overflow-hidden"
+                      className="truncate"
                     >
-                      <span className="block w-full overflow-hidden text-ellipsis whitespace-nowrap font-semibold leading-tight">
+                      <span className="font-semibold leading-tight">
                         {agent.name}
                       </span>
                     </Link>
-                    <span className="text-secondary-foreground block w-full overflow-hidden text-ellipsis whitespace-nowrap text-xs">
+                    <span className="text-secondary-foreground/70 block min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-xs">
                       {agent.description}
                     </span>
                   </div>

--- a/apps/comps/components/user-vote.tsx
+++ b/apps/comps/components/user-vote.tsx
@@ -53,10 +53,7 @@ export const UserVote: React.FC<UserVoteProps> = ({
                 <div className="flex min-w-0 items-center gap-3">
                   <AgentAvatar agent={agent} size={32} />
                   <div className="flex min-w-0 flex-1 flex-col">
-                    <Link
-                      href={`/agents/${agent.id}`}
-                      className="truncate"
-                    >
+                    <Link href={`/agents/${agent.id}`} className="truncate">
                       <span className="font-semibold leading-tight">
                         {agent.name}
                       </span>


### PR DESCRIPTION
Fix "Your Vote" table overflow by truncating `agent.description` to match other table implementations.

---
Linear Issue: [APP-205](https://linear.app/recall-labs/issue/APP-205/fix-your-vote-table-overflow-in-ui-component)

<a href="https://cursor.com/background-agent?bcId=bc-72a60d92-5f6b-421f-ab11-64c23d7aa4d4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-72a60d92-5f6b-421f-ab11-64c23d7aa4d4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

