### PR TITLE
Fix Typos in Docs

### DIFF
--- a/packages/api-sdk/FUNCTIONS.md
+++ b/packages/api-sdk/FUNCTIONS.md
@@ -1,11 +1,11 @@
 # Standalone Functions
 
 > [!NOTE]
-> This section is useful if you are using a bundler and targetting browsers and
+> This section is useful if you are using a bundler and targeting browsers and
 > runtimes where the size of an application affects performance and load times.
 
 Every method in this SDK is also available as a standalone function. This
-alternative API is suitable when targetting the browser or serverless runtimes
+alternative API is suitable when targeting the browser or serverless runtimes
 and using a bundler to build your application since all unused functionality
 will be tree-shaken away. This includes code for unused methods, Zod schemas,
 encoding helpers and response handlers. The result is dramatically smaller

--- a/packages/api-sdk/src/lib/http.ts
+++ b/packages/api-sdk/src/lib/http.ts
@@ -12,7 +12,7 @@ export type Awaitable<T> = T | Promise<T>;
 const DEFAULT_FETCHER: Fetcher = (input, init) => {
   // If input is a Request and init is undefined, Bun will discard the method,
   // headers, body and other options that were set on the request object.
-  // Node.js and browers would ignore an undefined init value. This check is
+  // Node.js and browsers would ignore an undefined init value. This check is
   // therefore needed for interop with Bun.
   if (init == null) {
     return fetch(input);


### PR DESCRIPTION
Corrected misspellings:

- `targetting` → `targeting`
- `browers` → `browsers`