### PR TITLE
fix(api): cache comps endpoint if incldues user-specific info

### DIFF
--- a/apps/api/src/controllers/competition.controller.ts
+++ b/apps/api/src/controllers/competition.controller.ts
@@ -241,6 +241,8 @@ export function makeCompetitionController(services: ServiceRegistry) {
         const cacheKey = generateCacheKey(req, "list", {
           status,
           ...pagingParams,
+          // Include userId in cache key since response includes user-specific voting data
+          ...(userId && { userId }),
         });
 
         if (shouldCacheResponse) {
@@ -315,6 +317,8 @@ export function makeCompetitionController(services: ServiceRegistry) {
         const shouldCacheResponse = checkShouldCacheResponse(req);
         const cacheKey = generateCacheKey(req, "byId", {
           competitionId,
+          // Include userId in cache key since response includes user-specific voting data
+          ...(userId && { userId }),
         });
 
         if (shouldCacheResponse) {


### PR DESCRIPTION
we implemented a user-specific cache fix in [APP-418](https://linear.app/recall-labs/issue/APP-418/backend-api-returns-cached-data-for-hasvoted) ([PR](https://github.com/recallnet/js-recall/pull/1218/files#diff-003348c608e4df375ba22aa3d535d217103aca9cd7d7b07f3ecaf2e43641c20fR544)) that somehow got removed. this adds the code back.

note: we disabled this feature in production as a hotfix, so that's why we haven't heard about the problem.