### PR TITLE
fix(ci): install deps

### DIFF
--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -63,6 +63,9 @@ jobs:
         with:
           version: 9.12.3 # Note: matches exact version from root `package.json`
 
+      - name: Install Dependencies
+        run: pnpm install
+
       - name: Install Vercel CLI
         run: pnpm install --global vercel@latest
 


### PR DESCRIPTION
Fix CI action for vercel deployment by installing deps. See [here](https://github.com/recallnet/js-recall/actions/runs/18048746632/job/51365785912#step:7:846) for error.