### PR TITLE
fix: ci & db-schema package publishing

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -22,6 +22,7 @@
     "@recallnet/ui",
     "@recallnet/ui2",
     "@recallnet/react",
-    "@recallnet/api-sdk"
+    "@recallnet/api-sdk",
+    "@recallnet/db-schema"
   ]
 }

--- a/apps/api/trade-simulator-docker/Dockerfile
+++ b/apps/api/trade-simulator-docker/Dockerfile
@@ -17,6 +17,7 @@ COPY . .
 
 # Build the application
 RUN pnpm --filter=@recallnet/api-sdk build && \
+    pnpm --filter=@recallnet/db-schema build && \
     pnpm --filter=@recallnet/staking-contracts build && \
     pnpm --filter=api build
 

--- a/packages/db-schema/package.json
+++ b/packages/db-schema/package.json
@@ -2,9 +2,7 @@
   "name": "@recallnet/db-schema",
   "version": "0.0.0",
   "license": "MIT AND Apache-2.0",
-  "publishConfig": {
-    "access": "public"
-  },
+  "private": true,
   "description": "Recall Drizzle schema.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
1. CI is failing to build the docker image because we explicitly include only a subset of packages—and the new db-schema package isn't included
2. we want to keep our db-schema package off of npm