### PR TITLE
feat: add rewards endpoints

### DIFF
--- a/apps/api/e2e/tests/rewards-api.test.ts
+++ b/apps/api/e2e/tests/rewards-api.test.ts
@@ -1,0 +1,195 @@
+import { hexToBytes } from "viem";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import { BoostRepository } from "@recallnet/db/repositories/boost";
+import { CompetitionRepository } from "@recallnet/db/repositories/competition";
+import { RewardsRepository } from "@recallnet/db/repositories/rewards";
+import { competitions } from "@recallnet/db/schema/core/defs";
+import { InsertReward } from "@recallnet/db/schema/voting/types";
+import { RewardsService, createLeafNode } from "@recallnet/services";
+
+import { db } from "@/database/db.js";
+import { ApiClient } from "@/e2e/utils/api-client.js";
+import {
+  RewardProof,
+  RewardsProofsResponse,
+  RewardsTotalResponse,
+} from "@/e2e/utils/api-types.js";
+import {
+  createPrivyAuthenticatedClient,
+  createTestClient,
+} from "@/e2e/utils/test-helpers.js";
+import { logger } from "@/lib/logger.js";
+
+import { TestPrivyUser } from "../utils/privy.js";
+
+// Mock the RewardsAllocator class
+const mockRewardsAllocator = {
+  allocate: vi.fn().mockResolvedValue({
+    transactionHash:
+      "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+    blockNumber: BigInt(12345),
+    gasUsed: BigInt(100000),
+  }),
+};
+
+let testUserAddress: string;
+let testClient: ApiClient;
+
+describe("Rewards API", () => {
+  // Clean up test state before each test
+  let rewardsService: RewardsService;
+  let testCompetitionId: string;
+  let testRewards: InsertReward[];
+  let testUser: TestPrivyUser;
+
+  // Test constants for the allocate method
+  const testTokenAddress =
+    "0x1234567890123456789012345678901234567890" as `0x${string}`;
+  const testStartTimestamp = Math.floor(Date.now() / 1000); // Current timestamp
+
+  beforeEach(async () => {
+    const rewardsRepository = new RewardsRepository(db, logger);
+    // Create RewardsService with mock RewardsAllocator
+    rewardsService = new RewardsService(
+      rewardsRepository,
+      new CompetitionRepository(db, db, logger),
+      new BoostRepository(db),
+      mockRewardsAllocator as any, // eslint-disable-line
+      db,
+      logger,
+    );
+
+    // Create a test competition with UUID
+    const competitionId = "756fddf2-d5a3-4d07-b769-109583469c88";
+    const [competition] = await db
+      .insert(competitions)
+      .values({
+        id: competitionId,
+        name: "Test Competition",
+        description: "A test competition for rewards",
+        status: "active",
+        type: "trading",
+        startDate: new Date(),
+        endDate: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000), // 7 days from now
+      })
+      .returning();
+
+    expect(!competition).toBe(false);
+    testCompetitionId = competitionId;
+
+    // Create a SIWE-authenticated client to get a test user address
+    const { client, user } = await createPrivyAuthenticatedClient({
+      userName: `Test User ${Date.now()}`,
+      userEmail: `test-user-${Date.now()}@test.com`,
+    });
+
+    testUserAddress = user.walletAddress;
+    testClient = client;
+    testUser = user as unknown as TestPrivyUser;
+
+    // Create test rewards data with proper leaf hashes
+    testRewards = [];
+
+    // Create first reward for the test user
+    const amount1 = BigInt(1);
+    const leafHashHex1 = createLeafNode(
+      testUserAddress as `0x${string}`,
+      amount1,
+    );
+
+    testRewards.push({
+      id: crypto.randomUUID(),
+      competitionId: testCompetitionId,
+      address: testUserAddress as `0x${string}`,
+      amount: amount1,
+      leafHash: hexToBytes(leafHashHex1),
+      claimed: false,
+    });
+
+    // Create second reward for the test user
+    const amount2 = BigInt(1);
+    const leafHashHex2 = createLeafNode(
+      testUserAddress as `0x${string}`,
+      amount2,
+    );
+
+    testRewards.push({
+      id: crypto.randomUUID(),
+      competitionId: testCompetitionId,
+      address: testUserAddress as `0x${string}`,
+      amount: amount2,
+      leafHash: hexToBytes(leafHashHex2),
+      claimed: false,
+    });
+
+    // Insert test rewards into database
+    await rewardsRepository.insertRewards(testRewards);
+
+    // Execute the allocate method with all required parameters
+    await rewardsService.allocate(
+      testCompetitionId,
+      testTokenAddress,
+      testStartTimestamp,
+    );
+  });
+
+  test("unauthenticated user cannot access rewards endpoints", async () => {
+    const client = createTestClient();
+
+    // Test GET /user/rewards/total without authentication
+    const totalResponse = await client.getTotalClaimableRewards();
+    expect(totalResponse.success).toBe(false);
+
+    // Test GET /user/rewards/proofs without authentication
+    const proofsResponse = await client.getRewardsWithProofs();
+    expect(proofsResponse.success).toBe(false);
+  });
+
+  test("authenticated user can get total claimable rewards", async () => {
+    // Verify testClient and testUser are properly initialized
+    expect(testClient).toBeDefined();
+    expect(testUser).toBeDefined();
+    expect(testUser.walletAddress).toBeDefined();
+
+    // Get total claimable rewards using the test client
+    const response = await testClient.getTotalClaimableRewards();
+
+    expect(response.success).toBe(true);
+    const responseData = response as RewardsTotalResponse;
+    expect(responseData.address.toLowerCase()).toBe(
+      testUser.walletAddress?.toLowerCase(),
+    );
+    expect(responseData.totalClaimableRewards).toBeDefined();
+    expect(typeof responseData.totalClaimableRewards).toBe("string");
+    // The rewards have amounts 1 and 1, so total should be "2"
+    expect(responseData.totalClaimableRewards).toBe("2");
+  });
+
+  test("authenticated user can get rewards with proofs", async () => {
+    // Get rewards with proofs using the test client
+    const response = await testClient.getRewardsWithProofs();
+
+    expect(response.success).toBe(true);
+    const responseData = response as RewardsProofsResponse;
+    expect(responseData.address.toLowerCase()).toBe(
+      testUser.walletAddress?.toLowerCase(),
+    );
+    expect(Array.isArray(responseData.rewards)).toBe(true);
+    expect(responseData.rewards.length).toBe(2); // Should have exactly two rewards
+
+    // Validate the reward structure for both rewards
+    responseData.rewards.forEach((reward: RewardProof) => {
+      expect(reward.merkleRoot).toMatch(/^0x[a-fA-F0-9]{64}$/);
+      expect(typeof reward.amount).toBe("string");
+      expect(reward.amount).toBe("1"); // Each reward has amount 1
+      expect(Array.isArray(reward.proof)).toBe(true);
+      expect(reward.proof.length).toBe(2); // With 2 rewards, each proof has 1 sibling
+
+      // Validate proof format (should be hex strings)
+      reward.proof.forEach((proofItem: string) => {
+        expect(proofItem).toMatch(/^0x[a-fA-F0-9]{64}$/);
+      });
+    });
+  });
+});

