### PR TITLE
fix(ci): ignore speakeasy generated folders in `pnpm format:check`

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -11,3 +11,8 @@ packages/fonts/src/*
 **/node_modules
 **/.next
 **/.turbo
+
+# Speakeasy SDK generated / hidden files
+packages/api-sdk/.tshy
+packages/api-sdk/bin
+packages/api-sdk/docs


### PR DESCRIPTION
the husky precommit hook always fail with `pnpm format:check` for the package `packages/api-sdk`. we ignore `.tshy/` and other folders that aren't meant to be formatted (they're ignored by `packages/api-sdk`).

for reference, this PR fixes the same error that we see in the [GH release action](https://github.com/recallnet/js-recall/actions/runs/17655606913/job/50177450278#step:9:189):
```
> @recallnet/api-sdk@0.0.1 format:check /Users/dtb/rcl/js-recall/packages/
api-sdk
> prettier --check . --ignore-path=../../.prettierignore

Checking formatting...
[warn] .tshy/commonjs.json
[warn] .tshy/esm.json
[warn] bin/mcp-server.js
[warn] Code style issues found in 3 files. Run Prettier with --write to fi
x.
 ELIFECYCLE  Command failed with exit code 1.
command finished with error: command (/Users/dtb/rcl/js-recall/packages/ap
i-sdk) /Users/dtb/Library/pnpm/.tools/@pnpm+macos-arm64/9.12.3/bin/pnpm ru
n format:check exited (1)
└─ @recallnet/api-sdk#format:check ──
@recallnet/api-sdk#format:check: command (/Users/dtb/rcl/js-recall/packages/api-sdk) /Users/dtb/Library/pnpm/.tools/@pnpm+macos-arm64/9.12.3/bin/pnpm run format:check exited (1)

 Tasks:    7 successful, 9 total
Cached:    0 cached, 9 total
  Time:    7.476s 
Failed:    @recallnet/api-sdk#format:check
```