### PR TITLE
test(api): refactor helpers to use named params

### DIFF
--- a/apps/api/e2e/tests/admin.test.ts
+++ b/apps/api/e2e/tests/admin.test.ts
@@ -1163,11 +1163,11 @@ describe("Admin API", () => {
 
     // Start competition with both agents
     const competitionName = `Per-Competition Remove Test ${Date.now()}`;
-    const startResponse = await startTestCompetition(
+    const startResponse = await startTestCompetition({
       adminClient,
-      competitionName,
-      [agent1.id, agent2.id],
-    );
+      name: competitionName,
+      agentIds: [agent1.id, agent2.id],
+    });
     const competition = startResponse.competition;
 
     // Verify both agents are initially in the competition
@@ -1229,11 +1229,11 @@ describe("Admin API", () => {
 
     // Start competition with the agent
     const competitionName = `Per-Competition Reactivate Test ${Date.now()}`;
-    const startResponse = await startTestCompetition(
+    const startResponse = await startTestCompetition({
       adminClient,
-      competitionName,
-      [agent.id],
-    );
+      name: competitionName,
+      agentIds: [agent.id],
+    });
     const competition = startResponse.competition;
 
     // Remove agent from the competition first
@@ -1316,11 +1316,11 @@ describe("Admin API", () => {
     });
 
     const competitionName = `Valid Competition Test ${Date.now()}`;
-    const startResponse = await startTestCompetition(
+    const startResponse = await startTestCompetition({
       adminClient,
-      competitionName,
-      [agent.id],
-    );
+      name: competitionName,
+      agentIds: [agent.id],
+    });
     const competition = startResponse.competition;
 
     // Try to remove non-existent agent
@@ -1353,11 +1353,11 @@ describe("Admin API", () => {
 
     // Start competition with only agent1
     const competitionName = `Single Agent Competition Test ${Date.now()}`;
-    const startResponse = await startTestCompetition(
+    const startResponse = await startTestCompetition({
       adminClient,
-      competitionName,
-      [agent1.id],
-    );
+      name: competitionName,
+      agentIds: [agent1.id],
+    });
     const competition = startResponse.competition;
 
     // Try to remove agent2 (who is not in the competition)
@@ -1391,11 +1391,11 @@ describe("Admin API", () => {
 
     // Start competition with only agent1
     const competitionName = `Reactivate Not In Competition Test ${Date.now()}`;
-    const startResponse = await startTestCompetition(
+    const startResponse = await startTestCompetition({
       adminClient,
-      competitionName,
-      [agent1.id],
-    );
+      name: competitionName,
+      agentIds: [agent1.id],
+    });
     const competition = startResponse.competition;
 
     // Try to reactivate agent2 (who is not in the competition)
@@ -1422,11 +1422,11 @@ describe("Admin API", () => {
       });
 
     const competitionName = `Auth Test Competition ${Date.now()}`;
-    const startResponse = await startTestCompetition(
+    const startResponse = await startTestCompetition({
       adminClient,
-      competitionName,
-      [agent.id],
-    );
+      name: competitionName,
+      agentIds: [agent.id],
+    });
     const competition = startResponse.competition;
 
     // Try per-competition operations with non-admin client
@@ -1463,11 +1463,11 @@ describe("Admin API", () => {
 
     // Start competition with the agent
     const competitionName = `Status Independence Test ${Date.now()}`;
-    const startResponse = await startTestCompetition(
+    const startResponse = await startTestCompetition({
       adminClient,
-      competitionName,
-      [agent.id],
-    );
+      name: competitionName,
+      agentIds: [agent.id],
+    });
     const competition = startResponse.competition;
 
     // Verify agent can access API initially

--- a/apps/api/e2e/tests/agent.test.ts
+++ b/apps/api/e2e/tests/agent.test.ts
@@ -415,19 +415,19 @@ describe("Agent API", () => {
 
     // Step 2: Create and start first competition with the agent
     const firstCompName = `Competition 1 ${Date.now()}`;
-    const createCompResult = await adminClient.createCompetition(
-      firstCompName,
-      "First test competition",
-    );
+    const createCompResult = await adminClient.createCompetition({
+      name: firstCompName,
+      description: "First test competition",
+    });
     expect(createCompResult.success).toBe(true);
     const createCompResponse = createCompResult as CreateCompetitionResponse;
     const firstCompetitionId = createCompResponse.competition.id;
 
     // Start the first competition with our agent
-    const startCompResult = await adminClient.startExistingCompetition(
-      firstCompetitionId,
-      [agent.id],
-    );
+    const startCompResult = await adminClient.startExistingCompetition({
+      competitionId: firstCompetitionId,
+      agentIds: [agent.id],
+    });
     expect(startCompResult.success).toBe(true);
 
     // Verify agent can use API during first competition
@@ -448,19 +448,19 @@ describe("Agent API", () => {
 
     // Step 4: Create and start a second competition with the same agent
     const secondCompName = `Competition 2 ${Date.now()}`;
-    const createCompResult2 = await adminClient.createCompetition(
-      secondCompName,
-      "Second test competition",
-    );
+    const createCompResult2 = await adminClient.createCompetition({
+      name: secondCompName,
+      description: "Second test competition",
+    });
     expect(createCompResult2.success).toBe(true);
     const createCompResponse2 = createCompResult2 as CreateCompetitionResponse;
     const secondCompetitionId = createCompResponse2.competition.id;
 
     // Start the second competition with the same agent
-    const startCompResult2 = await adminClient.startExistingCompetition(
-      secondCompetitionId,
-      [agent.id],
-    );
+    const startCompResult2 = await adminClient.startExistingCompetition({
+      competitionId: secondCompetitionId,
+      agentIds: [agent.id],
+    });
     expect(startCompResult2.success).toBe(true);
 
     // Step 5: Verify agent can still use API after being added to second competition
@@ -496,19 +496,19 @@ describe("Agent API", () => {
 
     // Step 2: Create and start a competition with the agent
     const compName = `Cache Test Competition ${Date.now()}`;
-    const createCompResult = await adminClient.createCompetition(
-      compName,
-      "Competition to test cache consistency",
-    );
+    const createCompResult = await adminClient.createCompetition({
+      name: compName,
+      description: "Competition to test cache consistency",
+    });
     expect(createCompResult.success).toBe(true);
     const createCompResponse = createCompResult as CreateCompetitionResponse;
     const competitionId = createCompResponse.competition.id;
 
     // Start the competition with our agent
-    const startCompResult = await adminClient.startExistingCompetition(
+    const startCompResult = await adminClient.startExistingCompetition({
       competitionId,
-      [agent.id],
-    );
+      agentIds: [agent.id],
+    });
     expect(startCompResult.success).toBe(true);
 
     // Step 3: Verify initial API functionality
@@ -1055,18 +1055,18 @@ describe("Agent API", () => {
 
     // NOTE: we can't have more than one active comp right now
     async function createComp(compName: string) {
-      const createCompResult = await adminClient.createCompetition(
-        compName,
-        `Test competition ${compName}`,
-      );
+      const createCompResult = await adminClient.createCompetition({
+        name: compName,
+        description: `Test competition ${compName}`,
+      });
       expect(createCompResult.success).toBe(true);
       const createCompResponse = createCompResult as CreateCompetitionResponse;
       createdCompetitions.push(createCompResponse.competition);
 
-      const startCompResult = await adminClient.startExistingCompetition(
-        createCompResponse.competition.id,
-        [agent.id],
-      );
+      const startCompResult = await adminClient.startExistingCompetition({
+        competitionId: createCompResponse.competition.id,
+        agentIds: [agent.id],
+      });
 
       expect(startCompResult.success).toBe(true);
     }
@@ -1075,17 +1075,17 @@ describe("Agent API", () => {
     await adminClient.endCompetition(createdCompetitions[0]?.id as string);
     await createComp(competitionNames[1] as string);
 
-    const pendingCompResponse = await adminClient.createCompetition(
-      competitionNames[2] as string,
-      `Test competition ${competitionNames[2] as string}`,
-    );
+    const pendingCompResponse = await adminClient.createCompetition({
+      name: competitionNames[2] as string,
+      description: `Test competition ${competitionNames[2] as string}`,
+    });
     expect(pendingCompResponse.success).toBe(true);
 
     // make sure there is at least one comp that the agent is not part of so we can test that it is not returned in the responses
-    const notJoinedCompResponse = await adminClient.createCompetition(
-      competitionNames[2] as string,
-      `Test competition ${competitionNames[2] as string}`,
-    );
+    const notJoinedCompResponse = await adminClient.createCompetition({
+      name: competitionNames[2] as string,
+      description: `Test competition ${competitionNames[2] as string}`,
+    });
     expect(notJoinedCompResponse.success).toBe(true);
 
     const pendingComp = pendingCompResponse as CreateCompetitionResponse;
@@ -1807,16 +1807,19 @@ Purpose: WALLET_VERIFICATION`;
 
     // Step 2: Create and start first competition with the agent
     const firstCompName = `Competition 1 ${Date.now()}`;
-    const createCompResult = await adminClient.createCompetition(
-      firstCompName,
-      "First test competition",
-    );
+    const createCompResult = await adminClient.createCompetition({
+      name: firstCompName,
+      description: "First test competition",
+    });
     expect(createCompResult.success).toBe(true);
     const createCompResponse = createCompResult as CreateCompetitionResponse;
     const firstCompetitionId = createCompResponse.competition.id;
 
     // Start the first competition with our agent
-    await adminClient.startExistingCompetition(firstCompetitionId, [agent.id]);
+    await adminClient.startExistingCompetition({
+      competitionId: firstCompetitionId,
+      agentIds: [agent.id],
+    });
     await agentClient.executeTrade({
       fromToken: config.specificChainTokens.eth.usdc,
       toToken: "0x000000000000000000000000000000000000dead", // Burn address - make agent 1 lose
@@ -1949,15 +1952,18 @@ Purpose: WALLET_VERIFICATION`;
 
       // Create and start competition
       const compName = `Leave Competition Test ${Date.now()}`;
-      const createCompResult = await adminClient.createCompetition(
-        compName,
-        "Test competition for leave functionality",
-      );
+      const createCompResult = await adminClient.createCompetition({
+        name: compName,
+        description: "Test competition for leave functionality",
+      });
       expect(createCompResult.success).toBe(true);
       const competitionId = (createCompResult as CreateCompetitionResponse)
         .competition.id;
 
-      await adminClient.startExistingCompetition(competitionId, [agent.id]);
+      await adminClient.startExistingCompetition({
+        competitionId,
+        agentIds: [agent.id],
+      });
 
       // Verify agent can access API while in active competition
       const profileResponse1 = await agentClient.getAgentProfile();
@@ -1992,15 +1998,18 @@ Purpose: WALLET_VERIFICATION`;
 
       // Create and start competition
       const compName = `Competition End Test ${Date.now()}`;
-      const createCompResult = await adminClient.createCompetition(
-        compName,
-        "Test competition for end functionality",
-      );
+      const createCompResult = await adminClient.createCompetition({
+        name: compName,
+        description: "Test competition for end functionality",
+      });
       expect(createCompResult.success).toBe(true);
       const competitionId = (createCompResult as CreateCompetitionResponse)
         .competition.id;
 
-      await adminClient.startExistingCompetition(competitionId, [agent.id]);
+      await adminClient.startExistingCompetition({
+        competitionId,
+        agentIds: [agent.id],
+      });
 
       // Verify agent can access API during competition
       const profileResponse1 = await agentClient.getAgentProfile();
@@ -2033,15 +2042,18 @@ Purpose: WALLET_VERIFICATION`;
 
       // Create and start competition
       const compName = `History Test ${Date.now()}`;
-      const createCompResult = await adminClient.createCompetition(
-        compName,
-        "Test competition for history preservation",
-      );
+      const createCompResult = await adminClient.createCompetition({
+        name: compName,
+        description: "Test competition for history preservation",
+      });
       expect(createCompResult.success).toBe(true);
       const competitionId = (createCompResult as CreateCompetitionResponse)
         .competition.id;
 
-      await adminClient.startExistingCompetition(competitionId, [agent.id]);
+      await adminClient.startExistingCompetition({
+        competitionId,
+        agentIds: [agent.id],
+      });
 
       // Execute a trade to create history
       await agentClient.executeTrade({
@@ -2094,19 +2106,19 @@ Purpose: WALLET_VERIFICATION`;
 
       // Create and start a competition
       const compName = `Enhanced Metrics Test ${Date.now()}`;
-      const createCompResult = await adminClient.createCompetition(
-        compName,
-        "Test competition for enhanced metrics",
-      );
+      const createCompResult = await adminClient.createCompetition({
+        name: compName,
+        description: "Test competition for enhanced metrics",
+      });
       expect(createCompResult.success).toBe(true);
       const createCompResponse = createCompResult as CreateCompetitionResponse;
       const competitionId = createCompResponse.competition.id;
 
       // Start the competition with both agents
-      await adminClient.startExistingCompetition(competitionId, [
-        agent1.id,
-        agent2.id,
-      ]);
+      await adminClient.startExistingCompetition({
+        competitionId,
+        agentIds: [agent1.id, agent2.id],
+      });
 
       // Execute some trades for agent1 to generate metrics
       await agentClient1.executeTrade({
@@ -2181,24 +2193,27 @@ Purpose: WALLET_VERIFICATION`;
       const comp1Name = `Competition A ${Date.now()}`;
       const comp2Name = `Competition B ${Date.now()}`;
 
-      const createComp1Result = await adminClient.createCompetition(
-        comp1Name,
-        "First competition for sorting test",
-      );
+      const createComp1Result = await adminClient.createCompetition({
+        name: comp1Name,
+        description: "First competition for sorting test",
+      });
       expect(createComp1Result.success).toBe(true);
       const comp1Id = (createComp1Result as CreateCompetitionResponse)
         .competition.id;
 
-      const createComp2Result = await adminClient.createCompetition(
-        comp2Name,
-        "Second competition for sorting test",
-      );
+      const createComp2Result = await adminClient.createCompetition({
+        name: comp2Name,
+        description: "Second competition for sorting test",
+      });
       expect(createComp2Result.success).toBe(true);
       const comp2Id = (createComp2Result as CreateCompetitionResponse)
         .competition.id;
 
       // Start comp1 first (respecting single active competition constraint)
-      await adminClient.startExistingCompetition(comp1Id, [agent.id]);
+      await adminClient.startExistingCompetition({
+        competitionId: comp1Id,
+        agentIds: [agent.id],
+      });
 
       // Execute different numbers of trades in each competition
       // Competition 1: 1 trade
@@ -2211,7 +2226,10 @@ Purpose: WALLET_VERIFICATION`;
 
       // End comp1 and start comp2 (respecting single active competition constraint)
       await adminClient.endCompetition(comp1Id);
-      await adminClient.startExistingCompetition(comp2Id, [agent.id]);
+      await adminClient.startExistingCompetition({
+        competitionId: comp2Id,
+        agentIds: [agent.id],
+      });
       await agentClient.executeTrade({
         fromToken: config.specificChainTokens.eth.usdc,
         toToken: config.specificChainTokens.eth.eth,
@@ -2302,16 +2320,19 @@ Purpose: WALLET_VERIFICATION`;
 
       // Create a competition but don't execute any trades
       const compName = `No Trades Competition ${Date.now()}`;
-      const createCompResult = await adminClient.createCompetition(
-        compName,
-        "Competition with no trades for edge case testing",
-      );
+      const createCompResult = await adminClient.createCompetition({
+        name: compName,
+        description: "Competition with no trades for edge case testing",
+      });
       expect(createCompResult.success).toBe(true);
       const competitionId = (createCompResult as CreateCompetitionResponse)
         .competition.id;
 
       // Start the competition with just this agent
-      await adminClient.startExistingCompetition(competitionId, [agent.id]);
+      await adminClient.startExistingCompetition({
+        competitionId,
+        agentIds: [agent.id],
+      });
 
       // Get competitions without any trades or portfolio snapshots
       const competitionsResponse = await agentClient.getAgentCompetitions(
@@ -2449,19 +2470,19 @@ Purpose: WALLET_VERIFICATION`;
 
       // Create a competition with all 4 agents
       const compName = `Multi-Agent Ranking Test ${Date.now()}`;
-      const createCompResult = await adminClient.createCompetition(
-        compName,
-        "Competition for testing multi-agent ranking accuracy",
-      );
+      const createCompResult = await adminClient.createCompetition({
+        name: compName,
+        description: "Competition for testing multi-agent ranking accuracy",
+      });
       expect(createCompResult.success).toBe(true);
       const competitionId = (createCompResult as CreateCompetitionResponse)
         .competition.id;
 
       // Start competition with all agents
-      await adminClient.startExistingCompetition(
+      await adminClient.startExistingCompetition({
         competitionId,
-        agents.map((agent) => agent.id),
-      );
+        agentIds: agents.map((agent) => agent.id),
+      });
 
       // Execute different trading strategies to create distinct performance levels
       // Agent 1: Top performer (keeps valuable assets - ETH)
@@ -2614,20 +2635,20 @@ Purpose: WALLET_VERIFICATION`;
 
       for (let i = 1; i <= 3; i++) {
         const compName = `Cross-Competition Test ${i} ${Date.now()}`;
-        const createCompResult = await adminClient.createCompetition(
-          compName,
-          `Competition ${i} for cross-competition testing`,
-        );
+        const createCompResult = await adminClient.createCompetition({
+          name: compName,
+          description: `Competition ${i} for cross-competition testing`,
+        });
         expect(createCompResult.success).toBe(true);
         const competitionId = (createCompResult as CreateCompetitionResponse)
           .competition.id;
         competitions.push(competitionId);
 
         // Start this competition with both agents
-        await adminClient.startExistingCompetition(competitionId, [
-          agent1.id,
-          agent2.id,
-        ]);
+        await adminClient.startExistingCompetition({
+          competitionId,
+          agentIds: [agent1.id, agent2.id],
+        });
 
         // Execute trades in this competition with different patterns
         // Agent 1: Escalating strategy (1, 2, 3 trades respectively)
@@ -2823,20 +2844,20 @@ Purpose: WALLET_VERIFICATION`;
 
       // Create a competition with all 3 agents
       const compName = `Active-Disqualified Ranking Test ${Date.now()}`;
-      const createCompResult = await adminClient.createCompetition(
-        compName,
-        "Competition for testing active vs disqualified agent ranking behavior",
-      );
+      const createCompResult = await adminClient.createCompetition({
+        name: compName,
+        description:
+          "Competition for testing active vs disqualified agent ranking behavior",
+      });
       expect(createCompResult.success).toBe(true);
       const competitionId = (createCompResult as CreateCompetitionResponse)
         .competition.id;
 
       // Start competition with all agents
-      await adminClient.startExistingCompetition(competitionId, [
-        agent1.id,
-        agent2.id,
-        agent3.id,
-      ]);
+      await adminClient.startExistingCompetition({
+        competitionId,
+        agentIds: [agent1.id, agent2.id, agent3.id],
+      });
 
       // Execute trades to create different performance levels
       // Agent 1: Good performance (buys ETH)

--- a/apps/api/e2e/tests/auto-end-competition.test.ts
+++ b/apps/api/e2e/tests/auto-end-competition.test.ts
@@ -36,28 +36,22 @@ describe("Competition End Date Processing", () => {
     const competitionName = `Auto End Competition ${Date.now()}`;
     const endDate = new Date(Date.now() + 5000); // 5 seconds from now
 
-    const createResponse = await adminClient.createCompetition(
-      competitionName,
-      "Competition that should auto-end",
-      undefined, // tradingType
-      false, // sandboxMode
-      undefined, // externalUrl
-      undefined, // imageUrl
-      undefined, // type
-      endDate.toISOString(), // endDate
-      undefined, // votingStartDate
-      undefined, // votingEndDate
-    );
+    const createResponse = await adminClient.createCompetition({
+      name: competitionName,
+      description: "Competition that should auto-end",
+      sandboxMode: false,
+      endDate: endDate.toISOString(),
+    });
 
     expect(createResponse.success).toBe(true);
     const competition = (createResponse as CreateCompetitionResponse)
       .competition;
 
     // Start the competition
-    const startResponse = await adminClient.startExistingCompetition(
-      competition.id,
-      [agent.id],
-    );
+    const startResponse = await adminClient.startExistingCompetition({
+      competitionId: competition.id,
+      agentIds: [agent.id],
+    });
     expect(startResponse.success).toBe(true);
 
     // Verify competition is active
@@ -100,28 +94,22 @@ describe("Competition End Date Processing", () => {
     const endDate = new Date(Date.now() + 30000); // 30 seconds from now
     const competitionName = `Future End Competition ${Date.now()}`;
 
-    const createResponse = await adminClient.createCompetition(
-      competitionName,
-      "Competition that should not auto-end yet",
-      undefined, // tradingType
-      false, // sandboxMode
-      undefined, // externalUrl
-      undefined, // imageUrl
-      undefined, // type
-      endDate.toISOString(), // endDate
-      undefined, // votingStartDate
-      undefined, // votingEndDate
-    );
+    const createResponse = await adminClient.createCompetition({
+      name: competitionName,
+      description: "Competition that should not auto-end yet",
+      sandboxMode: false,
+      endDate: endDate.toISOString(),
+    });
 
     expect(createResponse.success).toBe(true);
     const competition = (createResponse as CreateCompetitionResponse)
       .competition;
 
     // Start the competition
-    const startResponse = await adminClient.startExistingCompetition(
-      competition.id,
-      [agent.id],
-    );
+    const startResponse = await adminClient.startExistingCompetition({
+      competitionId: competition.id,
+      agentIds: [agent.id],
+    });
     expect(startResponse.success).toBe(true);
 
     // Verify competition is active

--- a/apps/api/e2e/tests/base-trades.test.ts
+++ b/apps/api/e2e/tests/base-trades.test.ts
@@ -61,16 +61,13 @@ describe("Base Chain Trading", () => {
 
     // Start a competition with our agent
     const competitionName = `Base Trading Test ${Date.now()}`;
-    await startTestCompetition(
+    await startTestCompetition({
       adminClient,
-      competitionName,
-      [agent.id],
-      undefined, // sandboxMode
-      undefined, // externalUrl
-      undefined, // imageUrl
+      name: competitionName,
+      agentIds: [agent.id],
       // disable trading constraints for testing base chain functionality
-      noTradingConstraints,
-    );
+      tradingConstraints: noTradingConstraints,
+    });
 
     // Wait for balances to be properly initialized
     await wait(500);
@@ -225,7 +222,11 @@ describe("Base Chain Trading", () => {
 
     // Start a competition with our agent
     const competitionName = `Cross-Chain Restriction Test ${Date.now()}`;
-    await startTestCompetition(adminClient, competitionName, [agent.id]);
+    await startTestCompetition({
+      adminClient,
+      name: competitionName,
+      agentIds: [agent.id],
+    });
 
     // Wait for balances to be properly initialized
     await wait(500);
@@ -345,16 +346,13 @@ describe("Base Chain Trading", () => {
 
     // Start a competition with our agent
     const competitionName = `Spending Limit Test ${Date.now()}`;
-    await startTestCompetition(
+    await startTestCompetition({
       adminClient,
-      competitionName,
-      [agent.id],
-      undefined, // sandboxMode
-      undefined, // externalUrl
-      undefined, // imageUrl
+      name: competitionName,
+      agentIds: [agent.id],
       // disable trading constraints for testing base chain functionality
-      noTradingConstraints,
-    );
+      tradingConstraints: noTradingConstraints,
+    });
 
     // Wait for balances to be properly initialized
     await wait(500);

--- a/apps/api/e2e/tests/chain-specific.test.ts
+++ b/apps/api/e2e/tests/chain-specific.test.ts
@@ -43,7 +43,11 @@ describe("Specific Chains", () => {
 
     // Start a competition with the agent
     const competitionName = `Specific Chain Test ${Date.now()}`;
-    await startTestCompetition(adminClient, competitionName, [agent.id]);
+    await startTestCompetition({
+      adminClient,
+      name: competitionName,
+      agentIds: [agent.id],
+    });
 
     // Use the agent client API to get balances instead of direct DB query
     const balancesResponse = (await client.getBalance()) as BalancesResponse;
@@ -99,7 +103,11 @@ describe("Specific Chains", () => {
 
     // Start a competition with the agent
     const competitionName = `Trade Chain Test ${Date.now()}`;
-    await startTestCompetition(adminClient, competitionName, [agent.id]);
+    await startTestCompetition({
+      adminClient,
+      name: competitionName,
+      agentIds: [agent.id],
+    });
 
     // Get agent's current balances
     const balanceResponse = (await client.getBalance()) as BalancesResponse;
@@ -176,15 +184,12 @@ describe("Specific Chains", () => {
 
     // Start a competition with the agent
     const competitionName = `Token Purchase Test ${Date.now()}`;
-    await startTestCompetition(
+    await startTestCompetition({
       adminClient,
-      competitionName,
-      [agent.id],
-      undefined,
-      undefined,
-      undefined,
-      noTradingConstraints,
-    );
+      name: competitionName,
+      agentIds: [agent.id],
+      tradingConstraints: noTradingConstraints,
+    });
 
     // Get agent's current balances
     const balanceResponse = (await client.getBalance()) as BalancesResponse;
@@ -336,7 +341,11 @@ describe("Specific Chains", () => {
 
     // Start a competition with the agent
     const competitionName = `Token Purchase Test ${Date.now()}`;
-    await startTestCompetition(adminClient, competitionName, [agent.id]);
+    await startTestCompetition({
+      adminClient,
+      name: competitionName,
+      agentIds: [agent.id],
+    });
 
     // Track successfully purchased tokens
     const purchasedTokens: string[] = [];
@@ -440,22 +449,14 @@ describe("Specific Chains", () => {
 
     // Start a competition with the agent
     const competitionName = `Token Purchase Test ${Date.now()}`;
-    await startTestCompetition(
+    await startTestCompetition({
       adminClient,
-      competitionName,
-      [agent.id],
-      undefined,
-      undefined,
-      undefined,
+      name: competitionName,
+      agentIds: [agent.id],
       // This test fails sometimes because of constraint validation. skipping
       // so that the actual test path always runs.
-      {
-        minimum24hVolumeUsd: 0,
-        minimumFdvUsd: 0,
-        minimumLiquidityUsd: 0,
-        minimumPairAgeHours: 0,
-      },
-    );
+      tradingConstraints: noTradingConstraints,
+    });
 
     // Get agent's current balances
     const balanceResponse = (await client.getBalance()) as BalancesResponse;

--- a/apps/api/e2e/tests/competition-timeline.test.ts
+++ b/apps/api/e2e/tests/competition-timeline.test.ts
@@ -45,11 +45,11 @@ describe("Competition Timeline API", () => {
 
     // Start a competition
     const competitionName = `Timeline Test Competition ${Date.now()}`;
-    const competitionResponse = await startTestCompetition(
+    const competitionResponse = await startTestCompetition({
       adminClient,
-      competitionName,
-      [agent1.id, agent2.id],
-    );
+      name: competitionName,
+      agentIds: [agent1.id, agent2.id],
+    });
 
     // Verify competition was started
     const competition = competitionResponse.competition;
@@ -144,11 +144,11 @@ describe("Competition Timeline API", () => {
 
     // Start a competition
     const competitionName = `Public Timeline Test Competition ${Date.now()}`;
-    const competitionResponse = await startTestCompetition(
+    const competitionResponse = await startTestCompetition({
       adminClient,
-      competitionName,
-      [agent1.id, agent2.id],
-    );
+      name: competitionName,
+      agentIds: [agent1.id, agent2.id],
+    });
 
     // Test: Direct axios call without authentication
     const response = await axios.get(
@@ -256,11 +256,11 @@ describe("Competition Timeline API", () => {
 
     // Start a competition
     const competitionName = `Timeline Test Competition ${Date.now()}`;
-    const competitionResponse = await startTestCompetition(
+    const competitionResponse = await startTestCompetition({
       adminClient,
-      competitionName,
-      [agent1.id, agent2.id],
-    );
+      name: competitionName,
+      agentIds: [agent1.id, agent2.id],
+    });
 
     // Verify competition was started
     const competition = competitionResponse.competition;

--- a/apps/api/e2e/tests/deactivate.test.ts
+++ b/apps/api/e2e/tests/deactivate.test.ts
@@ -41,7 +41,11 @@ describe("Agent Deactivation API", () => {
     });
 
     const competitionName = `Test Competition ${Date.now()}`;
-    await startTestCompetition(adminClient, competitionName, [agent.id]);
+    await startTestCompetition({
+      adminClient,
+      name: competitionName,
+      agentIds: [agent.id],
+    });
 
     // Deactivate the agent
     const reason = "Violated competition rules by using external API";
@@ -82,7 +86,11 @@ describe("Agent Deactivation API", () => {
 
     // Start a competition with the agent
     const competitionName = `Deactivation Test ${Date.now()}`;
-    await startTestCompetition(adminClient, competitionName, [agent.id]);
+    await startTestCompetition({
+      adminClient,
+      name: competitionName,
+      agentIds: [agent.id],
+    });
 
     // Verify agent can access API before deactivation
     const profileResponse = await client.getAgentProfile();
@@ -151,7 +159,11 @@ describe("Agent Deactivation API", () => {
 
     // Start a competition with the agent
     const competitionName = `Reactivation Test ${Date.now()}`;
-    await startTestCompetition(adminClient, competitionName, [agent.id]);
+    await startTestCompetition({
+      adminClient,
+      name: competitionName,
+      agentIds: [agent.id],
+    });
 
     // Deactivate the agent
     const reason = "Temporary deactivation for testing";
@@ -207,10 +219,11 @@ describe("Agent Deactivation API", () => {
 
     // Start a competition with both agents
     const competitionName = `Non-Admin Test ${Date.now()}`;
-    await startTestCompetition(adminClient, competitionName, [
-      agent1.id,
-      agent2.id,
-    ]);
+    await startTestCompetition({
+      adminClient,
+      name: competitionName,
+      agentIds: [agent1.id, agent2.id],
+    });
 
     // Agent One tries to deactivate Agent Two (should fail)
     const deactivateResponse = (await client1.deactivateAgent(
@@ -254,11 +267,11 @@ describe("Agent Deactivation API", () => {
 
     // Create competition with all three agents
     const competitionName = `Leaderboard Test ${Date.now()}`;
-    const competition = await startTestCompetition(
+    const competition = await startTestCompetition({
       adminClient,
-      competitionName,
-      [agent1.id, agent2.id, agent3.id],
-    );
+      name: competitionName,
+      agentIds: [agent1.id, agent2.id, agent3.id],
+    });
 
     // Make some trades to differentiate portfolio values
     // We'll have Agent 3 (to be deactivated) make some trades to put them on the leaderboard
@@ -416,11 +429,11 @@ describe("Agent Deactivation API", () => {
 
     // Create competition with both agents
     const competitionName = `Ranking Consistency Test ${Date.now()}`;
-    const competition = await startTestCompetition(
+    const competition = await startTestCompetition({
       adminClient,
-      competitionName,
-      [agent1.id, agent2.id],
-    );
+      name: competitionName,
+      agentIds: [agent1.id, agent2.id],
+    });
 
     // Make trades to establish different portfolio values
     const usdcTokenAddress = config.specificChainTokens.svm.usdc;

--- a/apps/api/e2e/tests/leaderboard-access.test.ts
+++ b/apps/api/e2e/tests/leaderboard-access.test.ts
@@ -43,7 +43,11 @@ describe("Leaderboard Access Control", () => {
 
     // Start a competition with the agent
     const competitionName = `Admin Access Test ${Date.now()}`;
-    await startTestCompetition(adminClient, competitionName, [agent.id]);
+    await startTestCompetition({
+      adminClient,
+      name: competitionName,
+      agentIds: [agent.id],
+    });
 
     // Verify the admin can still access the leaderboard
     const adminResponse =

--- a/apps/api/e2e/tests/leaderboard.test.ts
+++ b/apps/api/e2e/tests/leaderboard.test.ts
@@ -292,28 +292,24 @@ describe("Leaderboard API", () => {
     const votingStartDate = new Date(now.getTime() - 60 * 60 * 1000); // 1 hour ago
     const votingEndDate = new Date(now.getTime() + 60 * 60 * 1000); // 1 hour from now
 
-    const createResponse = await adminClient.createCompetition(
-      competitionName,
-      "Test competition for leaderboard votes",
-      "disallowAll",
-      undefined, // sandboxMode
-      undefined, // externalUrl
-      undefined, // imageUrl
-      "trading", // type
-      undefined, // endDate
-      votingStartDate.toISOString(), // votingStartDate
-      votingEndDate.toISOString(), // votingEndDate
-    );
+    const createResponse = await adminClient.createCompetition({
+      name: competitionName,
+      description: "Test competition for leaderboard votes",
+      tradingType: CROSS_CHAIN_TRADING_TYPE.DISALLOW_ALL,
+      type: "trading", // type
+      votingStartDate: votingStartDate.toISOString(),
+      votingEndDate: votingEndDate.toISOString(),
+    });
 
     expect(createResponse.success).toBe(true);
     const competition = (createResponse as CreateCompetitionResponse)
       .competition;
 
     // Start the competition with agents
-    await adminClient.startExistingCompetition(competition.id, [
-      agent1.id,
-      agent2.id,
-    ]);
+    await adminClient.startExistingCompetition({
+      competitionId: competition.id,
+      agentIds: [agent1.id, agent2.id],
+    });
     const firstCompetitionId = competition.id;
 
     // Create 2 users and vote for agent 1 and agent 2, respectively
@@ -336,28 +332,24 @@ describe("Leaderboard API", () => {
 
     // Create second competition with proper voting dates
     const newCompetitionName = `Agents Test Competition ${Date.now()}`;
-    const createResponse2 = await adminClient.createCompetition(
-      newCompetitionName,
-      "Second test competition for leaderboard votes",
-      "disallowAll",
-      undefined, // sandboxMode
-      undefined, // externalUrl
-      undefined, // imageUrl
-      "trading", // type
-      undefined, // endDate
-      votingStartDate.toISOString(), // votingStartDate
-      votingEndDate.toISOString(), // votingEndDate
-    );
+    const createResponse2 = await adminClient.createCompetition({
+      name: newCompetitionName,
+      description: "Second test competition for leaderboard votes",
+      tradingType: CROSS_CHAIN_TRADING_TYPE.DISALLOW_ALL,
+      type: "trading", // type
+      votingStartDate: votingStartDate.toISOString(),
+      votingEndDate: votingEndDate.toISOString(),
+    });
 
     expect(createResponse2.success).toBe(true);
     const competition2 = (createResponse2 as CreateCompetitionResponse)
       .competition;
 
     // Start the second competition with agents
-    await adminClient.startExistingCompetition(competition2.id, [
-      agent1.id,
-      agent2.id,
-    ]);
+    await adminClient.startExistingCompetition({
+      competitionId: competition2.id,
+      agentIds: [agent1.id, agent2.id],
+    });
     const secondCompetitionId = competition2.id;
 
     // Vote for the *same* agent in the second competition
@@ -407,29 +399,23 @@ describe("Leaderboard API", () => {
     const votingStartDate = new Date(now.getTime() - 60 * 60 * 1000); // 1 hour ago
     const votingEndDate = new Date(now.getTime() + 60 * 60 * 1000); // 1 hour from now
 
-    const createResponse1 = await adminClient.createCompetition(
-      competitionName1,
-      "Test competition for sorting",
-      "disallowAll",
-      undefined, // sandboxMode
-      undefined, // externalUrl
-      undefined, // imageUrl
-      "trading", // type
-      undefined, // endDate
-      votingStartDate.toISOString(), // votingStartDate
-      votingEndDate.toISOString(), // votingEndDate
-    );
+    const createResponse1 = await adminClient.createCompetition({
+      name: competitionName1,
+      description: "Test competition for sorting",
+      tradingType: CROSS_CHAIN_TRADING_TYPE.DISALLOW_ALL,
+      votingStartDate: votingStartDate.toISOString(),
+      votingEndDate: votingEndDate.toISOString(),
+    });
 
     expect(createResponse1.success).toBe(true);
     const competition1 = (createResponse1 as CreateCompetitionResponse)
       .competition;
 
     // Start the competition with agents
-    await adminClient.startExistingCompetition(competition1.id, [
-      agent1.id,
-      agent2.id,
-      agent3.id,
-    ]);
+    await adminClient.startExistingCompetition({
+      competitionId: competition1.id,
+      agentIds: [agent1.id, agent2.id, agent3.id],
+    });
 
     // Make different trades to create score differences
     // Agent 1: Best performance (profitable trade)
@@ -489,28 +475,23 @@ describe("Leaderboard API", () => {
 
     // Create second competition with proper voting dates (only agent1 and agent2)
     const competitionName2 = `Sort Test Competition 2 ${Date.now()}`;
-    const createResponse2 = await adminClient.createCompetition(
-      competitionName2,
-      "Second test competition for sorting",
-      "disallowAll",
-      undefined, // sandboxMode
-      undefined, // externalUrl
-      undefined, // imageUrl
-      "trading", // type
-      undefined, // endDate
-      votingStartDate.toISOString(), // votingStartDate
-      votingEndDate.toISOString(), // votingEndDate
-    );
+    const createResponse2 = await adminClient.createCompetition({
+      name: competitionName2,
+      description: "Second test competition for sorting",
+      tradingType: CROSS_CHAIN_TRADING_TYPE.DISALLOW_ALL,
+      votingStartDate: votingStartDate.toISOString(),
+      votingEndDate: votingEndDate.toISOString(),
+    });
 
     expect(createResponse2.success).toBe(true);
     const competition2 = (createResponse2 as CreateCompetitionResponse)
       .competition;
 
     // Start the second competition with only agent1 and agent2
-    await adminClient.startExistingCompetition(competition2.id, [
-      agent1.id,
-      agent2.id,
-    ]);
+    await adminClient.startExistingCompetition({
+      competitionId: competition2.id,
+      agentIds: [agent1.id, agent2.id],
+    });
 
     await agentClient1.executeTrade({
       fromToken: config.specificChainTokens.eth.usdc,

--- a/apps/api/e2e/tests/logging-metrics.test.ts
+++ b/apps/api/e2e/tests/logging-metrics.test.ts
@@ -224,19 +224,19 @@ describe("Logging and Metrics API", () => {
 
     // Step 2: Create and start a competition
     const competitionName = `Logging Test Competition ${Date.now()}`;
-    const createCompResult = await adminClient.createCompetition(
-      competitionName,
-      "Competition to test logging during trading workflow",
-    );
+    const createCompResult = await adminClient.createCompetition({
+      name: competitionName,
+      description: "Competition to test logging during trading workflow",
+    });
     expect(createCompResult.success).toBe(true);
     const createCompResponse = createCompResult as CreateCompetitionResponse;
     const competitionId = createCompResponse.competition.id;
 
     // Start the competition with both agents
-    const startCompResult = await adminClient.startExistingCompetition(
+    const startCompResult = await adminClient.startExistingCompetition({
       competitionId,
-      [agent1.id, agent2.id],
-    );
+      agentIds: [agent1.id, agent2.id],
+    });
     expect(startCompResult.success).toBe(true);
 
     // Step 3: Execute multiple trades to generate logging activity
@@ -445,19 +445,19 @@ describe("Logging and Metrics API", () => {
 
     // Create a competition to trigger even more database operations
     const competitionName = `DB Classification Test Competition ${Date.now()}`;
-    const createCompResult = await client.createCompetition(
-      competitionName,
-      "Competition to test database operation classification",
-    );
+    const createCompResult = await client.createCompetition({
+      name: competitionName,
+      description: "Competition to test database operation classification",
+    });
     expect(createCompResult.success).toBe(true);
     const createCompResponse = createCompResult as CreateCompetitionResponse;
     const competitionId = createCompResponse.competition.id;
 
     // Start the competition with the agent
-    const startCompResult = await client.startExistingCompetition(
+    const startCompResult = await client.startExistingCompetition({
       competitionId,
-      [agent.id],
-    );
+      agentIds: [agent.id],
+    });
     expect(startCompResult.success).toBe(true);
 
     // Execute operations that trigger different types of database operations

--- a/apps/api/e2e/tests/multi-agent-competition.test.ts
+++ b/apps/api/e2e/tests/multi-agent-competition.test.ts
@@ -91,11 +91,11 @@ describe("Multi-Agent Competition", () => {
     const competitionName = `Multi-Agent Competition ${Date.now()}`;
     const agentIds = agentClients.map((tc) => tc.agent.id);
 
-    const competitionResponse = await startTestCompetition(
+    const competitionResponse = await startTestCompetition({
       adminClient,
-      competitionName,
+      name: competitionName,
       agentIds,
-    );
+    });
 
     expect(competitionResponse.success).toBe(true);
     expect(competitionResponse.competition).toBeDefined();
@@ -252,15 +252,12 @@ describe("Multi-Agent Competition", () => {
     const competitionName = `Multi-Agent Token Trading ${Date.now()}`;
     const agentIds = agentClients.map((tc) => tc.agent.id);
 
-    const competitionResponse = await startTestCompetition(
+    const competitionResponse = await startTestCompetition({
       adminClient,
-      competitionName,
+      name: competitionName,
       agentIds,
-      undefined,
-      undefined,
-      undefined,
-      noTradingConstraints,
-    );
+      tradingConstraints: noTradingConstraints,
+    });
 
     expect(competitionResponse.success).toBe(true);
     expect(competitionResponse.competition).toBeDefined();
@@ -401,15 +398,12 @@ describe("Multi-Agent Competition", () => {
     const competitionName = `Portfolio Value Test ${Date.now()}`;
     const agentIds = agentClients.map((tc) => tc.agent.id);
 
-    const competitionResponse = await startTestCompetition(
+    const competitionResponse = await startTestCompetition({
       adminClient,
-      competitionName,
+      name: competitionName,
       agentIds,
-      undefined,
-      undefined,
-      undefined,
-      noTradingConstraints,
-    );
+      tradingConstraints: noTradingConstraints,
+    });
 
     expect(competitionResponse.success).toBe(true);
     expect(competitionResponse.competition).toBeDefined();

--- a/apps/api/e2e/tests/portfolio-snapshots.test.ts
+++ b/apps/api/e2e/tests/portfolio-snapshots.test.ts
@@ -40,11 +40,11 @@ describe("Portfolio Snapshots", () => {
 
     // Start a competition with our agent
     const competitionName = `Snapshot Test ${Date.now()}`;
-    const startResult = await startTestCompetition(
+    const startResult = await startTestCompetition({
       adminClient,
-      competitionName,
-      [agent.id],
-    );
+      name: competitionName,
+      agentIds: [agent.id],
+    });
 
     // Wait for operations to complete
     await wait(500);
@@ -85,11 +85,11 @@ describe("Portfolio Snapshots", () => {
 
     // Start a competition with our agent
     const competitionName = `Periodic Snapshot Test ${Date.now()}`;
-    const startResult = await startTestCompetition(
+    const startResult = await startTestCompetition({
       adminClient,
-      competitionName,
-      [agent.id],
-    );
+      name: competitionName,
+      agentIds: [agent.id],
+    });
 
     // Get the competition ID
     const competitionId = startResult.competition.id;
@@ -155,11 +155,11 @@ describe("Portfolio Snapshots", () => {
 
     // Start a competition with our agent
     const competitionName = `End Snapshot Test ${Date.now()}`;
-    const startResult = await startTestCompetition(
+    const startResult = await startTestCompetition({
       adminClient,
-      competitionName,
-      [agent.id],
-    );
+      name: competitionName,
+      agentIds: [agent.id],
+    });
 
     // Get the competition ID
     const competitionId = startResult.competition.id;
@@ -225,11 +225,11 @@ describe("Portfolio Snapshots", () => {
 
     // Start a competition with our agent
     const competitionName = `Value Calculation Test ${Date.now()}`;
-    const startResult = await startTestCompetition(
+    const startResult = await startTestCompetition({
       adminClient,
-      competitionName,
-      [agent.id],
-    );
+      name: competitionName,
+      agentIds: [agent.id],
+    });
 
     // Get the competition ID
     const competitionId = startResult.competition.id;

--- a/apps/api/e2e/tests/rate-limiter.test.ts
+++ b/apps/api/e2e/tests/rate-limiter.test.ts
@@ -40,10 +40,11 @@ describe("Rate Limiter Middleware", () => {
 
     // Start a competition with both agents
     const competitionName = `Rate Limit Test ${Date.now()}`;
-    await startTestCompetition(adminClient, competitionName, [
-      agent1.id,
-      agent2.id,
-    ]);
+    await startTestCompetition({
+      adminClient,
+      name: competitionName,
+      agentIds: [agent1.id, agent2.id],
+    });
 
     // Wait for competition to initialize
     await wait(500);
@@ -121,7 +122,11 @@ describe("Rate Limiter Middleware", () => {
 
     // Start a competition
     const competitionName = `Endpoint Rate Limit Test ${Date.now()}`;
-    await startTestCompetition(adminClient, competitionName, [agent.id]);
+    await startTestCompetition({
+      adminClient,
+      name: competitionName,
+      agentIds: [agent.id],
+    });
 
     // Wait for competition to initialize
     await wait(500);
@@ -211,7 +216,11 @@ describe("Rate Limiter Middleware", () => {
 
     // Start a competition
     const competitionName = `Headers Rate Limit Test ${Date.now()}`;
-    await startTestCompetition(adminClient, competitionName, [agent.id]);
+    await startTestCompetition({
+      adminClient,
+      name: competitionName,
+      agentIds: [agent.id],
+    });
 
     // Wait for competition to initialize
     await wait(500);

--- a/apps/api/e2e/tests/sandbox-mode.test.ts
+++ b/apps/api/e2e/tests/sandbox-mode.test.ts
@@ -51,12 +51,12 @@ describe("Sandbox Mode", () => {
 
       // Create and start a sandbox competition with the dummy agent
       const competitionName = `Sandbox Test Competition ${Date.now()}`;
-      const competitionResponse = await startTestCompetition(
+      const competitionResponse = await startTestCompetition({
         adminClient,
-        competitionName,
-        [dummyAgent!.id],
-        true, // sandboxMode = true
-      );
+        name: competitionName,
+        agentIds: [dummyAgent!.id],
+        sandboxMode: true,
+      });
       expect(competitionResponse.success).toBe(true);
       const competition = competitionResponse.competition;
       expect(competition.sandboxMode).toBe(true);
@@ -150,12 +150,12 @@ describe("Sandbox Mode", () => {
 
       // Create and start a NON-sandbox competition
       const competitionName = `Non-Sandbox Test Competition ${Date.now()}`;
-      const competitionResponse = await startTestCompetition(
+      const competitionResponse = await startTestCompetition({
         adminClient,
-        competitionName,
-        [dummyAgent!.id],
-        false, // sandboxMode = false
-      );
+        name: competitionName,
+        agentIds: [dummyAgent!.id],
+        sandboxMode: false,
+      });
       expect(competitionResponse.success).toBe(true);
       const competition = competitionResponse.competition;
       expect(competition.sandboxMode).toBe(false);
@@ -275,12 +275,12 @@ describe("Sandbox Mode", () => {
 
       // Create and start a sandbox competition
       const competitionName = `Multi-Agent Sandbox Test ${Date.now()}`;
-      const competitionResponse = await startTestCompetition(
+      const competitionResponse = await startTestCompetition({
         adminClient,
-        competitionName,
-        [dummyAgent!.id],
-        true, // sandboxMode = true
-      );
+        name: competitionName,
+        agentIds: [dummyAgent!.id],
+        sandboxMode: true,
+      });
       expect(competitionResponse.success).toBe(true);
       const competition = competitionResponse.competition;
 
@@ -370,12 +370,12 @@ describe("Sandbox Mode", () => {
 
       // Start a sandbox competition
       const competitionName = `Separate Registration Test ${Date.now()}`;
-      const competitionResponse = await startTestCompetition(
+      const competitionResponse = await startTestCompetition({
         adminClient,
-        competitionName,
-        [dummyAgent!.id],
-        true, // sandboxMode = true
-      );
+        name: competitionName,
+        agentIds: [dummyAgent!.id],
+        sandboxMode: true,
+      });
       expect(competitionResponse.success).toBe(true);
       const competition = competitionResponse.competition;
 
@@ -421,12 +421,12 @@ describe("Sandbox Mode", () => {
 
   test("should create competition with sandboxMode=true", async () => {
     const competitionName = `Sandbox Creation Test ${Date.now()}`;
-    const competitionResponse = await createTestCompetition(
+    const competitionResponse = await createTestCompetition({
       adminClient,
-      competitionName,
-      "Test competition with sandbox mode enabled",
-      true, // sandboxMode = true
-    );
+      name: competitionName,
+      description: "Test competition with sandbox mode enabled",
+      sandboxMode: true,
+    });
 
     expect(competitionResponse.success).toBe(true);
     const competition = competitionResponse.competition;
@@ -437,12 +437,12 @@ describe("Sandbox Mode", () => {
 
   test("should create competition with sandboxMode=false", async () => {
     const competitionName = `Non-Sandbox Creation Test ${Date.now()}`;
-    const competitionResponse = await createTestCompetition(
+    const competitionResponse = await createTestCompetition({
       adminClient,
-      competitionName,
-      "Test competition with sandbox mode disabled",
-      false, // sandboxMode = false
-    );
+      name: competitionName,
+      description: "Test competition with sandbox mode disabled",
+      sandboxMode: false,
+    });
 
     expect(competitionResponse.success).toBe(true);
     const competition = competitionResponse.competition;
@@ -453,11 +453,11 @@ describe("Sandbox Mode", () => {
 
   test("should default sandboxMode to false when not specified", async () => {
     const competitionName = `Default Sandbox Test ${Date.now()}`;
-    const competitionResponse = await createTestCompetition(
+    const competitionResponse = await createTestCompetition({
       adminClient,
-      competitionName,
-      "Test competition with default sandbox mode",
-    );
+      name: competitionName,
+      description: "Test competition with default sandbox mode",
+    });
 
     expect(competitionResponse.success).toBe(true);
     const competition = competitionResponse.competition;
@@ -475,24 +475,23 @@ describe("Sandbox Mode", () => {
 
     // Create a pending competition with sandbox mode
     const competitionName = `Pending Sandbox Start Test ${Date.now()}`;
-    const createResponse = await createTestCompetition(
+    const createResponse = await createTestCompetition({
       adminClient,
-      competitionName,
-      "Test starting pending competition with sandbox mode",
-      true, // sandboxMode = true
-    );
+      name: competitionName,
+      description: "Test starting pending competition with sandbox mode",
+      sandboxMode: true,
+    });
     expect(createResponse.success).toBe(true);
     const pendingCompetition = createResponse.competition;
     expect(pendingCompetition.sandboxMode).toBe(true);
     expect(pendingCompetition.status).toBe("pending");
 
     // Start the competition
-    const startResponse = await adminClient.startExistingCompetition(
-      pendingCompetition.id,
-      [agent1.id, agent2.id],
-      undefined, // crossChainTradingType
-      true, // sandboxMode - should maintain or override the setting
-    );
+    const startResponse = await adminClient.startExistingCompetition({
+      competitionId: pendingCompetition.id,
+      agentIds: [agent1.id, agent2.id],
+      sandboxMode: true, // sandboxMode - should maintain or override the setting,
+    });
     expect(startResponse.success).toBe(true);
     const startedCompetition = (startResponse as StartCompetitionResponse)
       .competition;
@@ -508,12 +507,12 @@ describe("Sandbox Mode", () => {
 
     // Start a sandbox competition with this agent
     const competitionName = `Duplicate Join Test ${Date.now()}`;
-    const competitionResponse = await startTestCompetition(
+    const competitionResponse = await startTestCompetition({
       adminClient,
-      competitionName,
-      [agent.id],
-      true, // sandboxMode = true
-    );
+      name: competitionName,
+      agentIds: [agent.id],
+      sandboxMode: true, // sandboxMode = true
+    });
     expect(competitionResponse.success).toBe(true);
     const competition = competitionResponse.competition;
 
@@ -542,12 +541,12 @@ describe("Sandbox Mode", () => {
 
     // Start first sandbox competition
     const competition1Name = `First Sandbox Competition ${Date.now()}`;
-    const competition1Response = await startTestCompetition(
+    const competition1Response = await startTestCompetition({
       adminClient,
-      competition1Name,
-      [agent1.id],
-      true, // sandboxMode = true
-    );
+      name: competition1Name,
+      agentIds: [agent1.id],
+      sandboxMode: true, // sandboxMode = true
+    });
     expect(competition1Response.success).toBe(true);
     const competition1 = competition1Response.competition;
 
@@ -556,12 +555,12 @@ describe("Sandbox Mode", () => {
 
     // This should fail because only one competition can be active at a time
     try {
-      await startTestCompetition(
+      await startTestCompetition({
         adminClient,
-        competition2Name,
-        [agent2.id],
-        true, // sandboxMode = true
-      );
+        name: competition2Name,
+        agentIds: [agent2.id],
+        sandboxMode: true, // sandboxMode = true
+      });
       // If we get here, the test should fail
       expect(true).toBe(false); // Force failure
     } catch (error) {
@@ -596,12 +595,12 @@ describe("Sandbox Mode", () => {
 
     // Create and start a sandbox competition with the dummy agent
     const competitionName = `Sandbox Test Competition ${Date.now()}`;
-    const competitionResponse = await startTestCompetition(
+    const competitionResponse = await startTestCompetition({
       adminClient,
-      competitionName,
-      [dummyAgent!.id],
-      true, // sandboxMode = true
-    );
+      name: competitionName,
+      agentIds: [dummyAgent!.id],
+      sandboxMode: true, // sandboxMode = true
+    });
     expect(competitionResponse.success).toBe(true);
     const competition = competitionResponse.competition;
     expect(competition.sandboxMode).toBe(true);

--- a/apps/api/e2e/tests/snapshots.test.ts
+++ b/apps/api/e2e/tests/snapshots.test.ts
@@ -49,11 +49,11 @@ describe("get24hSnapshots Repository Function", () => {
 
     // Start a competition with multiple agents
     const competitionName = `Get24hSnapshots Test ${Date.now()}`;
-    const startResult = await startTestCompetition(
+    const startResult = await startTestCompetition({
       adminClient,
-      competitionName,
-      [agent1.id, agent2.id],
-    );
+      name: competitionName,
+      agentIds: [agent1.id, agent2.id],
+    });
 
     const competitionId = startResult.competition.id;
 
@@ -118,11 +118,11 @@ describe("get24hSnapshots Repository Function", () => {
 
     // Start a competition with single agent
     const competitionName = `Single Agent Test ${Date.now()}`;
-    const startResult = await startTestCompetition(
+    const startResult = await startTestCompetition({
       adminClient,
-      competitionName,
-      [agent.id],
-    );
+      name: competitionName,
+      agentIds: [agent.id],
+    });
 
     const competitionId = startResult.competition.id;
 
@@ -176,11 +176,11 @@ describe("get24hSnapshots Repository Function", () => {
 
     // Start a competition with the real agent
     const competitionName = `Non-existent Agent Test ${Date.now()}`;
-    const startResult = await startTestCompetition(
+    const startResult = await startTestCompetition({
       adminClient,
-      competitionName,
-      [agent.id],
-    );
+      name: competitionName,
+      agentIds: [agent.id],
+    });
 
     const competitionId = startResult.competition.id;
 
@@ -213,11 +213,11 @@ describe("get24hSnapshots Repository Function", () => {
 
     // Start a competition with the real agent
     const competitionName = `Mixed Agent Test ${Date.now()}`;
-    const startResult = await startTestCompetition(
+    const startResult = await startTestCompetition({
       adminClient,
-      competitionName,
-      [agent.id],
-    );
+      name: competitionName,
+      agentIds: [agent.id],
+    });
 
     const competitionId = startResult.competition.id;
 
@@ -269,11 +269,11 @@ describe("get24hSnapshots Repository Function", () => {
 
     // Start a competition
     const competitionName = `Consistency Test ${Date.now()}`;
-    const startResult = await startTestCompetition(
+    const startResult = await startTestCompetition({
       adminClient,
-      competitionName,
-      [agent.id],
-    );
+      name: competitionName,
+      agentIds: [agent.id],
+    });
 
     const competitionId = startResult.competition.id;
 

--- a/apps/api/e2e/tests/trading.test.ts
+++ b/apps/api/e2e/tests/trading.test.ts
@@ -204,7 +204,11 @@ describe("Trading API", () => {
 
     // Start a competition with our agent
     const competitionName = `Arbitrary Token Test ${Date.now()}`;
-    await startTestCompetition(adminClient, competitionName, [agent.id]);
+    await startTestCompetition({
+      adminClient,
+      name: competitionName,
+      agentIds: [agent.id],
+    });
 
     // Check initial balance
     const initialBalanceResponse = await agentClient.getBalance();
@@ -301,11 +305,11 @@ describe("Trading API", () => {
       });
 
     // Start a competition with our agent
-    await startTestCompetition(
+    await startTestCompetition({
       adminClient,
-      `Invalid Trading Test ${Date.now()}`,
-      [agent.id],
-    );
+      name: `Invalid Trading Test ${Date.now()}`,
+      agentIds: [agent.id],
+    });
 
     // Check initial balance
     const initialBalanceResponse = await agentClient.getBalance();
@@ -422,11 +426,11 @@ describe("Trading API", () => {
       });
 
     // Start a competition with our agent
-    await startTestCompetition(
+    await startTestCompetition({
       adminClient,
-      `Max Trade Limit Test ${Date.now()}`,
-      [agent.id],
-    );
+      name: `Max Trade Limit Test ${Date.now()}`,
+      agentIds: [agent.id],
+    });
 
     // Check initial balance
     const initialBalanceResponse =
@@ -511,15 +515,15 @@ describe("Trading API", () => {
 
     // Start a competition with our agent
     const competitionName = `Price Calculation Test ${Date.now()}`;
-    await startTestCompetition(
+    await startTestCompetition({
       adminClient,
-      competitionName,
-      [agent.id],
-      undefined,
-      undefined,
-      undefined,
-      { ...looseTradingConstraints, minimumLiquidityUsd: 500 },
-    );
+      name: competitionName,
+      agentIds: [agent.id],
+      tradingConstraints: {
+        ...looseTradingConstraints,
+        minimumLiquidityUsd: 500,
+      },
+    });
 
     // Check initial balance
     const initialBalanceResponse = await agentClient.getBalance();
@@ -721,7 +725,11 @@ describe("Trading API", () => {
 
     // Start a competition with our agent
     const competitionName = `Chain-Specific Trading Test ${Date.now()}`;
-    await startTestCompetition(adminClient, competitionName, [agent.id]);
+    await startTestCompetition({
+      adminClient,
+      name: competitionName,
+      agentIds: [agent.id],
+    });
 
     // Check initial balance
     const initialBalanceResponse = await agentClient.getBalance();
@@ -835,7 +843,11 @@ describe("Trading API", () => {
 
     // Start a competition with our agent
     const competitionName = `Reason Verification Test ${Date.now()}`;
-    await startTestCompetition(adminClient, competitionName, [agent.id]);
+    await startTestCompetition({
+      adminClient,
+      name: competitionName,
+      agentIds: [agent.id],
+    });
 
     // Get tokens to trade
     const usdcTokenAddress = config.specificChainTokens.svm.usdc;
@@ -899,7 +911,11 @@ describe("Trading API", () => {
 
     // Start a competition with our agent
     const competitionName = `Reason Required Test ${Date.now()}`;
-    await startTestCompetition(adminClient, competitionName, [agent.id]);
+    await startTestCompetition({
+      adminClient,
+      name: competitionName,
+      agentIds: [agent.id],
+    });
 
     // Get tokens to trade
     const usdcTokenAddress = config.specificChainTokens.svm.usdc;
@@ -1261,11 +1277,11 @@ describe("Trading API", () => {
 
     // Start a competition with our agent
     const competitionName = `Reason Required Test ${Date.now()}`;
-    const competition = await startTestCompetition(
+    const competition = await startTestCompetition({
       adminClient,
-      competitionName,
-      [agent.id],
-    );
+      name: competitionName,
+      agentIds: [agent.id],
+    });
 
     const smallValue = 2.938e-27;
 
@@ -1319,7 +1335,11 @@ describe("Trading API", () => {
 
     // Start a competition with our agent
     const competitionName = `USD Amount Test ${Date.now()}`;
-    await startTestCompetition(adminClient, competitionName, [agent.id]);
+    await startTestCompetition({
+      adminClient,
+      name: competitionName,
+      agentIds: [agent.id],
+    });
 
     // Get tokens to trade
     const usdcTokenAddress = config.specificChainTokens.svm.usdc;
@@ -1414,7 +1434,11 @@ describe("Trading API", () => {
 
     // Start a competition with our agent
     const competitionName = `Symbol Verification Test ${Date.now()}`;
-    await startTestCompetition(adminClient, competitionName, [agent.id]);
+    await startTestCompetition({
+      adminClient,
+      name: competitionName,
+      agentIds: [agent.id],
+    });
 
     // Get tokens to trade - use tokens we know have symbols
     const usdcTokenAddress = config.specificChainTokens.svm.usdc;

--- a/apps/api/e2e/tests/user.test.ts
+++ b/apps/api/e2e/tests/user.test.ts
@@ -23,6 +23,7 @@ import {
   createTestCompetition,
   generateTestCompetitions,
   getAdminApiKey,
+  noTradingConstraints,
   registerUserAndAgentAndGetClient,
   startExistingTestCompetition,
   wait,
@@ -1412,10 +1413,10 @@ describe("User API", () => {
 
       // Create 3 competitions where both agents participate
       for (let i = 0; i < 3; i++) {
-        const createResponse = await adminClient.createCompetition(
-          `Multi-Agent Pagination Competition ${i}`,
-          `Competition ${i} with multiple agents from same user`,
-        );
+        const createResponse = await adminClient.createCompetition({
+          name: `Multi-Agent Pagination Competition ${i}`,
+          description: `Competition ${i} with multiple agents from same user`,
+        });
         expect(createResponse.success).toBe(true);
         const createCompResponse = createResponse as CreateCompetitionResponse;
 
@@ -1476,10 +1477,10 @@ describe("User API", () => {
 
       // Create exactly 5 competitions
       for (let i = 0; i < 5; i++) {
-        const createResponse = await adminClient.createCompetition(
-          `HasMore Competition ${i}`,
-          `Competition ${i} for hasMore testing`,
-        );
+        const createResponse = await adminClient.createCompetition({
+          name: `HasMore Competition ${i}`,
+          description: `Competition ${i} for hasMore testing`,
+        });
         expect(createResponse.success).toBe(true);
         const createCompResponse = createResponse as CreateCompetitionResponse;
         await userClient.joinCompetition(
@@ -1537,10 +1538,10 @@ describe("User API", () => {
       await adminClient.loginAsAdmin(adminApiKey);
 
       for (let i = 0; i < 2; i++) {
-        const createResponse = await adminClient.createCompetition(
-          `Edge Test Competition ${i}`,
-          `Competition ${i} for edge testing`,
-        );
+        const createResponse = await adminClient.createCompetition({
+          name: `Edge Test Competition ${i}`,
+          description: `Competition ${i} for edge testing`,
+        });
         expect(createResponse.success).toBe(true);
         const createCompResponse = createResponse as CreateCompetitionResponse;
         await userClient.joinCompetition(
@@ -1587,10 +1588,10 @@ describe("User API", () => {
       const secondComp = "Beta Competition";
       const thirdComp = "Charlie Competition";
 
-      const create1Response = await adminClient.createCompetition(
-        firstComp,
-        `Description for ${firstComp}`,
-      );
+      const create1Response = await adminClient.createCompetition({
+        name: firstComp,
+        description: `Description for ${firstComp}`,
+      });
       expect(create1Response.success).toBe(true);
       const competitionIdForFirstComp = (
         create1Response as CreateCompetitionResponse
@@ -1598,20 +1599,20 @@ describe("User API", () => {
       await userClient.joinCompetition(competitionIdForFirstComp, agent.id);
       await wait(50);
 
-      const create2Response = await adminClient.createCompetition(
-        secondComp,
-        `Description for ${secondComp}`,
-      );
+      const create2Response = await adminClient.createCompetition({
+        name: secondComp,
+        description: `Description for ${secondComp}`,
+      });
       expect(create2Response.success).toBe(true);
       const createCompResponse2 = create2Response as CreateCompetitionResponse;
       const competitionIdForSecondComp = createCompResponse2.competition.id;
       await userClient.joinCompetition(competitionIdForSecondComp, agent.id);
       await wait(50);
 
-      const create3Response = await adminClient.createCompetition(
-        thirdComp,
-        `Description for ${thirdComp}`,
-      );
+      const create3Response = await adminClient.createCompetition({
+        name: thirdComp,
+        description: `Description for ${thirdComp}`,
+      });
       expect(create3Response.success).toBe(true);
       const competitionIdForThirdComp = (
         create3Response as CreateCompetitionResponse
@@ -1620,19 +1621,19 @@ describe("User API", () => {
       await wait(50);
 
       // Start/end the first competition, start/end the second competition, and keep the third pending
-      const startCompResponse = await adminClient.startExistingCompetition(
-        competitionIdForFirstComp,
-        [agent.id],
-      );
+      const startCompResponse = await adminClient.startExistingCompetition({
+        competitionId: competitionIdForFirstComp,
+        agentIds: [agent.id],
+      });
       expect(startCompResponse.success).toBe(true);
       const endCompResponse = await adminClient.endCompetition(
         competitionIdForFirstComp,
       );
       expect(endCompResponse.success).toBe(true);
-      const startCompResponse2 = await adminClient.startExistingCompetition(
-        competitionIdForSecondComp,
-        [agent.id],
-      );
+      const startCompResponse2 = await adminClient.startExistingCompetition({
+        competitionId: competitionIdForSecondComp,
+        agentIds: [agent.id],
+      });
       expect(startCompResponse2.success).toBe(true);
 
       // Test name ascending sort (should work)
@@ -1712,10 +1713,10 @@ describe("User API", () => {
       ];
 
       for (const name of competitionNames) {
-        const createResponse = await adminClient.createCompetition(
+        const createResponse = await adminClient.createCompetition({
           name,
-          `Description for ${name}`,
-        );
+          description: `Description for ${name}`,
+        });
         expect(createResponse.success).toBe(true);
         const createCompResponse = createResponse as CreateCompetitionResponse;
         await userClient.joinCompetition(
@@ -1801,10 +1802,10 @@ describe("User API", () => {
       ];
 
       for (const comp of competitionData) {
-        const createResponse = await adminClient.createCompetition(
-          comp.name,
-          `Description for ${comp.name}`,
-        );
+        const createResponse = await adminClient.createCompetition({
+          name: comp.name,
+          description: `Description for ${comp.name}`,
+        });
         expect(createResponse.success).toBe(true);
         const createCompResponse = createResponse as CreateCompetitionResponse;
         await userClient.joinCompetition(
@@ -1872,10 +1873,10 @@ describe("User API", () => {
       // Create competitions and have different agents join different competitions
       const competitions = [];
       for (let i = 0; i < 3; i++) {
-        const createResponse = await adminClient.createCompetition(
-          `AgentName Sort Competition ${i}`,
-          `Competition ${i} for agentName sorting`,
-        );
+        const createResponse = await adminClient.createCompetition({
+          name: `AgentName Sort Competition ${i}`,
+          description: `Competition ${i} for agentName sorting`,
+        });
         expect(createResponse.success).toBe(true);
         const competition = (createResponse as CreateCompetitionResponse)
           .competition;
@@ -1957,17 +1958,17 @@ describe("User API", () => {
       const agent3 = (agent3Response as AgentProfileResponse).agent;
 
       // Create two competitions
-      const comp1Response = await adminClient.createCompetition(
-        "Multi-Agent Competition 1",
-        "Competition with Charlie and Alpha agents",
-      );
+      const comp1Response = await adminClient.createCompetition({
+        name: "Multi-Agent Competition 1",
+        description: "Competition with Charlie and Alpha agents",
+      });
       expect(comp1Response.success).toBe(true);
       const comp1 = (comp1Response as CreateCompetitionResponse).competition;
 
-      const comp2Response = await adminClient.createCompetition(
-        "Multi-Agent Competition 2",
-        "Competition with Beta and Charlie agents",
-      );
+      const comp2Response = await adminClient.createCompetition({
+        name: "Multi-Agent Competition 2",
+        description: "Competition with Beta and Charlie agents",
+      });
       expect(comp2Response.success).toBe(true);
       const comp2 = (comp2Response as CreateCompetitionResponse).competition;
 
@@ -2036,18 +2037,18 @@ describe("User API", () => {
       }
 
       // Create two competitions with different ranking scenarios
-      const comp1Response = await createTestCompetition(
+      const comp1Response = await createTestCompetition({
         adminClient,
-        "Multi-Agent Competition",
-        "Competition with multiple agents for ranking",
-      );
+        name: "Multi-Agent Competition",
+        description: "Competition with multiple agents for ranking",
+      });
       const comp1 = comp1Response.competition;
 
-      const comp2Response = await createTestCompetition(
+      const comp2Response = await createTestCompetition({
         adminClient,
-        "Single Agent Competition",
-        "Competition with single agent",
-      );
+        name: "Single Agent Competition",
+        description: "Competition with single agent",
+      });
       const comp2 = comp2Response.competition;
 
       // Join competitions
@@ -2057,11 +2058,11 @@ describe("User API", () => {
       await userClient.joinCompetition(comp2.id, agents[0]!.id); // Will be rank 1 (only agent)
 
       // Start first competition and create ranking differences using established patterns
-      await startExistingTestCompetition(adminClient, comp1.id, [
-        agents[0]!.id,
-        agents[1]!.id,
-        agents[2]!.id,
-      ]);
+      await startExistingTestCompetition({
+        adminClient,
+        competitionId: comp1.id,
+        agentIds: [agents[0]!.id, agents[1]!.id, agents[2]!.id],
+      });
 
       // Create ranking differences using the established burn address pattern
       // Agent 1: Small profitable trade (best rank)
@@ -2093,9 +2094,11 @@ describe("User API", () => {
 
       // End first competition and start second
       await adminClient.endCompetition(comp1.id);
-      await startExistingTestCompetition(adminClient, comp2.id, [
-        agents[0]!.id,
-      ]);
+      await startExistingTestCompetition({
+        adminClient,
+        competitionId: comp2.id,
+        agentIds: [agents[0]!.id],
+      });
 
       // Wait for portfolio snapshots to be created
       await wait(2000);
@@ -2165,18 +2168,18 @@ describe("User API", () => {
       const agent = (agentResponse as AgentProfileResponse).agent;
 
       // Create one started competition (will have rank) and one unstarted (no rank)
-      const startedCompResponse = await createTestCompetition(
+      const startedCompResponse = await createTestCompetition({
         adminClient,
-        "Started Competition",
-        "Competition that will be started",
-      );
+        name: "Started Competition",
+        description: "Competition that will be started",
+      });
       const startedComp = startedCompResponse.competition;
 
-      const unstartedCompResponse = await createTestCompetition(
+      const unstartedCompResponse = await createTestCompetition({
         adminClient,
-        "Unstarted Competition",
-        "Competition that will not be started",
-      );
+        name: "Unstarted Competition",
+        description: "Competition that will not be started",
+      });
       const unstartedComp = unstartedCompResponse.competition;
 
       // Join both competitions
@@ -2184,9 +2187,11 @@ describe("User API", () => {
       await userClient.joinCompetition(unstartedComp.id, agent.id);
 
       // Start only one competition
-      await startExistingTestCompetition(adminClient, startedComp.id, [
-        agent.id,
-      ]);
+      await startExistingTestCompetition({
+        adminClient,
+        competitionId: startedComp.id,
+        agentIds: [agent.id],
+      });
       await wait(1000);
 
       // Test rank ascending sort - competitions with undefined ranks should go to end
@@ -2270,10 +2275,10 @@ describe("User API", () => {
 
       // Create competitions with same agent names but different creation times
       for (let i = 0; i < 3; i++) {
-        const createResponse = await adminClient.createCompetition(
-          `Combined Sort Competition ${i}`,
-          `Competition ${i} for combined sort testing`,
-        );
+        const createResponse = await adminClient.createCompetition({
+          name: `Combined Sort Competition ${i}`,
+          description: `Competition ${i} for combined sort testing`,
+        });
         expect(createResponse.success).toBe(true);
         const competition = (createResponse as CreateCompetitionResponse)
           .competition;
@@ -2332,10 +2337,10 @@ describe("User API", () => {
 
       // Create 5 competitions, each with a different agent
       for (let i = 0; i < 5; i++) {
-        const createResponse = await adminClient.createCompetition(
-          `AgentName Pagination Competition ${i}`,
-          `Competition ${i} for agentName pagination testing`,
-        );
+        const createResponse = await adminClient.createCompetition({
+          name: `AgentName Pagination Competition ${i}`,
+          description: `Competition ${i} for agentName pagination testing`,
+        });
         expect(createResponse.success).toBe(true);
         const competition = (createResponse as CreateCompetitionResponse)
           .competition;
@@ -2444,18 +2449,20 @@ describe("User API", () => {
 
       // Create started competitions with different performance levels
       for (let i = 0; i < 2; i++) {
-        const createResponse = await createTestCompetition(
+        const createResponse = await createTestCompetition({
           adminClient,
-          `Started Rank Competition ${i}`,
-          `Started competition ${i} for rank testing`,
-        );
+          name: `Started Rank Competition ${i}`,
+          description: `Started competition ${i} for rank testing`,
+        });
         const competition = createResponse.competition;
         competitions.push(competition);
 
         await userClient.joinCompetition(competition.id, agents[i]!.id);
-        await startExistingTestCompetition(adminClient, competition.id, [
-          agents[i]!.id,
-        ]);
+        await startExistingTestCompetition({
+          adminClient,
+          competitionId: competition.id,
+          agentIds: [agents[i]!.id],
+        });
 
         // Create different performance levels using established burn address pattern
         const agentClient = adminClient.createAgentClient(agents[i]!.apiKey!);
@@ -2483,11 +2490,11 @@ describe("User API", () => {
 
       // Unstarted competitions
       for (let i = 2; i < 4; i++) {
-        const createResponse = await createTestCompetition(
+        const createResponse = await createTestCompetition({
           adminClient,
-          `Unstarted Rank Competition ${i}`,
-          `Unstarted competition ${i} for rank testing`,
-        );
+          name: `Unstarted Rank Competition ${i}`,
+          description: `Unstarted competition ${i} for rank testing`,
+        });
         const competition = createResponse.competition;
         competitions.push(competition);
 
@@ -2567,10 +2574,10 @@ describe("User API", () => {
 
       // Create 6 competitions, each with a different agent
       for (let i = 0; i < 6; i++) {
-        const createResponse = await adminClient.createCompetition(
-          `Computed Pagination Competition ${i}`,
-          `Competition ${i} for computed pagination testing`,
-        );
+        const createResponse = await adminClient.createCompetition({
+          name: `Computed Pagination Competition ${i}`,
+          description: `Competition ${i} for computed pagination testing`,
+        });
         expect(createResponse.success).toBe(true);
         const competition = (createResponse as CreateCompetitionResponse)
           .competition;
@@ -2692,10 +2699,10 @@ describe("User API", () => {
 
       // Create competitions with controlled timing for secondary sort
       for (let i = 0; i < agentData.length; i++) {
-        const createResponse = await adminClient.createCompetition(
-          agentData[i]!.comp,
-          `Competition ${i} for mixed sorting`,
-        );
+        const createResponse = await adminClient.createCompetition({
+          name: agentData[i]!.comp,
+          description: `Competition ${i} for mixed sorting`,
+        });
         expect(createResponse.success).toBe(true);
         const competition = (createResponse as CreateCompetitionResponse)
           .competition;
@@ -2784,37 +2791,21 @@ describe("User API", () => {
 
     // Create and start a competition
     const competitionName = `Best Placement Test Competition ${Date.now()}`;
-    const createCompResult = await adminClient.createCompetition(
-      competitionName,
-      "Test competition for bestPlacement verification",
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      {
-        minimum24hVolumeUsd: 0,
-        minimumFdvUsd: 0,
-        minimumLiquidityUsd: 0,
-        minimumPairAgeHours: 0,
-      },
-    );
+    const createCompResult = await adminClient.createCompetition({
+      name: competitionName,
+      description: "Test competition for bestPlacement verification",
+      tradingConstraints: noTradingConstraints,
+    });
     expect(createCompResult.success).toBe(true);
     const createCompResponse = createCompResult as CreateCompetitionResponse;
     const competitionId = createCompResponse.competition.id;
 
     // Enter all 5 agents in the competition
     const agentIds = createdAgents.map((agent) => agent.id);
-    const startResult = await adminClient.startExistingCompetition(
+    const startResult = await adminClient.startExistingCompetition({
       competitionId,
       agentIds,
-    );
+    });
     expect(startResult.success).toBe(true);
 
     // Create different performance levels by executing different trades
@@ -3005,19 +2996,19 @@ describe("User API", () => {
 
     // FIRST COMPETITION
     const competition1Name = `Multi Competition Test 1 ${Date.now()}`;
-    const createComp1Result = await adminClient.createCompetition(
-      competition1Name,
-      "First test competition for multi-comp verification",
-    );
+    const createComp1Result = await adminClient.createCompetition({
+      name: competition1Name,
+      description: "First test competition for multi-comp verification",
+    });
     expect(createComp1Result.success).toBe(true);
     const createComp1Response = createComp1Result as CreateCompetitionResponse;
     const competition1Id = createComp1Response.competition.id;
 
     // Start first competition with both agents
-    const startComp1Result = await adminClient.startExistingCompetition(
-      competition1Id,
-      [agent1.id, agent2.id],
-    );
+    const startComp1Result = await adminClient.startExistingCompetition({
+      competitionId: competition1Id,
+      agentIds: [agent1.id, agent2.id],
+    });
     expect(startComp1Result.success).toBe(true);
 
     // Agent 1: Make stable trade (USDC to ETH)
@@ -3045,19 +3036,19 @@ describe("User API", () => {
 
     // SECOND COMPETITION
     const competition2Name = `Multi Competition Test 2 ${Date.now()}`;
-    const createComp2Result = await adminClient.createCompetition(
-      competition2Name,
-      "Second test competition for multi-comp verification",
-    );
+    const createComp2Result = await adminClient.createCompetition({
+      name: competition2Name,
+      description: "Second test competition for multi-comp verification",
+    });
     expect(createComp2Result.success).toBe(true);
     const createComp2Response = createComp2Result as CreateCompetitionResponse;
     const competition2Id = createComp2Response.competition.id;
 
     // Start second competition with both agents
-    const startComp2Result = await adminClient.startExistingCompetition(
-      competition2Id,
-      [agent1.id, agent2.id],
-    );
+    const startComp2Result = await adminClient.startExistingCompetition({
+      competitionId: competition2Id,
+      agentIds: [agent1.id, agent2.id],
+    });
     expect(startComp2Result.success).toBe(true);
 
     // REVERSE THE TRADING PATTERNS

--- a/apps/api/e2e/tests/voting.test.ts
+++ b/apps/api/e2e/tests/voting.test.ts
@@ -50,17 +50,12 @@ describe("Voting API", () => {
       const votingStartDate = new Date(now.getTime() - 60 * 60 * 1000); // 1 hour ago
       const votingEndDate = new Date(now.getTime() + 60 * 60 * 1000); // 1 hour from now
 
-      const competitionResponse = await createTestCompetition(
+      const competitionResponse = await createTestCompetition({
         adminClient,
-        competitionName,
-        undefined, // description
-        undefined, // sandboxMode
-        undefined, // externalUrl
-        undefined, // imageUrl
-        undefined, // competition type
-        votingStartDate.toISOString(), // votingStartDate
-        votingEndDate.toISOString(), // votingEndDate
-      );
+        name: competitionName,
+        votingStartDate: votingStartDate.toISOString(),
+        votingEndDate: votingEndDate.toISOString(),
+      });
       const competition = competitionResponse.competition;
 
       // Join agents to the competition using their owner's SIWE authentication
@@ -117,29 +112,24 @@ describe("Voting API", () => {
       const votingStartDate = new Date(now.getTime() - 60 * 60 * 1000); // 1 hour ago
       const votingEndDate = new Date(now.getTime() + 60 * 60 * 1000); // 1 hour from now
 
-      const createResponse = await adminClient.createCompetition(
-        competitionName,
-        "Test active competition with voting",
-        "disallowAll",
-        undefined, // sandboxMode
-        undefined, // externalUrl
-        undefined, // imageUrl
-        "trading", // type
-        undefined, // endDate
-        votingStartDate.toISOString(), // votingStartDate
-        votingEndDate.toISOString(), // votingEndDate
-      );
+      const createResponse = await adminClient.createCompetition({
+        name: competitionName,
+        description: "Test active competition with voting",
+        tradingType: "disallowAll",
+        type: "trading", // type
+        votingStartDate: votingStartDate.toISOString(),
+        votingEndDate: votingEndDate.toISOString(),
+      });
 
       expect(createResponse.success).toBe(true);
       const competition = (createResponse as CreateCompetitionResponse)
         .competition;
 
       // Start the competition with agents
-      await adminClient.startExistingCompetition(competition.id, [
-        agent1.id,
-        agent2.id,
-      ]);
-
+      await adminClient.startExistingCompetition({
+        competitionId: competition.id,
+        agentIds: [agent1.id, agent2.id],
+      });
       // Create SIWE authenticated user
       const { client: userClient, user } = await createSiweAuthenticatedClient({
         adminApiKey,
@@ -181,28 +171,24 @@ describe("Voting API", () => {
       const votingStartDate = new Date(now.getTime() - 60 * 60 * 1000); // 1 hour ago
       const votingEndDate = new Date(now.getTime() + 60 * 60 * 1000); // 1 hour from now
 
-      const createResponse = await adminClient.createCompetition(
-        competitionName,
-        "Test duplicate vote prevention",
-        "disallowAll",
-        undefined, // sandboxMode
-        undefined, // externalUrl
-        undefined, // imageUrl
-        "trading", // type
-        undefined, // endDate
-        votingStartDate.toISOString(), // votingStartDate
-        votingEndDate.toISOString(), // votingEndDate
-      );
+      const createResponse = await adminClient.createCompetition({
+        name: competitionName,
+        description: "Test duplicate vote prevention",
+        tradingType: "disallowAll",
+        type: "trading", // type
+        votingStartDate: votingStartDate.toISOString(),
+        votingEndDate: votingEndDate.toISOString(),
+      });
 
       expect(createResponse.success).toBe(true);
       const competition = (createResponse as CreateCompetitionResponse)
         .competition;
 
       // Start the competition with agents
-      await adminClient.startExistingCompetition(competition.id, [
-        agent1.id,
-        agent2.id,
-      ]);
+      await adminClient.startExistingCompetition({
+        competitionId: competition.id,
+        agentIds: [agent1.id, agent2.id],
+      });
 
       // Create SIWE authenticated user
       const { client: userClient } = await createSiweAuthenticatedClient({
@@ -253,28 +239,24 @@ describe("Voting API", () => {
       const votingStartDate = new Date(now.getTime() - 60 * 60 * 1000); // 1 hour ago
       const votingEndDate = new Date(now.getTime() + 60 * 60 * 1000); // 1 hour from now
 
-      const createResponse = await adminClient.createCompetition(
-        competitionName,
-        "Test multiple users voting for same agent",
-        "disallowAll",
-        undefined, // sandboxMode
-        undefined, // externalUrl
-        undefined, // imageUrl
-        "trading", // type
-        undefined, // endDate
-        votingStartDate.toISOString(), // votingStartDate
-        votingEndDate.toISOString(), // votingEndDate
-      );
+      const createResponse = await adminClient.createCompetition({
+        name: competitionName,
+        description: "Test multiple users voting for same agent",
+        tradingType: "disallowAll",
+        type: "trading", // type
+        votingStartDate: votingStartDate.toISOString(),
+        votingEndDate: votingEndDate.toISOString(),
+      });
 
       expect(createResponse.success).toBe(true);
       const competition = (createResponse as CreateCompetitionResponse)
         .competition;
 
       // Start the competition with agents
-      await adminClient.startExistingCompetition(competition.id, [
-        agent1.id,
-        agent2.id,
-      ]);
+      await adminClient.startExistingCompetition({
+        competitionId: competition.id,
+        agentIds: [agent1.id, agent2.id],
+      });
 
       // Create first SIWE authenticated user
       const { client: user1Client, user: user1 } =
@@ -325,11 +307,11 @@ describe("Voting API", () => {
 
       // Start a competition
       const competitionName = `Auth Test Competition ${Date.now()}`;
-      const competitionResponse = await startTestCompetition(
+      const competitionResponse = await startTestCompetition({
         adminClient,
-        competitionName,
-        [agent1.id],
-      );
+        name: competitionName,
+        agentIds: [agent1.id],
+      });
       const competition = competitionResponse.competition;
 
       // Create unauthenticated client
@@ -363,11 +345,11 @@ describe("Voting API", () => {
 
       // Start a competition
       const competitionName = `Invalid Agent Test ${Date.now()}`;
-      const competitionResponse = await startTestCompetition(
+      const competitionResponse = await startTestCompetition({
         adminClient,
-        competitionName,
-        [agent1.id],
-      );
+        name: competitionName,
+        agentIds: [agent1.id],
+      });
       const competition = competitionResponse.competition;
 
       // Create SIWE authenticated user
@@ -409,11 +391,11 @@ describe("Voting API", () => {
 
       // Start a competition with only agent1
       const competitionName = `Participation Test ${Date.now()}`;
-      const competitionResponse = await startTestCompetition(
+      const competitionResponse = await startTestCompetition({
         adminClient,
-        competitionName,
-        [agent1.id],
-      );
+        name: competitionName,
+        agentIds: [agent1.id],
+      });
       const competition = competitionResponse.competition;
 
       // Create SIWE authenticated user
@@ -474,17 +456,12 @@ describe("Voting API", () => {
       const votingStartDate = new Date(now.getTime() - 60 * 60 * 1000); // 1 hour ago
       const votingEndDate = new Date(now.getTime() + 60 * 60 * 1000); // 1 hour from now
 
-      const competitionResponse = await createTestCompetition(
+      const competitionResponse = await createTestCompetition({
         adminClient,
-        competitionName,
-        undefined, // description
-        undefined, // sandboxMode
-        undefined, // externalUrl
-        undefined, // imageUrl
-        undefined, // competition type
-        votingStartDate.toISOString(), // votingStartDate
-        votingEndDate.toISOString(), // votingEndDate
-      );
+        name: competitionName,
+        votingStartDate: votingStartDate.toISOString(),
+        votingEndDate: votingEndDate.toISOString(),
+      });
       const competition = competitionResponse.competition;
 
       // Join agent to competition
@@ -529,25 +506,23 @@ describe("Voting API", () => {
       const votingStartDate = new Date(now.getTime() - 60 * 60 * 1000); // 1 hour ago
       const votingEndDate = new Date(now.getTime() + 60 * 60 * 1000); // 1 hour from now
 
-      const createResponse = await adminClient.createCompetition(
-        competitionName,
-        "Test user vote info after voting",
-        "disallowAll",
-        undefined, // sandboxMode
-        undefined, // externalUrl
-        undefined, // imageUrl
-        "trading", // type
-        undefined, // endDate
-        votingStartDate.toISOString(), // votingStartDate
-        votingEndDate.toISOString(), // votingEndDate
-      );
+      const createResponse = await adminClient.createCompetition({
+        name: competitionName,
+        description: "Test user vote info after voting",
+        tradingType: "disallowAll",
+        votingStartDate: votingStartDate.toISOString(),
+        votingEndDate: votingEndDate.toISOString(),
+      });
 
       expect(createResponse.success).toBe(true);
       const competition = (createResponse as CreateCompetitionResponse)
         .competition;
 
       // Start the competition with agents
-      await adminClient.startExistingCompetition(competition.id, [agent1.id]);
+      await adminClient.startExistingCompetition({
+        competitionId: competition.id,
+        agentIds: [agent1.id],
+      });
 
       // Create SIWE authenticated user
       const { client: userClient } = await createSiweAuthenticatedClient({
@@ -600,28 +575,24 @@ describe("Voting API", () => {
       const votingStartDate = new Date(now.getTime() - 60 * 60 * 1000); // 1 hour ago
       const votingEndDate = new Date(now.getTime() + 60 * 60 * 1000); // 1 hour from now
 
-      const createResponse = await adminClient.createCompetition(
-        competitionName,
-        "Test canVote false after voting",
-        "disallowAll",
-        undefined, // sandboxMode
-        undefined, // externalUrl
-        undefined, // imageUrl
-        "trading", // type
-        undefined, // endDate
-        votingStartDate.toISOString(), // votingStartDate
-        votingEndDate.toISOString(), // votingEndDate
-      );
+      const createResponse = await adminClient.createCompetition({
+        name: competitionName,
+        description: "Test canVote false after voting",
+        tradingType: "disallowAll",
+        type: "trading", // type
+        votingStartDate: votingStartDate.toISOString(),
+        votingEndDate: votingEndDate.toISOString(),
+      });
 
       expect(createResponse.success).toBe(true);
       const competition = (createResponse as CreateCompetitionResponse)
         .competition;
 
       // Start the competition with agents
-      await adminClient.startExistingCompetition(competition.id, [
-        agent1.id,
-        agent2.id,
-      ]);
+      await adminClient.startExistingCompetition({
+        competitionId: competition.id,
+        agentIds: [agent1.id, agent2.id],
+      });
 
       // Create SIWE authenticated user
       const { client: userClient } = await createSiweAuthenticatedClient({
@@ -666,28 +637,23 @@ describe("Voting API", () => {
       const votingStartDate = new Date(now.getTime() - 60 * 60 * 1000); // 1 hour ago
       const votingEndDate = new Date(now.getTime() + 60 * 60 * 1000); // 1 hour from now
 
-      const createResponse = await adminClient.createCompetition(
-        competitionName,
-        "Test voting persistence after competition closes",
-        "disallowAll",
-        undefined, // sandboxMode
-        undefined, // externalUrl
-        undefined, // imageUrl
-        "trading", // type
-        undefined, // endDate
-        votingStartDate.toISOString(), // votingStartDate
-        votingEndDate.toISOString(), // votingEndDate
-      );
+      const createResponse = await adminClient.createCompetition({
+        name: competitionName,
+        description: "Test voting persistence after competition closes",
+        tradingType: "disallowAll",
+        votingStartDate: votingStartDate.toISOString(),
+        votingEndDate: votingEndDate.toISOString(),
+      });
 
       expect(createResponse.success).toBe(true);
       const competition = (createResponse as CreateCompetitionResponse)
         .competition;
 
       // Start the competition with agents
-      await adminClient.startExistingCompetition(competition.id, [
-        agent1.id,
-        agent2.id,
-      ]);
+      await adminClient.startExistingCompetition({
+        competitionId: competition.id,
+        agentIds: [agent1.id, agent2.id],
+      });
 
       // Create SIWE authenticated user
       const { client: userClient } = await createSiweAuthenticatedClient({
@@ -737,25 +703,23 @@ describe("Voting API", () => {
       const votingStartDate = new Date(now.getTime() - 60 * 60 * 1000); // 1 hour ago
       const votingEndDate = new Date(now.getTime() + 60 * 60 * 1000); // 1 hour from now
 
-      const createResponse = await adminClient.createCompetition(
-        competitionName,
-        "Test getting user votes",
-        "disallowAll",
-        undefined, // sandboxMode
-        undefined, // externalUrl
-        undefined, // imageUrl
-        "trading", // type
-        undefined, // endDate
-        votingStartDate.toISOString(), // votingStartDate
-        votingEndDate.toISOString(), // votingEndDate
-      );
+      const createResponse = await adminClient.createCompetition({
+        name: competitionName,
+        description: "Test getting user votes",
+        tradingType: "disallowAll",
+        votingStartDate: votingStartDate.toISOString(),
+        votingEndDate: votingEndDate.toISOString(),
+      });
 
       expect(createResponse.success).toBe(true);
       const competition = (createResponse as CreateCompetitionResponse)
         .competition;
 
       // Start the competition with agents
-      await adminClient.startExistingCompetition(competition.id, [agent1.id]);
+      await adminClient.startExistingCompetition({
+        competitionId: competition.id,
+        agentIds: [agent1.id],
+      });
 
       // Create SIWE authenticated user
       const { client: userClient } = await createSiweAuthenticatedClient({
@@ -809,25 +773,23 @@ describe("Voting API", () => {
       const votingStartDate = new Date(now.getTime() - 60 * 60 * 1000); // 1 hour ago
       const votingEndDate = new Date(now.getTime() + 60 * 60 * 1000); // 1 hour from now
 
-      const createResponse1 = await adminClient.createCompetition(
-        `Competition 1 ${Date.now()}`,
-        "Test filtering votes by competition 1",
-        "disallowAll",
-        undefined, // sandboxMode
-        undefined, // externalUrl
-        undefined, // imageUrl
-        "trading", // type
-        undefined, // endDate
-        votingStartDate.toISOString(), // votingStartDate
-        votingEndDate.toISOString(), // votingEndDate
-      );
+      const createResponse1 = await adminClient.createCompetition({
+        name: `Competition 1 ${Date.now()}`,
+        description: "Test filtering votes by competition 1",
+        tradingType: "disallowAll",
+        votingStartDate: votingStartDate.toISOString(),
+        votingEndDate: votingEndDate.toISOString(),
+      });
 
       expect(createResponse1.success).toBe(true);
       const competition1 = (createResponse1 as CreateCompetitionResponse)
         .competition;
 
       // Start first competition with agent1
-      await adminClient.startExistingCompetition(competition1.id, [agent1.id]);
+      await adminClient.startExistingCompetition({
+        competitionId: competition1.id,
+        agentIds: [agent1.id],
+      });
 
       // Cast vote in first competition
       await userClient.castVote(agent1.id, competition1.id);
@@ -836,25 +798,23 @@ describe("Voting API", () => {
       await adminClient.endCompetition(competition1.id);
 
       // Create second competition with proper voting dates
-      const createResponse2 = await adminClient.createCompetition(
-        `Competition 2 ${Date.now()}`,
-        "Test filtering votes by competition 2",
-        "disallowAll",
-        undefined, // sandboxMode
-        undefined, // externalUrl
-        undefined, // imageUrl
-        "trading", // type
-        undefined, // endDate
-        votingStartDate.toISOString(), // votingStartDate
-        votingEndDate.toISOString(), // votingEndDate
-      );
+      const createResponse2 = await adminClient.createCompetition({
+        name: `Competition 2 ${Date.now()}`,
+        description: "Test filtering votes by competition 2",
+        tradingType: "disallowAll",
+        votingStartDate: votingStartDate.toISOString(),
+        votingEndDate: votingEndDate.toISOString(),
+      });
 
       expect(createResponse2.success).toBe(true);
       const competition2 = (createResponse2 as CreateCompetitionResponse)
         .competition;
 
       // Start second competition with agent2
-      await adminClient.startExistingCompetition(competition2.id, [agent2.id]);
+      await adminClient.startExistingCompetition({
+        competitionId: competition2.id,
+        agentIds: [agent2.id],
+      });
 
       // Cast vote in second competition
       await userClient.castVote(agent2.id, competition2.id);
@@ -894,28 +854,23 @@ describe("Voting API", () => {
       const votingStartDate = new Date(now.getTime() - 60 * 60 * 1000); // 1 hour ago
       const votingEndDate = new Date(now.getTime() + 60 * 60 * 1000); // 1 hour from now
 
-      const createResponse = await adminClient.createCompetition(
-        competitionName,
-        "Test vote counts in competition agent response",
-        "disallowAll",
-        undefined, // sandboxMode
-        undefined, // externalUrl
-        undefined, // imageUrl
-        "trading", // type
-        undefined, // endDate
-        votingStartDate.toISOString(), // votingStartDate
-        votingEndDate.toISOString(), // votingEndDate
-      );
+      const createResponse = await adminClient.createCompetition({
+        name: competitionName,
+        description: "Test vote counts in competition agent response",
+        tradingType: "disallowAll",
+        votingStartDate: votingStartDate.toISOString(),
+        votingEndDate: votingEndDate.toISOString(),
+      });
 
       expect(createResponse.success).toBe(true);
       const competition = (createResponse as CreateCompetitionResponse)
         .competition;
 
       // Start the competition with agents
-      await adminClient.startExistingCompetition(competition.id, [
-        agent1.id,
-        agent2.id,
-      ]);
+      await adminClient.startExistingCompetition({
+        competitionId: competition.id,
+        agentIds: [agent1.id, agent2.id],
+      });
 
       // Create multiple users and cast votes
       const { client: user1Client } = await createSiweAuthenticatedClient({
@@ -976,25 +931,23 @@ describe("Voting API", () => {
       const votingStartDate = new Date(now.getTime() - 60 * 60 * 1000); // 1 hour ago
       const votingEndDate = new Date(now.getTime() + 60 * 60 * 1000); // 1 hour from now
 
-      const createResponse = await adminClient.createCompetition(
-        competitionName,
-        "Test user vote status in competition details",
-        "disallowAll",
-        undefined, // sandboxMode
-        undefined, // externalUrl
-        undefined, // imageUrl
-        "trading", // type
-        undefined, // endDate
-        votingStartDate.toISOString(), // votingStartDate
-        votingEndDate.toISOString(), // votingEndDate
-      );
+      const createResponse = await adminClient.createCompetition({
+        name: competitionName,
+        description: "Test user vote status in competition details",
+        tradingType: "disallowAll",
+        votingStartDate: votingStartDate.toISOString(),
+        votingEndDate: votingEndDate.toISOString(),
+      });
 
       expect(createResponse.success).toBe(true);
       const competition = (createResponse as CreateCompetitionResponse)
         .competition;
 
       // Start the competition with agents
-      await adminClient.startExistingCompetition(competition.id, [agent1.id]);
+      await adminClient.startExistingCompetition({
+        competitionId: competition.id,
+        agentIds: [agent1.id],
+      });
 
       // Create SIWE authenticated user
       const { client: userClient } = await createSiweAuthenticatedClient({
@@ -1046,25 +999,23 @@ describe("Voting API", () => {
       const futureEndDate = new Date(now.getTime() + 48 * 60 * 60 * 1000); // 48 hours from now
       const competitionName = `Future Voting Test ${Date.now()}`;
 
-      const createResponse = await adminClient.createCompetition(
-        competitionName,
-        "Test competition with future voting start date",
-        "disallowAll",
-        undefined, // sandboxMode
-        undefined, // externalUrl
-        undefined, // imageUrl
-        "trading", // type
-        undefined, // endDate
-        futureStartDate.toISOString(), // votingStartDate - in future
-        futureEndDate.toISOString(), // votingEndDate - also in future
-      );
+      const createResponse = await adminClient.createCompetition({
+        name: competitionName,
+        description: "Test competition with future voting start date",
+        tradingType: "disallowAll",
+        votingStartDate: futureStartDate.toISOString(),
+        votingEndDate: futureEndDate.toISOString(),
+      });
 
       expect(createResponse.success).toBe(true);
       const competition = (createResponse as CreateCompetitionResponse)
         .competition;
 
       // Add agent to competition
-      await adminClient.startExistingCompetition(competition.id, [agent1.id]);
+      await adminClient.startExistingCompetition({
+        competitionId: competition.id,
+        agentIds: [agent1.id],
+      });
 
       // Create user
       const { client: userClient } = await createSiweAuthenticatedClient({
@@ -1098,25 +1049,23 @@ describe("Voting API", () => {
       const pastEndDate = new Date(now.getTime() - 24 * 60 * 60 * 1000); // 24 hours ago
       const competitionName = `Past Voting Test ${Date.now()}`;
 
-      const createResponse = await adminClient.createCompetition(
-        competitionName,
-        "Test competition with past voting end date",
-        "disallowAll",
-        undefined, // sandboxMode
-        undefined, // externalUrl
-        undefined, // imageUrl
-        "trading", // type
-        undefined, // endDate
-        pastStartDate.toISOString(), // votingStartDate - in past
-        pastEndDate.toISOString(), // votingEndDate - also in past
-      );
+      const createResponse = await adminClient.createCompetition({
+        name: competitionName,
+        description: "Test competition with past voting end date",
+        tradingType: "disallowAll",
+        votingStartDate: pastStartDate.toISOString(),
+        votingEndDate: pastEndDate.toISOString(),
+      });
 
       expect(createResponse.success).toBe(true);
       const competition = (createResponse as CreateCompetitionResponse)
         .competition;
 
       // Add agent to competition
-      await adminClient.startExistingCompetition(competition.id, [agent1.id]);
+      await adminClient.startExistingCompetition({
+        competitionId: competition.id,
+        agentIds: [agent1.id],
+      });
 
       // Create user
       const { client: userClient } = await createSiweAuthenticatedClient({
@@ -1150,25 +1099,23 @@ describe("Voting API", () => {
       const endDate = new Date(now.getTime() + 60 * 60 * 1000); // 1 hour from now
       const competitionName = `Valid Voting Test ${Date.now()}`;
 
-      const createResponse = await adminClient.createCompetition(
-        competitionName,
-        "Test competition with valid voting date range",
-        "disallowAll",
-        undefined, // sandboxMode
-        undefined, // externalUrl
-        undefined, // imageUrl
-        "trading", // type
-        undefined, // endDate
-        startDate.toISOString(), // votingStartDate
-        endDate.toISOString(), // votingEndDate
-      );
+      const createResponse = await adminClient.createCompetition({
+        name: competitionName,
+        description: "Test competition with valid voting date range",
+        tradingType: "disallowAll",
+        votingStartDate: startDate.toISOString(),
+        votingEndDate: endDate.toISOString(),
+      });
 
       expect(createResponse.success).toBe(true);
       const competition = (createResponse as CreateCompetitionResponse)
         .competition;
 
       // Add agent to competition
-      await adminClient.startExistingCompetition(competition.id, [agent1.id]);
+      await adminClient.startExistingCompetition({
+        competitionId: competition.id,
+        agentIds: [agent1.id],
+      });
 
       // Create user
       const { client: userClient, user } = await createSiweAuthenticatedClient({
@@ -1201,25 +1148,21 @@ describe("Voting API", () => {
 
       // Create competition without voting dates
       const competitionName = `No Voting Dates Test ${Date.now()}`;
-      const createResponse = await adminClient.createCompetition(
-        competitionName,
-        "Test competition without voting dates",
-        "disallowAll",
-        undefined, // sandboxMode
-        undefined, // externalUrl
-        undefined, // imageUrl
-        "trading", // type
-        undefined, // endDate
-        undefined, // votingStartDate - not defined
-        undefined, // votingEndDate - not defined
-      );
+      const createResponse = await adminClient.createCompetition({
+        name: competitionName,
+        description: "Test competition without voting dates",
+        tradingType: "disallowAll",
+      });
 
       expect(createResponse.success).toBe(true);
       const competition = (createResponse as CreateCompetitionResponse)
         .competition;
 
       // Add agent to competition
-      await adminClient.startExistingCompetition(competition.id, [agent1.id]);
+      await adminClient.startExistingCompetition({
+        competitionId: competition.id,
+        agentIds: [agent1.id],
+      });
 
       // Create authenticated user
       const { client: userClient } = await createSiweAuthenticatedClient({
@@ -1255,25 +1198,22 @@ describe("Voting API", () => {
       // Create competition with only start date
       const competitionName = `Start Date Only Test ${Date.now()}`;
       const startDate = new Date(Date.now() - 60 * 60 * 1000); // 1 hour ago
-      const createResponse = await adminClient.createCompetition(
-        competitionName,
-        "Test competition with only start date",
-        "disallowAll",
-        undefined, // sandboxMode
-        undefined, // externalUrl
-        undefined, // imageUrl
-        "trading", // type
-        undefined, // endDate
-        startDate.toISOString(), // votingStartDate - defined
-        undefined, // votingEndDate - not defined
-      );
+      const createResponse = await adminClient.createCompetition({
+        name: competitionName,
+        description: "Test competition with only start date",
+        tradingType: "disallowAll",
+        votingStartDate: startDate.toISOString(),
+      });
 
       expect(createResponse.success).toBe(true);
       const competition = (createResponse as CreateCompetitionResponse)
         .competition;
 
       // Add agent to competition
-      await adminClient.startExistingCompetition(competition.id, [agent1.id]);
+      await adminClient.startExistingCompetition({
+        competitionId: competition.id,
+        agentIds: [agent1.id],
+      });
 
       // Create authenticated user
       const { client: userClient } = await createSiweAuthenticatedClient({
@@ -1309,18 +1249,12 @@ describe("Voting API", () => {
       // Create competition with only end date
       const competitionName = `End Date Only Test ${Date.now()}`;
       const endDate = new Date(Date.now() + 60 * 60 * 1000).toISOString(); // 1 hour from now
-      const createResponse = await adminClient.createCompetition(
-        competitionName,
-        "Test competition with only end date",
-        "disallowAll",
-        undefined, // sandboxMode
-        undefined, // externalUrl
-        undefined, // imageUrl
-        "trading", // type
-        undefined, // endDate
-        undefined, // votingStartDate - not defined
-        endDate, // votingEndDate - defined
-      );
+      const createResponse = await adminClient.createCompetition({
+        name: competitionName,
+        description: "Test competition with only end date",
+        tradingType: "disallowAll",
+        votingEndDate: endDate,
+      });
 
       expect(createResponse.success).toBe(true);
       const competition = (createResponse as CreateCompetitionResponse)
@@ -1330,7 +1264,10 @@ describe("Voting API", () => {
       expect(competition.votingEndDate).toBe(endDate);
 
       // Add agent to competition
-      await adminClient.startExistingCompetition(competition.id, [agent1.id]);
+      await adminClient.startExistingCompetition({
+        competitionId: competition.id,
+        agentIds: [agent1.id],
+      });
 
       // Create authenticated user
       const { client: userClient } = await createSiweAuthenticatedClient({

--- a/apps/api/e2e/utils/api-client.ts
+++ b/apps/api/e2e/utils/api-client.ts
@@ -417,34 +417,54 @@ export class ApiClient {
   /**
    * Create a competition in PENDING state
    */
-  async createCompetition(
-    name: string,
-    description?: string,
-    tradingType?: CrossChainTradingType,
-    sandboxMode?: boolean,
-    externalUrl?: string,
-    imageUrl?: string,
-    type?: string,
-    endDate?: string,
-    votingStartDate?: string,
-    votingEndDate?: string,
-    joinStartDate?: string,
-    joinEndDate?: string,
-    maxParticipants?: number,
-    tradingConstraints?: TradingConstraints,
-    rewards?: Record<number, number>,
-  ): Promise<CreateCompetitionResponse | ErrorResponse> {
+  async createCompetition({
+    name,
+    description,
+    tradingType,
+    sandboxMode,
+    externalUrl,
+    imageUrl,
+    type,
+    startDate,
+    endDate,
+    votingStartDate,
+    votingEndDate,
+    joinStartDate,
+    joinEndDate,
+    maxParticipants,
+    tradingConstraints,
+    rewards,
+  }: {
+    name?: string;
+    description?: string;
+    tradingType?: CrossChainTradingType;
+    sandboxMode?: boolean;
+    externalUrl?: string;
+    imageUrl?: string;
+    type?: string;
+    startDate?: string;
+    endDate?: string;
+    votingStartDate?: string;
+    votingEndDate?: string;
+    joinStartDate?: string;
+    joinEndDate?: string;
+    maxParticipants?: number;
+    tradingConstraints?: TradingConstraints;
+    rewards?: Record<number, number>;
+  }): Promise<CreateCompetitionResponse | ErrorResponse> {
+    const competitionName = name || `Test competition ${Date.now()}`;
     try {
       const response = await this.axiosInstance.post(
         "/api/admin/competition/create",
         {
-          name,
+          name: competitionName,
           description,
           tradingType,
           sandboxMode,
           externalUrl,
           imageUrl,
           type,
+          startDate,
           endDate,
           votingStartDate,
           votingEndDate,
@@ -465,14 +485,21 @@ export class ApiClient {
   /**
    * Start an existing competition with agents
    */
-  async startExistingCompetition(
-    competitionId: string,
-    agentIds?: string[],
-    crossChainTradingType?: CrossChainTradingType,
-    sandboxMode?: boolean,
-    externalUrl?: string,
-    imageUrl?: string,
-  ): Promise<StartCompetitionResponse | ErrorResponse> {
+  async startExistingCompetition({
+    competitionId,
+    agentIds,
+    crossChainTradingType,
+    sandboxMode,
+    externalUrl,
+    imageUrl,
+  }: {
+    competitionId: string;
+    agentIds?: string[];
+    crossChainTradingType?: CrossChainTradingType;
+    sandboxMode?: boolean;
+    externalUrl?: string;
+    imageUrl?: string;
+  }): Promise<StartCompetitionResponse | ErrorResponse> {
     try {
       const response = await this.axiosInstance.post(
         "/api/admin/competition/start",

--- a/apps/api/e2e/utils/test-helpers.ts
+++ b/apps/api/e2e/utils/test-helpers.ts
@@ -13,6 +13,7 @@ import { db } from "@/database/db.js";
 import { ApiClient } from "./api-client.js";
 import {
   CreateCompetitionResponse,
+  CrossChainTradingType,
   StartCompetitionResponse,
   TradingConstraints,
 } from "./api-types.js";
@@ -217,27 +218,33 @@ export async function registerUserAndAgentAndGetClient({
 /**
  * Start a competition with given agents
  */
-export async function startTestCompetition(
-  adminClient: ApiClient,
-  name: string,
-  agentIds: string[],
-  sandboxMode?: boolean,
-  externalUrl?: string,
-  imageUrl?: string,
-  tradingConstraints?: TradingConstraints,
-): Promise<StartCompetitionResponse> {
-  const result = await adminClient.startCompetition(
-    name,
-    `Test competition description for ${name}`,
-    agentIds,
-    undefined, // tradingType
+export async function startTestCompetition({
+  adminClient,
+  name,
+  agentIds,
+  sandboxMode,
+  externalUrl,
+  imageUrl,
+  tradingConstraints,
+}: {
+  adminClient: ApiClient;
+  name?: string;
+  agentIds?: string[];
+  sandboxMode?: boolean;
+  externalUrl?: string;
+  imageUrl?: string;
+  tradingConstraints?: TradingConstraints;
+}): Promise<StartCompetitionResponse> {
+  const competitionName = name || `Test competition ${Date.now()}`;
+  const result = await adminClient.startCompetition({
+    name: competitionName,
+    description: `Test competition description for ${competitionName}`,
+    agentIds: agentIds || [],
     sandboxMode,
     externalUrl,
     imageUrl,
-    undefined, // votingStartDate
-    undefined, // votingEndDate
     tradingConstraints,
-  );
+  });
 
   if (!result.success) {
     throw new Error("Failed to start competition");
@@ -249,37 +256,60 @@ export async function startTestCompetition(
 /**
  * Create a competition in PENDING state without starting it
  */
-export async function createTestCompetition(
-  adminClient: ApiClient,
-  name: string,
-  description?: string,
-  sandboxMode?: boolean,
-  externalUrl?: string,
-  imageUrl?: string,
-  type?: string,
-  votingStartDate?: string,
-  votingEndDate?: string,
-  joinStartDate?: string,
-  joinEndDate?: string,
-  maxParticipants?: number,
-  tradingConstraints?: TradingConstraints,
-): Promise<CreateCompetitionResponse> {
-  const result = await adminClient.createCompetition(
-    name,
-    description || `Test competition description for ${name}`,
-    undefined, // tradingType
+export async function createTestCompetition({
+  adminClient,
+  name,
+  description,
+  sandboxMode,
+  externalUrl,
+  imageUrl,
+  type,
+  tradingType,
+  startDate,
+  endDate,
+  votingStartDate,
+  votingEndDate,
+  joinStartDate,
+  joinEndDate,
+  maxParticipants,
+  tradingConstraints,
+}: {
+  adminClient: ApiClient;
+  name?: string;
+  description?: string;
+  sandboxMode?: boolean;
+  externalUrl?: string;
+  imageUrl?: string;
+  type?: string;
+  tradingType?: CrossChainTradingType;
+  startDate?: string;
+  endDate?: string;
+  votingStartDate?: string;
+  votingEndDate?: string;
+  joinStartDate?: string;
+  joinEndDate?: string;
+  maxParticipants?: number;
+  tradingConstraints?: TradingConstraints;
+}): Promise<CreateCompetitionResponse> {
+  const competitionName = name || `Test competition ${Date.now()}`;
+  const result = await adminClient.createCompetition({
+    name: competitionName,
+    description:
+      description || `Test competition description for ${competitionName}`,
+    tradingType,
     sandboxMode,
     externalUrl,
     imageUrl,
     type,
-    undefined, // endDate
+    startDate,
+    endDate,
     votingStartDate,
     votingEndDate,
     joinStartDate,
     joinEndDate,
     maxParticipants,
     tradingConstraints,
-  );
+  });
 
   if (!result.success) {
     throw new Error("Failed to create competition");
@@ -291,22 +321,28 @@ export async function createTestCompetition(
 /**
  * Start an existing competition with given agents
  */
-export async function startExistingTestCompetition(
-  adminClient: ApiClient,
-  competitionId: string,
-  agentIds?: string[],
-  sandboxMode?: boolean,
-  externalUrl?: string,
-  imageUrl?: string,
-): Promise<StartCompetitionResponse> {
-  const result = await adminClient.startExistingCompetition(
+export async function startExistingTestCompetition({
+  adminClient,
+  competitionId,
+  agentIds,
+  sandboxMode,
+  externalUrl,
+  imageUrl,
+}: {
+  adminClient: ApiClient;
+  competitionId: string;
+  agentIds?: string[];
+  sandboxMode?: boolean;
+  externalUrl?: string;
+  imageUrl?: string;
+}): Promise<StartCompetitionResponse> {
+  const result = await adminClient.startExistingCompetition({
     competitionId,
-    agentIds,
-    undefined, // crossChainTradingType
+    agentIds: agentIds || [],
     sandboxMode,
     externalUrl,
     imageUrl,
-  );
+  });
 
   if (!result.success) {
     throw new Error("Failed to start existing competition");
@@ -508,10 +544,10 @@ export async function generateTestCompetitions(adminApiKey: string) {
 
   const comps = [];
   for (let i = 0; i < 20; i++) {
-    const result = await createTestCompetition(
+    const result = await createTestCompetition({
       adminClient,
-      `Competition ${i} ${Date.now()}`,
-    );
+      name: `Competition ${i} ${Date.now()}`,
+    });
 
     comps.push(result);
 


### PR DESCRIPTION
The test helper methods to create/start comps have ordered params that are too hard to keep track of. This makes them named params.