--- a/apps/api/e2e/utils/api-client.ts
+++ b/apps/api/e2e/utils/api-client.ts
@@ -53,6 +53,8 @@ import {
   PublicAgentResponse,
   QuoteResponse,
   ResetApiKeyResponse,
+  RewardsProofsResponse,
+  RewardsTotalResponse,
   SpecificChain,
   StartCompetitionResponse,
   TradeExecutionParams,
@@ -2044,6 +2046,34 @@ export class ApiClient {
       return response.data;
     } catch (error) {
       return this.handleApiError(error, "unsubscribe from mailing list");
+    }
+  }
+
+  /**
+   * Get total claimable rewards for the authenticated user
+   * Requires SIWE session authentication
+   */
+  async getTotalClaimableRewards(): Promise<
+    RewardsTotalResponse | ErrorResponse
+  > {
+    try {
+      const response = await this.axiosInstance.get("/api/user/rewards/total");
+      return response.data;
+    } catch (error) {
+      return this.handleApiError(error, "get total claimable rewards");
+    }
+  }
+
+  /**
+   * Get rewards with proofs for the authenticated user
+   * Requires SIWE session authentication
+   */
+  async getRewardsWithProofs(): Promise<RewardsProofsResponse | ErrorResponse> {
+    try {
+      const response = await this.axiosInstance.get("/api/user/rewards/proofs");
+      return response.data;
+    } catch (error) {
+      return this.handleApiError(error, "get rewards with proofs");
     }
   }
 }

