### PR TITLE
fix(comps): retrieving agent api keys

### DIFF
--- a/apps/comps/app/api/sandbox/users/route.ts
+++ b/apps/comps/app/api/sandbox/users/route.ts
@@ -29,16 +29,35 @@ async function handleCreateUser(request: NextRequest) {
     sessionCookie,
   );
   const { user } = profileData;
-  const { walletAddress, name, email, imageUrl, metadata } = user;
+  const {
+    walletAddress,
+    name,
+    email,
+    imageUrl,
+    metadata,
+    privyId,
+    embeddedWalletAddress,
+  } = user;
 
-  // Check if user already exists in sandbox
-  const searchData = await sandboxAdminRequest<AdminSearchResult>(
+  // Check if user already exists in sandbox with wallet address
+  const searchByWalletAddress = await sandboxAdminRequest<AdminSearchResult>(
     `/admin/search?user.walletAddress=${walletAddress}`,
   );
+  if (searchByWalletAddress.results.users.length > 0) {
+    const existingUser = searchByWalletAddress.results.users[0];
+    return createSuccessResponse({
+      success: true,
+      user: existingUser,
+      message: "User already exists in sandbox",
+    });
+  }
 
-  // If user already exists, return the existing user
-  if (searchData.results?.users && searchData.results.users.length > 0) {
-    const existingUser = searchData.results.users[0];
+  // Check if user already exists in sandbox with email
+  const searchByEmail = await sandboxAdminRequest<AdminSearchResult>(
+    `/admin/search?user.email=${encodeURIComponent(email)}`,
+  );
+  if (searchByEmail.results.users.length > 0) {
+    const existingUser = searchByEmail.results.users[0];
     return createSuccessResponse({
       success: true,
       user: existingUser,
@@ -49,10 +68,12 @@ async function handleCreateUser(request: NextRequest) {
   // Create user in sandbox
   const createUserPayload = {
     walletAddress,
-    name: name || undefined,
-    email: email || undefined,
+    name,
+    email,
     userImageUrl: imageUrl || undefined,
     userMetadata: metadata || undefined,
+    privyId,
+    embeddedWalletAddress,
   };
 
   const createData = await sandboxAdminRequest<AdminUserResponse>(

--- a/apps/comps/components/agent-profile/credentials.tsx
+++ b/apps/comps/components/agent-profile/credentials.tsx
@@ -85,8 +85,13 @@ export const Credentials = ({
   agent: Agent;
   className?: string;
 }) => {
-  const { productionKey, sandboxKey, isLoadingKeys, isUnlocked, mutation } =
-    useUnlockKeys(agent.handle, agent.id);
+  const {
+    productionKey,
+    sandboxKey,
+    isLoadingKeys,
+    isSandboxUnlocked,
+    mutation,
+  } = useUnlockKeys(agent.handle, agent.id);
 
   const unlockKeys = () => {
     mutation.mutate();
@@ -118,7 +123,7 @@ export const Credentials = ({
             tooltip="Sandbox Agent API Key"
             apiKey={sandboxKey}
             isLoading={isLoadingKeys}
-            isLocked={!isUnlocked}
+            isLocked={!isSandboxUnlocked}
             onUnlock={unlockKeys}
             isUnlocking={mutation.isPending}
           />

--- a/apps/comps/components/agent-profile/credentials.tsx
+++ b/apps/comps/components/agent-profile/credentials.tsx
@@ -20,11 +20,17 @@ const ApiKeyRow = ({
   tooltip,
   apiKey,
   isLoading,
+  isLocked,
+  onUnlock,
+  isUnlocking,
 }: {
   label: string;
   tooltip: string;
   apiKey?: string;
   isLoading: boolean;
+  isLocked?: boolean;
+  onUnlock?: () => void;
+  isUnlocking?: boolean;
 }) => {
   const [isVisible, setIsVisible] = useState(false);
 
@@ -36,64 +42,38 @@ const ApiKeyRow = ({
         </Tooltip>
         <span className="text-sm">{label}</span>
       </div>
-      {isVisible || isLoading ? (
-        <span className="text-primary-foreground flex-grow truncate">
-          {apiKey}
-        </span>
+      {isLocked && onUnlock ? (
+        <div className="flex flex-grow items-center gap-4">
+          <span className="text-secondary-foreground text-sm">
+            Click to unlock your API key
+          </span>
+          <Button
+            onClick={onUnlock}
+            disabled={isUnlocking}
+            className="ml-auto flex gap-2 bg-blue-600 px-6 py-2 text-xs"
+          >
+            <KeyRound className="h-4 w-4" strokeWidth={1.3} />
+            <span>{isUnlocking ? "Loading..." : "Unlock"}</span>
+          </Button>
+        </div>
       ) : (
-        <span className="text-primary-foreground flex-grow truncate">
-          ••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••
-        </span>
+        <>
+          {isVisible || isLoading ? (
+            <span className="text-primary-foreground flex-grow truncate">
+              {apiKey}
+            </span>
+          ) : (
+            <span className="text-primary-foreground flex-grow truncate">
+              ••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••
+            </span>
+          )}
+          <VisibilityToggle
+            isVisible={isVisible}
+            onToggle={() => setIsVisible(!isVisible)}
+          />
+          <CopyButton textToCopy={apiKey || ""} />
+        </>
       )}
-      <VisibilityToggle
-        isVisible={isVisible}
-        onToggle={() => setIsVisible(!isVisible)}
-      />
-      <CopyButton textToCopy={apiKey || ""} />
-    </div>
-  );
-};
-
-const ApiKeyLocked = ({
-  unlockKeysMutation,
-}: {
-  unlockKeysMutation: ReturnType<typeof useUnlockKeys>["mutation"];
-}) => {
-  const unlockKeys = async () => {
-    unlockKeysMutation.mutate();
-  };
-
-  const button = (
-    <Button
-      onClick={unlockKeys}
-      disabled={unlockKeysMutation.isPending}
-      className="flex gap-3 bg-blue-600 px-12 py-7 text-xs"
-    >
-      <KeyRound className="h-6 w-6 uppercase" strokeWidth={1.3} />
-      <span>{unlockKeysMutation.isPending ? "Loading..." : "Unlock keys"}</span>
-    </Button>
-  );
-
-  return (
-    <div className="grid w-full grid-cols-1 items-center gap-4 sm:grid-cols-[30px_200px_1fr_300px]">
-      <div className="mx-auto flex w-8 items-center justify-center md:mx-0">
-        <KeyRound className="h-7 w-7 text-gray-500" strokeWidth={1.3} />
-      </div>
-
-      <div className="text-center sm:text-left">
-        <span className="text-secondary-foreground block text-sm font-bold">
-          Your API keys are
-          <span className="ml-1 text-red-500">locked</span>.
-        </span>
-      </div>
-
-      <div className="text-center sm:text-left">
-        <span className="text-secondary-foreground text-sm">
-          Click below to unlock your Production and Sandbox API keys.
-        </span>
-      </div>
-
-      <div className="flex justify-center sm:justify-end">{button}</div>
     </div>
   );
 };
@@ -108,6 +88,10 @@ export const Credentials = ({
   const { productionKey, sandboxKey, isLoadingKeys, isUnlocked, mutation } =
     useUnlockKeys(agent.handle, agent.id);
 
+  const unlockKeys = () => {
+    mutation.mutate();
+  };
+
   return (
     <div
       className={cn(
@@ -121,7 +105,7 @@ export const Credentials = ({
           <Skeleton className="h-10 w-full" />
           <Skeleton className="h-10 w-full" />
         </div>
-      ) : isUnlocked ? (
+      ) : (
         <>
           <ApiKeyRow
             label="Production API Key"
@@ -129,17 +113,16 @@ export const Credentials = ({
             apiKey={productionKey}
             isLoading={isLoadingKeys}
           />
-          {sandboxKey && (
-            <ApiKeyRow
-              label="Sandbox API Key"
-              tooltip="Sandbox Agent API Key"
-              apiKey={sandboxKey}
-              isLoading={isLoadingKeys}
-            />
-          )}
+          <ApiKeyRow
+            label="Sandbox API Key"
+            tooltip="Sandbox Agent API Key"
+            apiKey={sandboxKey}
+            isLoading={isLoadingKeys}
+            isLocked={!isUnlocked}
+            onUnlock={unlockKeys}
+            isUnlocking={mutation.isPending}
+          />
         </>
-      ) : (
-        <ApiKeyLocked unlockKeysMutation={mutation} />
       )}
     </div>
   );

--- a/apps/comps/components/create-agent/agent-created.tsx
+++ b/apps/comps/components/create-agent/agent-created.tsx
@@ -65,7 +65,7 @@ export function AgentCreated({ agent }: AgentCreatedProps) {
     productionKey,
     sandboxKey,
     isLoadingKeys,
-    isUnlocked,
+    isSandboxUnlocked,
   } = useUnlockKeys(agent.handle, agent.id);
   const { ready, backendUser } = useSession();
 
@@ -75,9 +75,9 @@ export function AgentCreated({ agent }: AgentCreatedProps) {
     unlockKeys.mutate();
   };
 
-  // Show keys if they are unlocked and loaded
-  const hasKeys = productionKey || sandboxKey;
-  const showKeys = isUnlocked && hasKeys && !isLoadingKeys;
+  // Always show production key, but only show sandbox key if it's unlocked (agent joined competition)
+  const showProductionKey = productionKey && !isLoadingKeys;
+  const showSandboxKey = isSandboxUnlocked && sandboxKey && !isLoadingKeys;
 
   return (
     <div className="mb-20 flex flex-col">
@@ -98,53 +98,46 @@ export function AgentCreated({ agent }: AgentCreatedProps) {
         environments using your unique API keys.
       </p>
 
-      {showKeys ? (
+      {showProductionKey && (
         // Show the actual API keys
         <div className="flex flex-col gap-6">
-          {productionKey && (
-            <ApiKeySection
-              title="Production API Key"
-              apiKey={productionKey}
-              description="Use this key to connect your agent to the production environment."
-            />
-          )}
-          {sandboxKey && (
+          <ApiKeySection
+            title="Production API Key"
+            apiKey={productionKey}
+            description="Use this key to connect your agent to the production environment."
+          />
+          {showSandboxKey ? (
             <ApiKeySection
               title="Sandbox API Key"
               apiKey={sandboxKey}
               description="Use this key to connect your agent to the sandbox environment for testing."
             />
+          ) : (
+            <Card
+              corner={["top-left", "top-right", "bottom-left", "bottom-right"]}
+              cropSize={[30, 30]}
+              className="text-secondary-foreground mt-4 flex flex-col gap-4 px-8 py-6"
+            >
+              <span className="text-primary-foreground text-lg font-bold">
+                Unlock Sandbox API Key
+              </span>
+              <span>Click to generate your Sandbox API key for testing.</span>
+              <div className="flex w-full justify-center">
+                <Button
+                  onClick={onUnlockKeys}
+                  disabled={unlockKeys.isPending}
+                  className="flex max-w-[250px] gap-3 bg-blue-600 px-12 py-7 text-xs"
+                >
+                  <KeyRound className="h-6 w-6" strokeWidth={1.3} />
+                  <span className="uppercase">
+                    {unlockKeys.isPending ? "Loading..." : "Generate key"}
+                  </span>
+                </Button>
+              </div>
+            </Card>
           )}
         </div>
-      ) : (
-        // Show the unlock keys step
-        <Card
-          corner={["top-left", "top-right", "bottom-left", "bottom-right"]}
-          cropSize={[30, 30]}
-          className="text-secondary-foreground flex flex-col gap-4 px-8 py-6"
-        >
-          <span className="text-primary-foreground text-lg font-bold">
-            Get your API Keys
-          </span>
-          <span>
-            Click below to generate your API Keys for connecting to our Sandbox
-            and Production environments.
-          </span>
-          <div className="flex w-full justify-center">
-            <Button
-              onClick={onUnlockKeys}
-              disabled={unlockKeys.isPending}
-              className="flex max-w-[250px] gap-3 bg-blue-600 px-12 py-7 text-xs"
-            >
-              <KeyRound className="h-6 w-6" strokeWidth={1.3} />
-              <span className="uppercase">
-                {unlockKeys.isPending ? "Loading..." : "Unlock keys"}
-              </span>
-            </Button>
-          </div>
-        </Card>
       )}
-
       <p className="text-secondary-foreground mt-4">
         Need help? Reach out on our{" "}
         <Link
@@ -158,7 +151,7 @@ export function AgentCreated({ agent }: AgentCreatedProps) {
       </p>
       <div className="xs:flex-row mt-8 flex flex-col justify-center gap-2">
         <Link
-          href="https://docs.recall.network/competitions/guides/verify-agent-wallet"
+          href="https://docs.recall.network/competitions/developer-guides"
           target="_blank"
         >
           <Button variant="outline" className="w-full px-10 uppercase">

--- a/apps/comps/lib/api-client.ts
+++ b/apps/comps/lib/api-client.ts
@@ -61,6 +61,11 @@ export class HttpError extends Error {
  */
 export class UnauthorizedError extends HttpError {
   constructor(message?: string) {
+    message = message?.includes(
+      "[AuthMiddleware] Authentication required. Invalid Privy token or no API key provided. Use Authorization: Bearer YOUR_API_KEY",
+    )
+      ? "Error authenticating. Please try again."
+      : message;
     super(401, "Unauthorized", message || "Unauthorized access");
     this.name = "UnauthorizedError";
   }

--- a/apps/comps/types/admin.ts
+++ b/apps/comps/types/admin.ts
@@ -1,17 +1,6 @@
-export interface SandboxUser {
-  id: string;
-  walletAddress: string;
-  name?: string;
-  email?: string;
-  imageUrl?: string;
-  metadata?: Record<string, unknown>;
-  status: string;
-  createdAt: string;
-  updatedAt: string;
-}
-
 export interface AdminAgent {
   id: string;
+  handle: string;
   ownerId: string;
   name: string;
   description?: string;
@@ -34,8 +23,8 @@ export interface AdminSearchResult {
   success: boolean;
   searchType: string;
   results: {
-    users?: AdminUser[];
-    agents?: AdminAgent[];
+    users: AdminUser[];
+    agents: AdminAgent[];
   };
 }
 
@@ -63,13 +52,18 @@ export interface AdminAgentUpdateResponse {
 export interface AdminUser {
   id: string;
   walletAddress: string;
+  walletLastVerifiedAt?: string;
+  embeddedWalletAddress?: string;
+  privyId?: string;
   name?: string;
-  email?: string;
+  email: string;
+  isSubscribed: boolean;
   imageUrl?: string;
   metadata?: Record<string, unknown>;
   status: string;
   createdAt: string;
   updatedAt: string;
+  lastLoginAt?: string;
 }
 
 export interface AdminAgent {

--- a/apps/comps/types/profile.ts
+++ b/apps/comps/types/profile.ts
@@ -6,7 +6,7 @@ export interface User {
   privyId?: string;
   status: "active" | "inactive" | "suspended" | "deleted";
   name?: string;
-  email?: string;
+  email: string;
   isSubscribed: boolean;
   imageUrl?: string;
   metadata?: {


### PR DESCRIPTION
closes [APP-419](https://linear.app/recall-labs/issue/APP-419/users-cannot-get-api-key-in-comps-ui-due-to-sandboxprod-db-mismatch). a few fixes:
1. legacy users in the sandbox db might _only_ have a wallet address
   - before: when we look up the agent API key, we were using the admin search API for user + agent combinations (`user.walletAddress` +  `agent.handle`). this can lead to problems in case the prod<>sandbox dbs get out of sync with user profile information.
   - now: since agent handles are globally unique, we can be more lenient and simply fetch the sandbox agent API key based on their handles. our existing logic better handles updates to the sandbox if the agent handle changes.
2. agent didn't exist
   - before: somehow, the frontend didnt trigger an agent to get created. when a user tried to get the sandbox API key, there was nothing to fetch.
   - now: we will create a sandbox agent if the agent handle is not found.
3. cant get prod keys, even though logged in
   - before: our old logic had wonky email verification that gated both prod and sandbox keys.
   - now: production API keys are always shown to the user. sandbox API keys are hidden, but only because the user needs to manually "join competition". (note: we can probably refactor this and auto-join agents into the sandbox competition.)