### PR TITLE
refactor(api): remove full scan & calculate summary metrics

### DIFF
--- a/apps/api/e2e/tests/competition.test.ts
+++ b/apps/api/e2e/tests/competition.test.ts
@@ -1934,9 +1934,16 @@ describe("Competition API", () => {
       reason: "Test trade 3",
     });
     expect(trades3.success).toBe(true);
+    const trades4 = await client2.executeTrade({
+      fromToken: config.specificChainTokens.eth.eth,
+      toToken: config.specificChainTokens.eth.usdc,
+      amount: "0.001",
+      reason: "Test trade 4",
+    });
+    expect(trades4.success).toBe(true);
 
     // Get the total trade values
-    const allTrades = [trades1, trades2, trades3] as TradeResponse[];
+    const allTrades = [trades1, trades2, trades3, trades4] as TradeResponse[];
     const totalVolume = allTrades.reduce(
       (acc, trade) => acc + (trade.transaction.tradeAmountUsd ?? 0),
       0,
@@ -1946,7 +1953,7 @@ describe("Competition API", () => {
     )) as CompetitionDetailResponse;
     const stats = competition.stats;
     expect(stats).toBeDefined();
-    expect(stats?.totalTrades).toBe(3);
+    expect(stats?.totalTrades).toBe(4);
     expect(stats?.totalAgents).toBe(2);
     expect(stats?.totalVolume).toBe(totalVolume);
     expect(stats?.uniqueTokens).toBe(3);

--- a/apps/api/src/controllers/competition.controller.ts
+++ b/apps/api/src/controllers/competition.controller.ts
@@ -692,8 +692,11 @@ export function makeCompetitionController(services: ServiceRegistry) {
           throw new ApiError(404, "Competition not found");
         }
 
-        const tradesResponse =
-          await services.tradeSimulator.getCompetitionTrades(competitionId);
+        // Get trade metrics for this competition
+        const { totalTrades, totalVolume, uniqueTokens } =
+          await services.tradeSimulator.getCompetitionTradeMetrics(
+            competitionId,
+          );
 
         // Get vote counts for this competition
         const voteCountsMap =
@@ -705,17 +708,11 @@ export function makeCompetitionController(services: ServiceRegistry) {
 
         // Get stats for this competition
         const stats = {
-          totalTrades: tradesResponse.total,
+          totalTrades,
           totalAgents: competition.registeredParticipants,
-          totalVolume: tradesResponse.trades.reduce<number>(
-            (acc, trade) => acc + trade.tradeAmountUsd,
-            0,
-          ),
+          totalVolume,
           totalVotes,
-          uniqueTokens: new Set([
-            ...tradesResponse.trades.map((trade) => trade.fromToken),
-            ...tradesResponse.trades.map((trade) => trade.toToken),
-          ]).size,
+          uniqueTokens,
         };
 
         const rewards =

--- a/apps/api/src/database/repositories/trade-repository.ts
+++ b/apps/api/src/database/repositories/trade-repository.ts
@@ -160,16 +160,16 @@ async function getCompetitionTradeMetricsImpl(competitionId: string) {
         unnest(ARRAY[b.from_token, b.to_token]) WITH ORDINALITY AS u(token, ord);
     `);
 
-    const r = query.rows[0] ?? {
+    const result = query.rows[0] ?? {
       total_trades: 0,
       total_volume: 0,
       unique_tokens: 0,
     };
 
     return {
-      totalTrades: Number(r.total_trades), // bigint → number (OK unless > 2^53)
-      totalVolume: Number(r.total_volume), // float8 already a number in many drivers
-      uniqueTokens: Number(r.unique_tokens),
+      totalTrades: Number(result.total_trades),
+      totalVolume: Number(result.total_volume),
+      uniqueTokens: Number(result.unique_tokens),
     };
   } catch (error) {
     repositoryLogger.error("Error in getCompetitionTradeMetrics:", error);

--- a/apps/api/src/services/trade-simulator.service.ts
+++ b/apps/api/src/services/trade-simulator.service.ts
@@ -6,6 +6,7 @@ import {
   createTradeWithBalances,
   getAgentTrades,
   getAgentTradesInCompetition,
+  getCompetitionTradeMetrics,
   getCompetitionTrades,
 } from "@/database/repositories/trade-repository.js";
 import { findByCompetitionId } from "@/database/repositories/trading-constraints-repository.js";
@@ -306,6 +307,27 @@ export class TradeSimulator {
         error,
       );
       return { trades: [], total: 0 };
+    }
+  }
+
+  /**
+   * Get trade metrics for a competition
+   * @param competitionId Competition ID
+   * @returns Count of trades, total volume, and number of unique tokens
+   */
+  async getCompetitionTradeMetrics(competitionId: string): Promise<{
+    totalTrades: number;
+    totalVolume: number;
+    uniqueTokens: number;
+  }> {
+    try {
+      return await getCompetitionTradeMetrics(competitionId);
+    } catch (error) {
+      serviceLogger.error(
+        `[TradeSimulator] Error getting competition trade metrics:`,
+        error,
+      );
+      return { totalTrades: 0, totalVolume: 0, uniqueTokens: 0 };
     }
   }
 


### PR DESCRIPTION
The `/competitions/:id` endpoint is currently doing a full scan of the `trades` table because we don't pass a limit to the method `services.tradeSimulator.getCompetitionTrades(competitionId)`. We only make that call because we need summary metrics (total trades, total volume, and # of unique tokens).

This PR adds a new method to simply calculate those metrics instead of doing "query all + in-memory computation"/