--- a/apps/api/e2e/utils/api-types.ts
+++ b/apps/api/e2e/utils/api-types.ts
@@ -1065,3 +1065,22 @@ export interface UserSubscriptionResponse extends ApiResponse {
   userId: string;
   isSubscribed: boolean;
 }
+
+// Rewards API response types
+export interface RewardsTotalResponse {
+  success: true;
+  address: string;
+  totalClaimableRewards: string;
+}
+
+export interface RewardProof {
+  merkleRoot: string;
+  amount: string;
+  proof: string[];
+}
+
+export interface RewardsProofsResponse {
+  success: true;
+  address: string;
+  rewards: RewardProof[];
+}

--- a/apps/api/openapi/API.md
+++ b/apps/api/openapi/API.md
@@ -2129,6 +2129,64 @@ Unsubscribe the authenticated user from the Loops mailing list
 | --------------- | ------ |
 | PrivyCookie     |        |
 
+### /api/user/rewards/total
+
+#### GET
+
+##### Summary:
+
+Get total claimable rewards for the authenticated user
+
+##### Description:
+
+Retrieves the total amount of unclaimed rewards for the authenticated user's wallet address.
+This endpoint sums all non-claimed rewards from the rewards table for the user's address.
+Users should have one rewards entry per competition.
+
+##### Responses
+
+| Code | Description                                    |
+| ---- | ---------------------------------------------- |
+| 200  | Total claimable rewards retrieved successfully |
+| 400  | Invalid request parameters                     |
+| 401  | User not authenticated                         |
+| 500  | Internal server error                          |
+
+##### Security
+
+| Security Schema | Scopes |
+| --------------- | ------ |
+| SIWESession     |        |
+
+### /api/user/rewards/proofs
+
+#### GET
+
+##### Summary:
+
+Get rewards with proofs for the authenticated user
+
+##### Description:
+
+Retrieves all unclaimed rewards for the authenticated user's wallet address along with their Merkle proofs.
+Each reward includes the merkle root (encoded in Hex), the amount (as string), and the proof (encoded in Hex).
+This endpoint is used for claiming rewards on-chain.
+
+##### Responses
+
+| Code | Description                                |
+| ---- | ------------------------------------------ |
+| 200  | Rewards with proofs retrieved successfully |
+| 400  | Invalid request parameters                 |
+| 401  | User not authenticated                     |
+| 500  | Internal server error                      |
+
+##### Security
+
+| Security Schema | Scopes |
+| --------------- | ------ |
+| SIWESession     |        |
+
 ### /api/user/vote
 
 #### POST

--- a/apps/api/openapi/openapi.json
+++ b/apps/api/openapi/openapi.json
@@ -9708,6 +9708,234 @@
         }
       }
     },
