### PR TITLE
fix: frontend competition table ordering for perps to use rank from backend

### DIFF
--- a/apps/comps/components/agents-table/index.tsx
+++ b/apps/comps/components/agents-table/index.tsx
@@ -72,12 +72,10 @@ export const AgentsTable: React.FC<AgentsTableProps> = ({
   const session = useSession();
   const router = useRouter();
   const tableContainerRef = useRef<HTMLDivElement>(null);
-  // Default sort: Calmar Ratio for perps, rank for others
-  const [sorting, setSorting] = useState<SortingState>(
-    competition.type === "perpetual_futures"
-      ? [{ id: "calmarRatio", desc: true }]
-      : [{ id: "rank", desc: false }],
-  );
+  // Default sort: Always sort by rank (backend handles Calmar-based ordering for perps)
+  const [sorting, setSorting] = useState<SortingState>([
+    { id: "rank", desc: false },
+  ]);
   const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({
     yourShare: session.ready && session.isAuthenticated,
   });


### PR DESCRIPTION
# Fix Frontend Display Order for Perps Competition Leaderboard

## Summary

This PR fixes the frontend display issue where agents in perps competitions were shown in incorrect visual order (3rd, 1st, 2nd) despite having correct rank assignments from the backend.

## Problem

The perps competition leaderboard was displaying agents out of order on the frontend. While the backend correctly:
1. Sorted agents by Calmar ratio (with fallback to equity for those without Calmar)
2. Assigned ranks correctly (1st, 2nd, 3rd)

The frontend was displaying them in the wrong visual order due to attempting to sort by `calmarRatio` field, which could be null for some agents.

## Root Cause

The agents table component was initializing with different sort states for different competition types:
- Perps competitions: Sorted by `calmarRatio` descending
- Other competitions: Sorted by `rank` ascending

Since some agents may not have Calmar ratios (showing as "-" in the UI), the sort by `calmarRatio` was producing unexpected ordering where agents with null values were positioned incorrectly.

## Solution

Changed the frontend to always sort by rank for all competition types, including perps competitions:

```typescript
// Before:
const [sorting, setSorting] = useState<SortingState>(
  competition.type === "perpetual_futures"
    ? [{ id: "calmarRatio", desc: true }]
    : [{ id: "rank", desc: false }],
);

// After:
const [sorting, setSorting] = useState<SortingState>([
  { id: "rank", desc: false },
]);
```

## Why This Works

- The backend already handles the complex Calmar-based sorting logic
- The backend assigns ranks based on that sorting (1, 2, 3, etc.)
- The frontend should simply display agents in rank order
- This ensures the visual order matches the assigned ranks

## Testing

The fix ensures that:
- Agents display in correct rank order (1st, 2nd, 3rd, etc.)
- The display order matches the rank numbers shown
- Works correctly for both agents with and without Calmar ratios

## Impact

This is a display-only fix with no backend changes. The ranking logic remains unchanged - only the visual presentation is corrected to match the assigned ranks.

## Files Changed

- `apps/comps/components/agents-table/index.tsx` - Changed default sort to always use rank instead of Calmar ratio for perps competitions
