### PR TITLE
fix(comps): safari table height virtualization bug

### DIFF
--- a/apps/comps/components/agents-table/index.tsx
+++ b/apps/comps/components/agents-table/index.tsx
@@ -368,12 +368,7 @@ export const AgentsTable: React.FC<AgentsTableProps> = ({
               </TableRow>
             ))}
           </TableHeader>
-          <TableBody
-            style={{
-              height: `${rowVirtualizer.getTotalSize()}px`,
-              position: "relative",
-            }}
-          >
+          <TableBody>
             {rowVirtualizer.getVirtualItems().map((virtualRow) => {
               const row = table.getRowModel().rows[virtualRow.index];
               if (!row) return null;
@@ -381,11 +376,6 @@ export const AgentsTable: React.FC<AgentsTableProps> = ({
                 <TableRow
                   key={row.id}
                   style={{
-                    position: "absolute",
-                    top: 0,
-                    left: 0,
-                    width: "100%",
-                    transform: `translateY(${virtualRow.start}px)`,
                     display: "flex",
                     cursor: "pointer",
                   }}


### PR DESCRIPTION
[Previous PR](https://github.com/recallnet/js-recall/pull/1137) should have been against `prod-latest` branch, which we use for front-end deployments, not `main`.