+    "/api/user/rewards/total": {
+      "get": {
+        "summary": "Get total claimable rewards for the authenticated user",
+        "description": "Retrieves the total amount of unclaimed rewards for the authenticated user's wallet address.\nThis endpoint sums all non-claimed rewards from the rewards table for the user's address.\nUsers should have one rewards entry per competition.\n",
+        "tags": ["User"],
+        "security": [
+          {
+            "SIWESession": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Total claimable rewards retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "address": {
+                      "type": "string",
+                      "description": "The authenticated user's wallet address",
+                      "example": "0x1234567890abcdef1234567890abcdef12345678"
+                    },
+                    "totalClaimableRewards": {
+                      "type": "string",
+                      "description": "The total amount of unclaimed rewards as a string (to handle large numbers)",
+                      "example": "1000000000000000000"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request parameters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": false
+                    },
+                    "error": {
+                      "type": "string",
+                      "examples": {
+                        "missing_address": "Invalid request format: address is required",
+                        "invalid_format": "Invalid request format: Invalid Ethereum address format"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "User not authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": false
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "User not authenticated"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": false
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Internal server error"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/user/rewards/proofs": {
+      "get": {
+        "summary": "Get rewards with proofs for the authenticated user",
+        "description": "Retrieves all unclaimed rewards for the authenticated user's wallet address along with their Merkle proofs.\nEach reward includes the merkle root (encoded in Hex), the amount (as string), and the proof (encoded in Hex).\nThis endpoint is used for claiming rewards on-chain.\n",
+        "tags": ["User"],
+        "security": [
+          {
+            "SIWESession": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Rewards with proofs retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "address": {
+                      "type": "string",
+                      "description": "The authenticated user's wallet address",
+                      "example": "0x1234567890abcdef1234567890abcdef12345678"
+                    },
+                    "rewards": {
+                      "type": "array",
+                      "description": "Array of rewards with their proofs",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "merkleRoot": {
+                            "type": "string",
+                            "description": "The Merkle root hash encoded in Hex",
+                            "example": "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef12"
+                          },
+                          "amount": {
+                            "type": "string",
+                            "description": "The reward amount as a string (to handle large numbers)",
+                            "example": "1000000000000000000"
+                          },
+                          "proof": {
+                            "type": "array",
+                            "description": "Array of proof hashes encoded in Hex",
+                            "items": {
+                              "type": "string",
+                              "example": "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request parameters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": false
+                    },
+                    "error": {
+                      "type": "string",
+                      "examples": {
+                        "missing_address": "Invalid request format: address is required",
+                        "invalid_format": "Invalid request format: Invalid Ethereum address format"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "User not authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": false
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "User not authenticated"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": false
+                    },
+                    "error": {
+                      "type": "string",
+                      "example": "Internal server error"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/user/vote": {
       "post": {
         "summary": "Cast a vote for an agent in a competition",

--- a/apps/api/src/controllers/rewards.controller.ts
+++ b/apps/api/src/controllers/rewards.controller.ts
@@ -1,0 +1,109 @@
+import { NextFunction, Request, Response } from "express";
+
+import { ApiError } from "@recallnet/services/types";
+
+import { serviceLogger } from "@/lib/logger.js";
+import { ServiceRegistry } from "@/services/index.js";
+
+import { ensureUserId } from "./request-helpers.js";
+
+// No query parameters needed - wallet address comes from authenticated user
+
+/**
+ * Rewards Controller
+ * Handles reward-related operations with SIWE session authentication
+ * All endpoints require authenticated user session (req.userId)
+ */
+export function makeRewardsController(services: ServiceRegistry) {
+  return {
+    /**
+     * Get total claimable rewards for the authenticated user
+     * GET /api/user/rewards/total
+     * @param req Express request with userId from session
+     * @param res Express response
+     * @param next Express next function
+     */
+    async getTotalClaimableRewards(
+      req: Request,
+      res: Response,
+      next: NextFunction,
+    ) {
+      try {
+        const userId = ensureUserId(req);
+
+        // Get user to retrieve wallet address
+        const user = await services.userService.getUser(userId);
+        if (!user) {
+          throw new ApiError(404, "User not found");
+        }
+
+        const totalRewards =
+          await services.rewardsService.getTotalClaimableRewards(
+            user.walletAddress,
+          );
+
+        serviceLogger.debug(
+          `[RewardsController] Retrieved total claimable rewards for address ${user.walletAddress}: ${totalRewards}`,
+        );
+
+        res.status(200).json({
+          success: true,
+          address: user.walletAddress,
+          totalClaimableRewards: totalRewards.toString(),
+        });
+      } catch (error) {
+        serviceLogger.error(
+          "[RewardsController] Error in getTotalClaimableRewards:",
+          error,
+        );
+        next(error);
+      }
+    },
+
+    /**
+     * Get rewards with proofs for the authenticated user
+     * GET /api/user/rewards/proofs
+     * @param req Express request with userId from session
+     * @param res Express response
+     * @param next Express next function
+     */
+    async getRewardsWithProofs(
+      req: Request,
+      res: Response,
+      next: NextFunction,
+    ) {
+      try {
+        const userId = ensureUserId(req);
+
+        // Get user to retrieve wallet address
+        const user = await services.userService.getUser(userId);
+        if (!user) {
+          throw new ApiError(404, "User not found");
+        }
+
+        const rewardsWithProofs =
+          await services.rewardsService.getRewardsWithProofs(
+            user.walletAddress,
+          );
+
+        serviceLogger.debug(
+          `[RewardsController] Retrieved ${rewardsWithProofs.length} rewards with proofs for address ${user.walletAddress}`,
+        );
+
+        res.status(200).json({
+          success: true,
+          address: user.walletAddress,
+          rewards: rewardsWithProofs,
+        });
+      } catch (error) {
+        serviceLogger.error(
+          "[RewardsController] Error in getRewardsWithProofs:",
+          error,
+        );
+        next(error);
+      }
+    },
+  };
+}
+
+export type RewardsController = ReturnType<typeof makeRewardsController>;

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -13,6 +13,7 @@ import { makeDocsController } from "@/controllers/docs.controller.js";
 import { makeHealthController } from "@/controllers/health.controller.js";
 import { makeLeaderboardController } from "@/controllers/leaderboard.controller.js";
 import { makePriceController } from "@/controllers/price.controller.js";
+import { makeRewardsController } from "@/controllers/rewards.controller.js";
 import { makeTradeController } from "@/controllers/trade.controller.js";
 import { makeUserController } from "@/controllers/user.controller.js";
 import { makeVoteController } from "@/controllers/vote.controller.js";
@@ -168,6 +169,7 @@ const competitionController = makeCompetitionController(services);
 const docsController = makeDocsController();
 const healthController = makeHealthController();
 const priceController = makePriceController(services);
+const rewardsController = makeRewardsController(services);
 const tradeController = makeTradeController(services);
 const userController = makeUserController(
   services,
@@ -191,7 +193,11 @@ const docsRoutes = configureDocsRoutes(docsController);
 const healthRoutes = configureHealthRoutes(healthController);
 const priceRoutes = configurePriceRoutes(priceController);
 const tradeRoutes = configureTradeRoutes(tradeController);
-const userRoutes = configureUserRoutes(userController, voteController);
+const userRoutes = configureUserRoutes(
+  userController,
+  voteController,
+  rewardsController,
+);
 const agentRoutes = configureAgentRoutes(agentController);
 const agentsRoutes = configureAgentsRoutes(agentController);
 const leaderboardRoutes = configureLeaderboardRoutes(leaderboardController);

--- a/packages/services/src/lib/index.ts
+++ b/packages/services/src/lib/index.ts
@@ -12,3 +12,4 @@ export * from "./sort.js";
 export * from "./trade-utils.js";
 export * from "./typescript-utils.js";
 export * from "./watchlist.js";
+export * from "./rewards-allocator-mock.js";

--- a/packages/services/src/lib/rewards-allocator-mock.ts
+++ b/packages/services/src/lib/rewards-allocator-mock.ts
@@ -1,0 +1,34 @@
+/**
+ * Mock implementation of RewardsAllocator for testing
+ * This module provides mock implementations that bypass blockchain interactions
+ */
+
+/**
+ * Mock implementation of RewardsAllocator for testing.
+ * Provides the same interface as the real RewardsAllocator but without blockchain interactions.
+ */
+export class MockRewardsAllocator {
+    /**
+     * Mock allocate method that simulates blockchain allocation without actual transactions
+     * @param root The Merkle root hash
+     * @param totalAmount The total amount to allocate
+     * @param startTimestamp The timestamp from which rewards can be claimed
+     * @returns Mock allocation result with fake transaction details
+     */
+    async allocate(
+      root: string, // eslint-disable-line @typescript-eslint/no-unused-vars
+      totalAmount: bigint, // eslint-disable-line @typescript-eslint/no-unused-vars
+      startTimestamp: number, // eslint-disable-line @typescript-eslint/no-unused-vars
+    ): Promise<{
+      transactionHash: string;
+      blockNumber: bigint;
+      gasUsed: bigint;
+    }> {
+      // Return mock transaction details
+      return {
+        transactionHash: `0x${"0".repeat(64)}`, // Mock transaction hash
+        blockNumber: 12345n, // Mock block number
+        gasUsed: 21000n, // Mock gas used
+      };
+    }
+  }


### PR DESCRIPTION
# Context

Closes [APP-318](https://linear.app/recall-labs/issue/APP-318/rewards-api-implementation)

Adds the following 3 endpoints:
1.  `GET /user/rewards/total`
2.  `GET /user/rewards/proofs`
3.  ~`POST /user/rewards/claim/`~

These will be used to implement the CLAIM flow button in the navbar:

<img width="720" height="134" alt="image" src="https://github.com/user-attachments/assets/88140e77-ea9e-4bf8-94c9-052caaf67d0d" />

