### PR TITLE
fix(ci): stop random chars from interactive output

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,5 @@
 #!/bin/sh
+export CI=1
 
 echo "🚀 Running pre-push quality checks..."
 


### PR DESCRIPTION
## Summary

fixes annoying random characters from being injected into your terminal when pushing to remote.

## Details

with the husky pre-push hook, it will run / exit...but then it logs a bunch of random numbers/characters. these are raw ANSI control codes from interactive output (spinners/progress) leaking out of the Git hook—e.g., pnpm.

<img width="1456" height="168" alt="image" src="https://github.com/user-attachments/assets/6a1c1bfe-ad0c-4ffc-8b34-2f111e89ef20" />