### PR TITLE
chore(comps): remove external address-utils package

### DIFF
--- a/apps/comps/Dockerfile
+++ b/apps/comps/Dockerfile
@@ -21,8 +21,7 @@ ARG NEXT_PUBLIC_API_BASE_URL
 ARG NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID
 
 # Build the application
-RUN pnpm --filter=@recallnet/address-utils build && \
-    pnpm --filter=@recallnet/fonts build && \
+RUN pnpm --filter=@recallnet/fonts build && \
     pnpm --filter=comps build
 
 FROM node:22-alpine

--- a/apps/comps/components/user-agents/agent-card.tsx
+++ b/apps/comps/components/user-agents/agent-card.tsx
@@ -4,12 +4,12 @@ import { Award } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 
-import { displayAddress } from "@recallnet/address-utils/display";
 import Card, { CardProps } from "@recallnet/ui2/components/card";
 import { cn } from "@recallnet/ui2/lib/utils";
 
 import MirrorImage from "@/components/mirror-image";
 import { Agent } from "@/types";
+import { displayAddress } from "@/utils/address";
 import { formatCompactNumber, toOrdinal } from "@/utils/format";
 
 import { VerificationBadge } from "../verification-badge";

--- a/apps/comps/package.json
+++ b/apps/comps/package.json
@@ -24,7 +24,6 @@
     "@radix-ui/react-dropdown-menu": "^2.1.7",
     "@radix-ui/react-icons": "^1.3.0",
     "@radix-ui/react-portal": "^1.1.9",
-    "@recallnet/address-utils": "workspace:*",
     "@recallnet/fonts": "workspace:*",
     "@recallnet/ui2": "workspace:*",
     "@sentry/nextjs": "^10.5.0",

--- a/apps/comps/utils/address.ts
+++ b/apps/comps/utils/address.ts
@@ -1,0 +1,80 @@
+/**
+ * Utility functions for formatting Ethereum addresses for display purposes.
+ */
+
+/**
+ * Options for customizing the address display format.
+ */
+export interface DisplayAddressOptions {
+  /**
+   * The number of characters to show at the start and end of the address.
+   * This determines how many characters from the beginning and end of the address will be visible.
+   *
+   * @example
+   * ```typescript
+   * // Show 6 characters at start and end
+   * { numChars: 6 } // "0x1234...5678"
+   * ```
+   *
+   * @default 4
+   */
+  numChars?: number;
+
+  /**
+   * The separator string to use between the start and end portions of the address.
+   * This string is inserted between the visible parts of the address.
+   *
+   * @example
+   * ```typescript
+   * // Use a custom separator
+   * { separator: "..." } // "0x12...5678"
+   * ```
+   *
+   * @default "…"
+   */
+  separator?: string;
+}
+
+/**
+ * Formats an Ethereum address for display by showing only the first and last few characters.
+ *
+ * This function takes a full Ethereum address and creates a shortened version that's more
+ * readable while still being recognizable. It shows a specified number of characters from
+ * the start and end of the address, separated by a customizable separator string.
+ *
+ * @example
+ * ```typescript
+ * // Basic usage (shows first 4 and last 4 characters)
+ * displayAddress("0x1234567890abcdef1234567890abcdef12345678")
+ * // Returns: "0x12…5678"
+ *
+ * // Custom number of characters
+ * displayAddress("0x1234567890abcdef1234567890abcdef12345678", { numChars: 6 })
+ * // Returns: "0x1234…345678"
+ *
+ * // Custom separator
+ * displayAddress("0x1234567890abcdef1234567890abcdef12345678", { separator: "..." })
+ * // Returns: "0x12...5678"
+ * ```
+ *
+ * @param address - The Ethereum address to format
+ * @param options - Optional configuration for the display format
+ * @returns The formatted address string
+ *
+ * @throws Will throw an error if the address is shorter than 2 * numChars
+ */
+export function displayAddress(
+  address: string,
+  options?: DisplayAddressOptions,
+) {
+  const numChars = options?.numChars ?? 4;
+  const separator = options?.separator ?? "…";
+
+  if (address.length < numChars * 2) {
+    throw new Error(
+      "Address is too short for the specified number of characters",
+    );
+  }
+
+  return `${address.slice(0, numChars)}${separator}${address.slice(-numChars)}`;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -246,9 +246,6 @@ importers:
       '@radix-ui/react-portal':
         specifier: ^1.1.9
         version: 1.1.9(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@recallnet/address-utils':
-        specifier: workspace:*
-        version: link:../../packages/address-utils
       '@recallnet/fonts':
         specifier: workspace:*
         version: link:../../packages/fonts


### PR DESCRIPTION
- We want to remove the `@recallnet/address-utils` package entirely since [it's only 1 method](https://github.com/recallnet/js-recall/blob/main/packages/address-utils/src/display.ts)
- Thus, this brings the method into the `app/comps` dir and cleans up the external dep