### PR TITLE
feat(comps): hide 'rules' tab for perps

### DIFF
--- a/apps/comps/components/competition-info.tsx
+++ b/apps/comps/components/competition-info.tsx
@@ -76,12 +76,15 @@ export const CompetitionInfo: React.FC<CompetitionInfoProps> = ({
         >
           Info
         </TabsTrigger>
-        <TabsTrigger
-          value="rules"
-          className="border border-white bg-black px-4 py-2 text-xs font-semibold uppercase text-white transition-colors duration-200 hover:bg-white hover:text-black data-[state=active]:bg-white data-[state=active]:text-black data-[state=active]:hover:bg-white data-[state=active]:hover:text-black"
-        >
-          Rules
-        </TabsTrigger>
+        {/* TODO: temporarily disable rules for perpetual futures since the `/rules` endpoint is inaccurate */}
+        {competition.type !== "perpetual_futures" && (
+          <TabsTrigger
+            value="rules"
+            className="border border-white bg-black px-4 py-2 text-xs font-semibold uppercase text-white transition-colors duration-200 hover:bg-white hover:text-black data-[state=active]:bg-white data-[state=active]:text-black data-[state=active]:hover:bg-white data-[state=active]:hover:text-black"
+          >
+            Rules
+          </TabsTrigger>
+        )}
       </TabsList>
 
       <TabsContent value="info" className="border">

--- a/apps/comps/types/competition.ts
+++ b/apps/comps/types/competition.ts
@@ -36,13 +36,15 @@ export interface AgentStatus {
   };
 }
 
+export type CompetitionType = "trading" | "perpetual_futures";
+
 export interface Competition {
   id: string;
   name: string;
   description: string | null;
   externalUrl: string | null;
   imageUrl: string | null;
-  type: string;
+  type: CompetitionType;
   status: CompetitionStatus;
   crossChainTradingType: CrossChainTradingType;
   startDate: string | null;


### PR DESCRIPTION
Hide the "rules" tab if it's a perps com
<img width="715" height="692" alt="Screenshot 2025-09-26 at 3 20 45 PM" src="https://github.com/user-attachments/assets/f601244e-7003-40e5-97a1-43b0f33a8358" />
