### PR TITLE
Rename sandbox api base to proxy base

### DIFF
--- a/apps/comps/README.md
+++ b/apps/comps/README.md
@@ -98,6 +98,27 @@ To start the development server, run the following. It should run on port `3001`
 PORT=3001 pnpm dev
 ```
 
+## Sandbox Proxy Routes
+
+⚠️ **IMPORTANT**: These are Next.js API routes that act as a PROXY to the sandbox server.
+
+### How it works:
+
+1. Frontend calls `/api/sandbox/competitions/{id}/agents/{id}` (this Next.js route)
+2. This route adds admin authentication
+3. Forwards to `https://api.sandbox.competitions.recall.network/admin/competitions/{id}/agents/{id}`
+
+### Why this exists:
+
+- Hides admin API keys from the browser
+- Allows users to join sandbox competitions without direct admin access
+- Enables balance reset on join (via admin endpoint)
+
+### Key difference from regular API:
+
+- Regular: `/competitions/{id}/agents/{id}` - NO balance reset
+- Admin proxy: `/admin/competitions/{id}/agents/{id}` - RESETS balances
+
 ## Contributing
 
 PRs accepted.

--- a/apps/comps/lib/sandbox-client.ts
+++ b/apps/comps/lib/sandbox-client.ts
@@ -11,7 +11,7 @@ import {
   AdminUserResponse,
 } from "@/types/admin";
 
-const SANDBOX_API_BASE = "/api/sandbox";
+const SANDBOX_PROXY_BASE = "/api/sandbox";
 
 /**
  * Client for interacting with sandbox API endpoints
@@ -22,7 +22,7 @@ export class SandboxClient {
    * @returns User creation response
    */
   async createUser(): Promise<AdminUserResponse> {
-    const response = await fetch(`${SANDBOX_API_BASE}/users`, {
+    const response = await fetch(`${SANDBOX_PROXY_BASE}/users`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -51,7 +51,7 @@ export class SandboxClient {
     email?: string;
     metadata?: Record<string, unknown>;
   }): Promise<AdminCreateAgentResponse> {
-    const response = await fetch(`${SANDBOX_API_BASE}/agents`, {
+    const response = await fetch(`${SANDBOX_PROXY_BASE}/agents`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -75,7 +75,7 @@ export class SandboxClient {
    */
   async getAgentApiKey(agentHandle: string): Promise<AdminAgentKeyResponse> {
     const response = await fetch(
-      `${SANDBOX_API_BASE}/api-key?handle=${encodeURIComponent(agentHandle)}`,
+      `${SANDBOX_PROXY_BASE}/api-key?handle=${encodeURIComponent(agentHandle)}`,
       {
         method: "GET",
         headers: {
@@ -110,7 +110,7 @@ export class SandboxClient {
       metadata?: Record<string, unknown>;
     },
   ): Promise<AdminAgentUpdateResponse> {
-    const response = await fetch(`${SANDBOX_API_BASE}/agents/${agentId}`, {
+    const response = await fetch(`${SANDBOX_PROXY_BASE}/agents/${agentId}`, {
       method: "PUT",
       headers: {
         "Content-Type": "application/json",
@@ -131,7 +131,7 @@ export class SandboxClient {
    * Get competitions
    */
   async getCompetitions(): Promise<CompetitionsResponse> {
-    const response = await fetch(`${SANDBOX_API_BASE}/competitions`, {
+    const response = await fetch(`${SANDBOX_PROXY_BASE}/competitions`, {
       method: "GET",
       headers: {
         "Content-Type": "application/json",
@@ -159,7 +159,7 @@ export class SandboxClient {
     agentId: string,
   ): Promise<JoinCompetitionResponse> {
     const response = await fetch(
-      `${SANDBOX_API_BASE}/competitions/${competitionId}/agents/${agentId}`,
+      `${SANDBOX_PROXY_BASE}/competitions/${competitionId}/agents/${agentId}`,
       {
         method: "POST",
         headers: {
@@ -189,7 +189,7 @@ export class SandboxClient {
   ): Promise<AgentCompetitionsResponse> {
     const queryParams = this.formatQueryParams(params);
     const response = await fetch(
-      `${SANDBOX_API_BASE}/agents/${agentId}/competitions${queryParams}`,
+      `${SANDBOX_PROXY_BASE}/agents/${agentId}/competitions${queryParams}`,
       {
         method: "GET",
         headers: {


### PR DESCRIPTION
Rename `SANDBOX_API_BASE` to `SANDBOX_PROXY_BASE` and add proxy documentation to `apps/comps/README.md` to clarify the purpose and usage of sandbox proxy routes.

---
Linear Issue: [APP-400](https://linear.app/recall-labs/issue/APP-400/rename-sandbox-api-base-to-sandbox-proxy-base)

<a href="https://cursor.com/background-agent?bcId=bc-2aef702a-3730-4d3d-8516-d487b24dfa24">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2aef702a-3730-4d3d-8516-d487b24dfa24">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

