### PR TITLE
test(api): fix abort error in retry helper

### DIFF
--- a/apps/api/src/lib/__tests__/retry-helper.test.ts
+++ b/apps/api/src/lib/__tests__/retry-helper.test.ts
@@ -139,6 +139,8 @@ describe("retry-helper", () => {
 
         const RETRY_CONFIG_WITH_OPTIONALS: RetryConfig = {
           ...TEST_RETRY_CONFIG,
+          // Ensure non-zero backoff so abort can be observed deterministically
+          jitter: "none",
           signal: controller.signal,
         };
 


### PR DESCRIPTION
The retry helper test is [flaky](https://github.com/recallnet/js-recall/actions/runs/18047512613/job/51361745426), likely due to the non-deterministic jitter and the configured timeouts.