### PR TITLE
Isolate db schema code

### DIFF
--- a/apps/api/scripts/backfill-stats.ts
+++ b/apps/api/scripts/backfill-stats.ts
@@ -8,7 +8,6 @@ import {
   getBulkAgentCompetitionRankings,
 } from "@/database/repositories/competition-repository.js";
 import { ServiceRegistry } from "@/services/index.js";
-import { COMPETITION_AGENT_STATUS, COMPETITION_STATUS } from "@/types/index.js";
 
 const services = new ServiceRegistry();
 
@@ -79,7 +78,7 @@ async function calculateBulkAgentStats(
         agentId,
       );
 
-      if (agent?.status !== COMPETITION_AGENT_STATUS.ACTIVE) {
+      if (agent?.status !== "active") {
         console.log(`Agent ${agentId} was deactivated, skipping`);
         continue;
       }
@@ -155,9 +154,7 @@ async function backfillCompetitionPnl() {
     );
 
     const competitions = await services.competitionManager.getAllCompetitions();
-    const endedCompetitions = competitions.filter(
-      (c) => c.status === COMPETITION_STATUS.ENDED,
-    );
+    const endedCompetitions = competitions.filter((c) => c.status === "ended");
     console.log(
       `${colors.magenta}----------------------------------------${colors.reset}`,
     );

--- a/apps/api/scripts/competition-status.ts
+++ b/apps/api/scripts/competition-status.ts
@@ -7,7 +7,6 @@ import {
   getCompetitionAgents,
 } from "@/database/repositories/competition-repository.js";
 import { ServiceRegistry } from "@/services/index.js";
-import { COMPETITION_STATUS } from "@/types/index.js";
 
 const services = new ServiceRegistry();
 
@@ -94,7 +93,7 @@ async function showCompetitionStatus() {
       // Check if there are any previous competitions
       const pastCompetitions = await findAll();
       const completedCompetitions = pastCompetitions.filter(
-        (c) => c.status === COMPETITION_STATUS.ENDED,
+        (c) => c.status === "ended",
       );
 
       if (completedCompetitions.length > 0) {

--- a/apps/api/src/config/index.ts
+++ b/apps/api/src/config/index.ts
@@ -1,11 +1,7 @@
 import dotenv from "dotenv";
 import path from "path";
 
-import {
-  CROSS_CHAIN_TRADING_TYPE,
-  CrossChainTradingType,
-  SpecificChain,
-} from "@/types/index.js";
+import { CrossChainTradingType, SpecificChain } from "@/types/index.js";
 
 // Simple console logging for config initialization (before full logger setup)
 const configLogger = {
@@ -351,7 +347,7 @@ export const features: {
   // Enable or disable cross-chain trading functionality
   // When set to false, trades can only occur between tokens on the same chain
   // Defaults to false for security, must be explicitly enabled
-  CROSS_CHAIN_TRADING_TYPE: CROSS_CHAIN_TRADING_TYPE.DISALLOW_ALL,
+  CROSS_CHAIN_TRADING_TYPE: "disallowAll",
   // Enable or disable sandbox mode for auto-joining newly registered agents
   // When set to true, newly registered agents are automatically joined to active competitions
   // Defaults to false, overridden by active competition configuration

--- a/apps/api/src/controllers/admin.controller.ts
+++ b/apps/api/src/controllers/admin.controller.ts
@@ -14,12 +14,7 @@ import { generateHandleFromName } from "@/lib/handle-utils.js";
 import { adminLogger } from "@/lib/logger.js";
 import { ApiError } from "@/middleware/errorHandler.js";
 import { ServiceRegistry } from "@/services/index.js";
-import {
-  ACTOR_STATUS,
-  ActorStatus,
-  AdminCreateAgentSchema,
-  COMPETITION_STATUS,
-} from "@/types/index.js";
+import { ActorStatus, AdminCreateAgentSchema } from "@/types/index.js";
 
 import {
   AdminAddAgentToCompetitionParamsSchema,
@@ -620,7 +615,7 @@ export function makeAdminController(services: ServiceRegistry) {
             continue;
           }
 
-          if (agent.status !== ACTOR_STATUS.ACTIVE) {
+          if (agent.status !== "active") {
             invalidAgentIds.push(agentId);
             continue;
           }
@@ -680,7 +675,7 @@ export function makeAdminController(services: ServiceRegistry) {
           }
 
           // Verify competition is in PENDING state
-          if (competition.status !== COMPETITION_STATUS.PENDING) {
+          if (competition.status !== "pending") {
             throw new ApiError(
               400,
               `Competition is already in ${competition.status} state and cannot be started`,
@@ -1682,7 +1677,7 @@ export function makeAdminController(services: ServiceRegistry) {
         }
 
         // Check if competition is still active
-        if (competition.status === COMPETITION_STATUS.ENDED) {
+        if (competition.status === "ended") {
           return res.status(400).json({
             success: false,
             error: "Cannot reactivate agent in ended competition",
@@ -1812,7 +1807,7 @@ export function makeAdminController(services: ServiceRegistry) {
         }
 
         // Check if competition is ended
-        if (competition.status === COMPETITION_STATUS.ENDED) {
+        if (competition.status === "ended") {
           return res.status(400).json({
             success: false,
             error: "Cannot add agent to ended competition",
@@ -1820,10 +1815,7 @@ export function makeAdminController(services: ServiceRegistry) {
         }
 
         // HARD RULE: Cannot add agents to active non-sandbox competitions
-        if (
-          competition.status === COMPETITION_STATUS.ACTIVE &&
-          !competition.sandboxMode
-        ) {
+        if (competition.status === "active" && !competition.sandboxMode) {
           return res.status(400).json({
             success: false,
             error:

--- a/apps/api/src/controllers/competition.controller.ts
+++ b/apps/api/src/controllers/competition.controller.ts
@@ -13,7 +13,6 @@ import {
   AuthenticatedRequest,
   BucketParamSchema,
   COMPETITION_JOIN_ERROR_TYPES,
-  COMPETITION_STATUS,
   CompetitionAgentParamsSchema,
   CompetitionJoinError,
   CompetitionStatusSchema,
@@ -297,7 +296,7 @@ export function makeCompetitionController(services: ServiceRegistry) {
             );
           }
           // AgentId is present, verify participation in the active competition
-          if (activeCompetition.status !== COMPETITION_STATUS.ACTIVE) {
+          if (activeCompetition.status !== "active") {
             // This check might be redundant if getActiveCompetition already ensures this,
             // but keeping for safety to ensure agent is not trying to get rules for a non-active comp.
             throw new ApiError(

--- a/apps/api/src/database/repositories/agent-repository.ts
+++ b/apps/api/src/database/repositories/agent-repository.ts
@@ -23,7 +23,6 @@ import { transformToTrophy } from "@/lib/trophy-utils.js";
 import {
   AgentCompetitionsParams,
   AgentSearchParams,
-  COMPETITION_AGENT_STATUS,
   PagingParams,
 } from "@/types/index.js";
 import { AgentQueryParams } from "@/types/sort/agent.js";
@@ -222,7 +221,7 @@ async function findByCompetitionImpl(
     // Build where conditions
     const whereConditions = [
       eq(competitionAgents.competitionId, competitionId),
-      eq(competitionAgents.status, COMPETITION_AGENT_STATUS.ACTIVE), // Only show active agents in competition
+      eq(competitionAgents.status, "active"), // Only show active agents in competition
     ];
 
     if (filter) {
@@ -902,7 +901,7 @@ async function getBulkAgentTrophiesImpl(agentIds: string[]): Promise<
         and(
           inArray(competitionAgents.agentId, agentIds),
           eq(competitions.status, "ended"), // Only ended competitions award trophies
-          eq(competitionAgents.status, COMPETITION_AGENT_STATUS.ACTIVE), // Only active participations
+          eq(competitionAgents.status, "active"), // Only active participations
         ),
       )
       .orderBy(desc(competitions.endDate)); // Most recent competitions first

--- a/apps/api/src/database/repositories/competition-repository.ts
+++ b/apps/api/src/database/repositories/competition-repository.ts
@@ -24,7 +24,6 @@ import {
 // Import for enrichment functionality
 import { votes } from "@/database/schema/core/defs.js";
 import {
-  InsertAgent,
   InsertCompetition,
   InsertCompetitionAgent,
   InsertCompetitionsLeaderboard,

--- a/apps/api/src/database/repositories/competition-repository.ts
+++ b/apps/api/src/database/repositories/competition-repository.ts
@@ -24,7 +24,9 @@ import {
 // Import for enrichment functionality
 import { votes } from "@/database/schema/core/defs.js";
 import {
+  InsertAgent,
   InsertCompetition,
+  InsertCompetitionAgent,
   InsertCompetitionsLeaderboard,
   UpdateCompetition,
 } from "@/database/schema/core/types.js";
@@ -41,8 +43,6 @@ import { createTimedRepositoryFunction } from "@/lib/repository-timing.js";
 import { ApiError } from "@/middleware/errorHandler.js";
 import {
   BestPlacementDbSchema,
-  COMPETITION_AGENT_STATUS,
-  COMPETITION_STATUS,
   CompetitionAgentStatus,
   CompetitionStatus,
   PagingParams,
@@ -331,7 +331,7 @@ async function addAgentToCompetitionImpl(
         .values({
           competitionId,
           agentId,
-          status: COMPETITION_AGENT_STATUS.ACTIVE,
+          status: "active",
           createdAt: new Date(),
           updatedAt: new Date(),
         })
@@ -375,7 +375,7 @@ async function removeAgentFromCompetitionImpl(
       const result = await tx
         .update(competitionAgents)
         .set({
-          status: COMPETITION_AGENT_STATUS.DISQUALIFIED,
+          status: "disqualified",
           deactivationReason: reason || "Disqualified from competition",
           deactivatedAt: new Date(),
           updatedAt: new Date(),
@@ -384,7 +384,7 @@ async function removeAgentFromCompetitionImpl(
           and(
             eq(competitionAgents.competitionId, competitionId),
             eq(competitionAgents.agentId, agentId),
-            eq(competitionAgents.status, COMPETITION_AGENT_STATUS.ACTIVE),
+            eq(competitionAgents.status, "active"),
           ),
         )
         .returning();
@@ -459,10 +459,10 @@ async function addAgentsImpl(competitionId: string, agentIds: string[]) {
       }
 
       const now = new Date();
-      const values = agentIds.map((agentId) => ({
+      const values: InsertCompetitionAgent[] = agentIds.map((agentId) => ({
         competitionId,
         agentId,
-        status: COMPETITION_AGENT_STATUS.ACTIVE,
+        status: "active",
         createdAt: now,
         updatedAt: now,
       }));
@@ -504,7 +504,7 @@ async function addAgentsImpl(competitionId: string, agentIds: string[]) {
  */
 async function getAgentsImpl(
   competitionId: string,
-  status: CompetitionAgentStatus = COMPETITION_AGENT_STATUS.ACTIVE,
+  status: CompetitionAgentStatus = "active",
 ) {
   try {
     const result = await db
@@ -554,7 +554,7 @@ async function isAgentActiveInCompetitionImpl(
         and(
           eq(competitionAgents.competitionId, competitionId),
           eq(competitionAgents.agentId, agentId),
-          eq(competitionAgents.status, COMPETITION_AGENT_STATUS.ACTIVE),
+          eq(competitionAgents.status, "active"),
         ),
       )
       .limit(1);
@@ -738,7 +738,7 @@ async function updateAgentCompetitionStatusImpl(
 
       // Add deactivation fields when moving to inactive status, clear them when reactivating
       const updateData =
-        status !== COMPETITION_AGENT_STATUS.ACTIVE
+        status !== "active"
           ? {
               ...baseUpdateData,
               deactivationReason: reason || `Status changed to ${status}`,
@@ -765,9 +765,8 @@ async function updateAgentCompetitionStatusImpl(
 
       // Update the registered participants counter if the status change affects it
       if (wasUpdated) {
-        const wasActive =
-          currentStatus.status === COMPETITION_AGENT_STATUS.ACTIVE;
-        const isNowActive = status === COMPETITION_AGENT_STATUS.ACTIVE;
+        const wasActive = currentStatus.status === "active";
+        const isNowActive = status === "active";
 
         if (wasActive && !isNowActive) {
           // Decrement counter: ACTIVE -> non-ACTIVE
@@ -848,7 +847,7 @@ async function markAgentAsWithdrawnImpl(
   return updateAgentCompetitionStatusImpl(
     competitionId,
     agentId,
-    COMPETITION_AGENT_STATUS.WITHDRAWN,
+    "withdrawn",
     reason || "Agent withdrew from competition voluntarily",
   );
 }
@@ -868,7 +867,7 @@ async function findActiveImpl() {
         competitions,
         eq(tradingCompetitions.competitionId, competitions.id),
       )
-      .where(eq(competitions.status, COMPETITION_STATUS.ACTIVE))
+      .where(eq(competitions.status, "active"))
       .limit(1);
 
     return result;
@@ -929,7 +928,7 @@ async function getLatestPortfolioSnapshotsImpl(competitionId: string) {
         LIMIT 1
       ) ps
       WHERE ca.competition_id = ${competitionId}
-        AND ca.status = ${COMPETITION_AGENT_STATUS.ACTIVE}
+        AND ca.status = ${"active"}
     `);
 
     // Convert snake_case to camelCase to match Drizzle `SelectPortfolioSnapshot` type
@@ -1023,7 +1022,7 @@ async function get24hSnapshotsImpl(
       .from(competitions)
       .where(
         and(
-          eq(competitions.status, COMPETITION_STATUS.ENDED),
+          eq(competitions.status, "ended"),
           eq(competitions.id, competitionId),
         ),
       );
@@ -1462,7 +1461,7 @@ async function countAgentCompetitionsImpl(agentId: string): Promise<number> {
       .where(
         and(
           eq(competitionAgents.agentId, agentId),
-          eq(competitions.status, COMPETITION_STATUS.ENDED),
+          eq(competitions.status, "ended"),
         ),
       );
 
@@ -1847,7 +1846,7 @@ async function findActiveCompetitionsPastEndDateImpl() {
       )
       .where(
         and(
-          eq(competitions.status, COMPETITION_STATUS.ACTIVE),
+          eq(competitions.status, "active"),
           isNotNull(competitions.endDate),
           lte(competitions.endDate, now),
         ),
@@ -2123,7 +2122,7 @@ async function getAgentPortfolioTimelineImpl(
         JOIN agents a ON a.id = ca.agent_id
         JOIN competitions c ON c.id = ca.competition_id
         WHERE ca.competition_id = ${competitionId}
-          AND ca.status = ${COMPETITION_AGENT_STATUS.ACTIVE}
+          AND ca.status = ${"active"}
       ) AS ranked_snapshots
       WHERE rn = 1
     `);

--- a/apps/api/src/database/repositories/competition-repository.ts
+++ b/apps/api/src/database/repositories/competition-repository.ts
@@ -1349,7 +1349,7 @@ async function getAgentRankingsInCompetitionsImpl(
             competitionIds.map((id) => sql`${id}`),
             sql`, `,
           )})
-            AND ca.status = ${COMPETITION_AGENT_STATUS.ACTIVE}
+            AND ca.status = ${"active"}
         ),
         ranked AS (
           SELECT

--- a/apps/api/src/database/repositories/leaderboard-repository.ts
+++ b/apps/api/src/database/repositories/leaderboard-repository.ts
@@ -25,11 +25,7 @@ import {
 import { repositoryLogger } from "@/lib/logger.js";
 import { createTimedRepositoryFunction } from "@/lib/repository-timing.js";
 import type { RawAgentMetricsQueryResult } from "@/types/agent-metrics.js";
-import {
-  COMPETITION_AGENT_STATUS,
-  COMPETITION_STATUS,
-  CompetitionType,
-} from "@/types/index.js";
+import { CompetitionType } from "@/types/index.js";
 
 /**
  * Leaderboard Repository
@@ -57,12 +53,7 @@ async function getGlobalStatsImpl(type: CompetitionType): Promise<{
   const relevantCompetitions = await dbRead
     .select({ id: competitions.id })
     .from(competitions)
-    .where(
-      and(
-        eq(competitions.type, type),
-        eq(competitions.status, COMPETITION_STATUS.ENDED),
-      ),
-    );
+    .where(and(eq(competitions.type, type), eq(competitions.status, "ended")));
 
   if (relevantCompetitions.length === 0) {
     return {
@@ -103,7 +94,7 @@ async function getGlobalStatsImpl(type: CompetitionType): Promise<{
     .where(
       and(
         inArray(competitionAgents.competitionId, relevantCompetitionIds),
-        eq(competitionAgents.status, COMPETITION_AGENT_STATUS.ACTIVE),
+        eq(competitionAgents.status, "active"),
       ),
     );
 

--- a/apps/api/src/database/schema/core/defs.ts
+++ b/apps/api/src/database/schema/core/defs.ts
@@ -16,42 +16,40 @@ import {
   varchar,
 } from "drizzle-orm/pg-core";
 
-import {
-  ACTOR_STATUS_VALUES,
-  COMPETITION_AGENT_STATUS_VALUES,
-  COMPETITION_STATUS_VALUES,
-  COMPETITION_TYPE_VALUES,
-  MAX_HANDLE_LENGTH,
-} from "@/types/index.js";
+export const MAX_HANDLE_LENGTH = 15;
 
 /**
  * Statuses for users, agents, and admins.
  */
-export const actorStatus = pgEnum("actor_status", ACTOR_STATUS_VALUES);
+export const actorStatus = pgEnum("actor_status", [
+  "active",
+  "inactive",
+  "suspended",
+  "deleted",
+]);
 
 /**
  * Defines the possible statuses for competitions.
  */
-export const competitionStatus = pgEnum(
-  "competition_status",
-  COMPETITION_STATUS_VALUES,
-);
+export const competitionStatus = pgEnum("competition_status", [
+  "pending",
+  "active",
+  "ended",
+]);
 
 /**
  * Defines the possible types for competitions.
  */
-export const competitionType = pgEnum(
-  "competition_type",
-  COMPETITION_TYPE_VALUES,
-);
+export const competitionType = pgEnum("competition_type", ["trading"]);
 
 /**
  * Defines the possible statuses for agents within competitions.
  */
-export const competitionAgentStatus = pgEnum(
-  "competition_agent_status",
-  COMPETITION_AGENT_STATUS_VALUES,
-);
+export const competitionAgentStatus = pgEnum("competition_agent_status", [
+  "active",
+  "withdrawn",
+  "disqualified",
+]);
 
 /**
  * Users represent the human owners of agents

--- a/apps/api/src/database/schema/trading/defs.ts
+++ b/apps/api/src/database/schema/trading/defs.ts
@@ -13,8 +13,6 @@ import {
   varchar,
 } from "drizzle-orm/pg-core";
 
-import { CROSS_CHAIN_TRADING_TYPE_VALUES } from "@/types/index.js";
-
 import { agents, competitions, competitionsLeaderboard } from "../core/defs.js";
 
 /**
@@ -27,7 +25,7 @@ export const tradingComps = pgSchema("trading_comps");
  */
 export const crossChainTradingType = tradingComps.enum(
   "cross_chain_trading_type",
-  CROSS_CHAIN_TRADING_TYPE_VALUES,
+  ["disallowAll", "disallowXParent", "allow"],
 );
 
 /**

--- a/apps/api/src/lib/handle-utils.ts
+++ b/apps/api/src/lib/handle-utils.ts
@@ -1,8 +1,5 @@
-import {
-  AgentHandleSchema,
-  MAX_HANDLE_LENGTH,
-  MIN_HANDLE_LENGTH,
-} from "@/types/index.js";
+import { MAX_HANDLE_LENGTH } from "@/database/schema/core/defs.js";
+import { AgentHandleSchema, MIN_HANDLE_LENGTH } from "@/types/index.js";
 
 /**
  * Utility functions for agent handle generation and validation

--- a/apps/api/src/middleware/active-comp-filter.middleware.ts
+++ b/apps/api/src/middleware/active-comp-filter.middleware.ts
@@ -6,7 +6,6 @@ import { db } from "@/database/db.js";
 import { competitions } from "@/database/schema/core/defs.js";
 import { middlewareLogger } from "@/lib/logger.js";
 import { ApiError } from "@/middleware/errorHandler.js";
-import { COMPETITION_STATUS } from "@/types/index.js";
 
 /**
  * Active Competition Filter Middleware
@@ -57,7 +56,7 @@ async function getActiveComp() {
   const [activeComp] = await db
     .select({ id: competitions.id, name: competitions.name })
     .from(competitions)
-    .where(eq(competitions.status, COMPETITION_STATUS.ACTIVE))
+    .where(eq(competitions.status, "active"))
     .limit(1);
 
   // Update cache

--- a/apps/api/src/services/agent-manager.service.ts
+++ b/apps/api/src/services/agent-manager.service.ts
@@ -51,7 +51,6 @@ import { AgentMetricsHelper } from "@/services/agent-metrics-helper.js";
 import { EmailService } from "@/services/email.service.js";
 import type { AgentWithMetrics } from "@/types/agent-metrics.js";
 import {
-  ACTOR_STATUS,
   AgentCompetitionsParams,
   AgentMetadata,
   AgentPublic,
@@ -316,10 +315,7 @@ export class AgentManager {
   private validateAgentStatus(agent: SelectAgent, apiKey: string): void {
     // Check if globally suspended/deleted
     // Note: We now allow "inactive" agents to authenticate for non-competition operations
-    if (
-      agent.status === ACTOR_STATUS.SUSPENDED ||
-      agent.status === ACTOR_STATUS.DELETED
-    ) {
+    if (agent.status === "suspended" || agent.status === "deleted") {
       // Cache the deactivation info
       this.inactiveAgentsCache.set(agent.id, {
         reason: agent.deactivationReason || "No reason provided",

--- a/apps/api/src/services/vote-manager.service.ts
+++ b/apps/api/src/services/vote-manager.service.ts
@@ -18,7 +18,6 @@ import {
 } from "@/database/schema/core/types.js";
 import { serviceLogger } from "@/lib/logger.js";
 import {
-  COMPETITION_STATUS,
   CompetitionVotingStatus,
   UserVoteInfo,
   VOTE_ERROR_TYPES,
@@ -328,8 +327,8 @@ export class VoteManager {
     competition: SelectCompetition,
   ): boolean {
     const votingEnabledStatuses: Array<SelectCompetition["status"]> = [
-      COMPETITION_STATUS.PENDING,
-      COMPETITION_STATUS.ACTIVE,
+      "pending",
+      "active",
     ];
 
     return votingEnabledStatuses.includes(competition.status);

--- a/apps/api/src/types/index.ts
+++ b/apps/api/src/types/index.ts
@@ -3,6 +3,15 @@ import { IronSession } from "iron-session";
 import { SiweMessage } from "siwe";
 import { z } from "zod/v4";
 
+import {
+  actorStatus,
+  competitionAgentStatus,
+  competitionStatus,
+  competitionType,
+} from "@/database/schema/core/defs.js";
+import { MAX_HANDLE_LENGTH } from "@/database/schema/core/defs.js";
+import { crossChainTradingType } from "@/database/schema/trading/defs.js";
+
 /**
  * Blockchain type enum
  */
@@ -369,28 +378,10 @@ export interface Admin {
 }
 
 /**
- * Cross-chain trading types values for zod or database enum.
- */
-export const CROSS_CHAIN_TRADING_TYPE_VALUES = [
-  "disallowAll",
-  "disallowXParent",
-  "allow",
-] as const;
-
-/**
- * Cross-chain trading types values.
- */
-export const CROSS_CHAIN_TRADING_TYPE = {
-  DISALLOW_ALL: "disallowAll",
-  DISALLOW_X_PARENT: "disallowXParent",
-  ALLOW: "allow",
-} as const;
-
-/**
  * Zod schema for the cross-chain trading type.
  */
 export const CrossChainTradingTypeSchema = z.enum(
-  CROSS_CHAIN_TRADING_TYPE_VALUES,
+  crossChainTradingType.enumValues,
 );
 
 /**
@@ -523,29 +514,9 @@ export interface LoginResponse {
 }
 
 /**
- * Actor (user, agent, admin) status values for zod or database enum.
- */
-export const ACTOR_STATUS_VALUES = [
-  "active",
-  "inactive",
-  "suspended",
-  "deleted",
-] as const;
-
-/**
- * Actor (user, agent, admin) statuses.
- */
-export const ACTOR_STATUS = {
-  ACTIVE: "active",
-  INACTIVE: "inactive",
-  SUSPENDED: "suspended",
-  DELETED: "deleted",
-} as const;
-
-/**
  * Zod schema for the status of a user, agent, or admin.
  */
-export const ActorStatusSchema = z.enum(ACTOR_STATUS_VALUES);
+export const ActorStatusSchema = z.enum(actorStatus.enumValues);
 
 /**
  * Status of a user, agent, or admin.
@@ -556,11 +527,6 @@ export type ActorStatus = z.infer<typeof ActorStatusSchema>;
  * Minimum length of a handle.
  */
 export const MIN_HANDLE_LENGTH = 3;
-
-/**
- * Maximum length of a handle.
- */
-export const MAX_HANDLE_LENGTH = 15;
 
 /**
  * Agent information Object
@@ -607,27 +573,9 @@ export const TradingConstraintsSchema = z
   .optional();
 
 /**
- * Competition status values for zod or database enum.
- */
-export const COMPETITION_STATUS_VALUES = [
-  "pending",
-  "active",
-  "ended",
-] as const;
-
-/**
- * Competition statuses.
- */
-export const COMPETITION_STATUS = {
-  PENDING: "pending",
-  ACTIVE: "active",
-  ENDED: "ended",
-} as const;
-
-/**
  * Zod schema for the status of a competition.
  */
-export const CompetitionStatusSchema = z.enum(COMPETITION_STATUS_VALUES);
+export const CompetitionStatusSchema = z.enum(competitionStatus.enumValues);
 
 /**
  * Status of a competition.
@@ -635,28 +583,10 @@ export const CompetitionStatusSchema = z.enum(COMPETITION_STATUS_VALUES);
 export type CompetitionStatus = z.infer<typeof CompetitionStatusSchema>;
 
 /**
- * Competition agent status values for zod or database enum.
- */
-export const COMPETITION_AGENT_STATUS_VALUES = [
-  "active",
-  "withdrawn",
-  "disqualified",
-] as const;
-
-/**
- * Competition agent statuses.
- */
-export const COMPETITION_AGENT_STATUS = {
-  ACTIVE: "active",
-  WITHDRAWN: "withdrawn",
-  DISQUALIFIED: "disqualified",
-} as const;
-
-/**
  * Zod schema for the status of an agent within a competition.
  */
 export const CompetitionAgentStatusSchema = z.enum(
-  COMPETITION_AGENT_STATUS_VALUES,
+  competitionAgentStatus.enumValues,
 );
 
 /**
@@ -667,21 +597,9 @@ export type CompetitionAgentStatus = z.infer<
 >;
 
 /**
- * Competition status values for zod or database enum.
- */
-export const COMPETITION_TYPE_VALUES = ["trading"] as const;
-
-/**
- * Competition statuses.
- */
-export const COMPETITION_TYPE = {
-  TRADING: "trading",
-} as const;
-
-/**
  * Zod schema for the status of a competition.
  */
-export const CompetitionTypeSchema = z.enum(COMPETITION_TYPE_VALUES);
+export const CompetitionTypeSchema = z.enum(competitionType.enumValues);
 
 /**
  * Status of a competition.
@@ -927,7 +845,7 @@ export const LEADERBOARD_SORT_FIELDS = [
  * Query string parameters for global leaderboard rankings
  */
 export const LeaderboardParamsSchema = z.object({
-  type: z.enum(COMPETITION_TYPE_VALUES).default(COMPETITION_TYPE.TRADING),
+  type: CompetitionTypeSchema.default("trading"),
   limit: z.coerce.number().min(1).max(100).default(50),
   offset: z.coerce.number().min(0).default(0),
   sort: z.string().optional().default("rank"), // Default to rank ascending


### PR DESCRIPTION
In preparation for implementing parts of our API in another app, to start with, we need to make the Drizzle schema shared code in its own package. This PR doesn't do that yet, but it untangles all the code in `apps/api/src/database/schema` from all other code in `apps/api`. This will allow us to move it to a new package in the next PR. In the process of doing this, it was clear there were places where the db schema should be the source of truth (mostly with enums that are used in other places in the app), so I refactored a bit to make it that way.