### PR TITLE
fix: return average equity and volume, change positions to open posit…

### DIFF
--- a/apps/api/e2e/tests/perps-competition.test.ts
+++ b/apps/api/e2e/tests/perps-competition.test.ts
@@ -118,6 +118,17 @@ describe("Perps Competition", () => {
 
     expect(comp?.stats?.totalPositions).toBeDefined();
     expect(comp.stats?.totalTrades).toBeUndefined();
+
+    // Verify perps competitions include volume and average equity stats
+    expect(comp?.stats?.totalVolume).toBeDefined();
+    expect(typeof comp?.stats?.totalVolume).toBe("number");
+    // Note: totalVolume can be 0 for a new competition with no trades yet
+    expect(comp?.stats?.totalVolume).toBeGreaterThanOrEqual(0);
+
+    expect(comp?.stats?.averageEquity).toBeDefined();
+    expect(typeof comp?.stats?.averageEquity).toBe("number");
+    // Note: averageEquity can be 0 if no agents have joined yet
+    expect(comp?.stats?.averageEquity).toBeGreaterThanOrEqual(0);
   });
 
   test("should get perps positions for an agent", async () => {
@@ -1153,10 +1164,10 @@ describe("Perps Competition", () => {
     expect(typedSummaryResponse.summary.totalPositions).toBeGreaterThanOrEqual(
       0,
     );
+    // After syncing data, we should have actual trading volume and equity
+    // All test agents have positive equity (minimum 500) and some have volume
     expect(typedSummaryResponse.summary.totalVolume).toBeGreaterThanOrEqual(0);
-    expect(typedSummaryResponse.summary.averageEquity).toBeGreaterThanOrEqual(
-      0,
-    );
+    expect(typedSummaryResponse.summary.averageEquity).toBeGreaterThan(0);
     expect(typedSummaryResponse.timestamp).toBeDefined();
   });
 

--- a/apps/api/e2e/utils/api-types.ts
+++ b/apps/api/e2e/utils/api-types.ts
@@ -348,9 +348,10 @@ export interface Competition {
     totalTrades?: number; // Optional - only for paper trading
     totalPositions?: number; // Optional - only for perps
     totalAgents: number;
-    totalVolume: number;
+    totalVolume?: number; // Optional - may not be present for all competition types
     totalVotes: number;
     uniqueTokens?: number; // Optional - only for paper trading
+    averageEquity?: number; // Optional - only for perps
     competitionType?: string; // Type indicator for clients
   };
   // Vote-related fields

--- a/apps/api/src/services/competition.service.ts
+++ b/apps/api/src/services/competition.service.ts
@@ -245,6 +245,7 @@ type CompetitionDetailsData = {
       uniqueTokens?: number;
       // Perps stats
       totalPositions?: number;
+      averageEquity?: number;
     };
     tradingConstraints: {
       minimumPairAgeHours: number | null;
@@ -2873,6 +2874,7 @@ export class CompetitionService {
         totalVolume?: number;
         uniqueTokens?: number;
         totalPositions?: number;
+        averageEquity?: number;
       };
 
       if (competition.type === "perpetual_futures") {
@@ -2884,6 +2886,8 @@ export class CompetitionService {
           totalAgents: competition.registeredParticipants,
           totalVotes,
           totalPositions: perpsStatsData?.totalPositions ?? 0,
+          totalVolume: perpsStatsData?.totalVolume ?? 0,
+          averageEquity: perpsStatsData?.averageEquity ?? 0,
         };
       } else {
         // For paper trading competitions, include trade metrics

--- a/apps/comps/components/agents-table/index.tsx
+++ b/apps/comps/components/agents-table/index.tsx
@@ -38,7 +38,7 @@ import {
   CompetitionStatus,
   PaginationResponse,
 } from "@/types";
-import { formatPercentage } from "@/utils/format";
+import { formatCompactNumber, formatPercentage } from "@/utils/format";
 import { getSortState } from "@/utils/table";
 
 import { AgentAvatar } from "../agent-avatar";
@@ -370,7 +370,9 @@ export const AgentsTable: React.FC<AgentsTableProps> = ({
           return (
             <div className="flex flex-col items-end">
               <span className="text-secondary-foreground font-semibold">
-                {isBoostDataLoading ? "..." : agentBoostTotal.toString()}
+                {isBoostDataLoading
+                  ? "..."
+                  : formatCompactNumber(agentBoostTotal)}
               </span>
               <span className="text-xs text-slate-400">
                 ({formatPercentage(Number(agentBoostTotal), Number(totalBoost))}

--- a/apps/comps/components/positions-table/index.tsx
+++ b/apps/comps/components/positions-table/index.tsx
@@ -196,7 +196,7 @@ export const PositionsTable: React.FC<PositionsTableProps> = ({
 
   return (
     <div className="mt-12 w-full">
-      <h2 className="mb-5 text-2xl font-bold">Positions</h2>
+      <h2 className="mb-5 text-2xl font-bold">Open Positions</h2>
       <div className="overflow-x-auto">
         <Table className="min-w-full">
           <TableHeader>


### PR DESCRIPTION
…ions (#1304)

# Fix Perps Competition Stats and UI Improvements

## Summary
This PR addresses missing statistics in perpetual futures competitions and improves UI clarity. The backend was not including `totalVolume` and `averageEquity` in the competition stats response, even though the frontend was already prepared to display them.

## Problem
- Volume and Average Equity showed as $0.00 on perps competition detail pages
- The backend was fetching these values from the database but not including them in the API response
- "Positions" heading was ambiguous - it specifically shows open positions only

## Changes

### Backend (apps/api)

#### Competition Service
(`apps/api/src/services/competition.service.ts`)
- Added `totalVolume` and `averageEquity` to perps competition stats
- Updated type definitions to include these optional fields
- Modified the stats building logic to include perps-specific metrics from `getPerpsCompetitionStats`

#### Test Coverage (`apps/api/e2e/tests/perps-competition.test.ts`)
- Added test assertions to verify `totalVolume` and `averageEquity` are included in the response
- Validates that these fields are numbers (not null or undefined)
- Ensures perps competitions have different stats structure than paper trading competitions

#### API Types (`apps/api/e2e/utils/api-types.ts`)
- Updated `Competition` interface to mark `totalVolume` as optional (may not be present for all competition types)
- Added `averageEquity` as an optional field specific to perps competitions

### Frontend (apps/comps)

#### Positions Table (`apps/comps/components/positions-table/index.tsx`)
- Changed heading from "Positions" to "Open Positions" for clarity
- This better reflects that the table only shows currently open positions, not closed ones

#### Agents Table (`apps/comps/components/agents-table/index.tsx`)
- Updated boost pool numbers to use compact number formatting
- Large numbers now display as "10.1M" instead of "10089948"
- Makes the UI more readable and consistent with modern number display conventions

## Technical Details

### Stats Calculation
The stats are calculated at the database level using SQL aggregations:
- **Total Volume**: Sum of `totalVolume` from each agent's latest account summary
- **Average Equity**: Average of `totalEquity` across all agents' latest summaries
- Both use lateral joins to efficiently get only the most recent data per agent

### Data Flow
1. Symphony API provides account summaries with volume and equity data
2. Perps repository stores these in `perps_account_summaries` table
3. `getPerpsCompetitionStats` aggregates using SQL (not in-memory processing)
4. Competition service now includes these aggregated values in the response
5. Frontend displays the values with proper currency formatting

## Impact
- Perps competition pages now correctly display total trading volume and average equity
- No breaking changes - fields are optional and frontend already handles null values
- OpenAPI spec already documented these as optional fields
- Improved clarity with "Open Positions" heading

## Testing
- All existing E2E tests pass
- New test coverage specifically validates the presence and type of these fields
- Manually verified the calculations match expected values from test data