### PR TITLE
fix(api): allow comp to start if max registrants reached

### DIFF
--- a/apps/api/e2e/utils/api-client.ts
+++ b/apps/api/e2e/utils/api-client.ts
@@ -355,9 +355,10 @@ export class ApiClient {
   async startCompetition(
     params:
       | {
-          name: string;
+          name?: string;
+          competitionId?: string;
           description?: string;
-          agentIds: string[];
+          agentIds?: string[];
           tradingType?: CrossChainTradingType;
           sandboxMode?: boolean;
           externalUrl?: string;
@@ -466,7 +467,7 @@ export class ApiClient {
    */
   async startExistingCompetition(
     competitionId: string,
-    agentIds: string[],
+    agentIds?: string[],
     crossChainTradingType?: CrossChainTradingType,
     sandboxMode?: boolean,
     externalUrl?: string,

--- a/apps/api/e2e/utils/test-helpers.ts
+++ b/apps/api/e2e/utils/test-helpers.ts
@@ -294,7 +294,7 @@ export async function createTestCompetition(
 export async function startExistingTestCompetition(
   adminClient: ApiClient,
   competitionId: string,
-  agentIds: string[],
+  agentIds?: string[],
   sandboxMode?: boolean,
   externalUrl?: string,
   imageUrl?: string,

--- a/apps/api/src/services/competition-manager.service.ts
+++ b/apps/api/src/services/competition-manager.service.ts
@@ -297,7 +297,20 @@ export class CompetitionManager {
       }
 
       // Register agent in the competition (automatically sets status to 'active')
-      await addAgentToCompetition(competitionId, agentId);
+      try {
+        await addAgentToCompetition(competitionId, agentId);
+      } catch (error) {
+        // If participant limit error, provide a more helpful error message
+        if (
+          error instanceof Error &&
+          error.message.includes("maximum participant limit")
+        ) {
+          throw new Error(
+            `Cannot start competition: ${error.message}. Some agents may already be registered.`,
+          );
+        }
+        throw error;
+      }
 
       serviceLogger.debug(
         `[CompetitionManager] Agent ${agentId} ready for competition`,


### PR DESCRIPTION
closes [APP-317](https://linear.app/recall-labs/issue/APP-317/admin-startcompetition-fails-due-to-registered-==-max-participants)