### PR TITLE
feat(api): auto-start comps

### DIFF
--- a/apps/api/e2e/tests/auto-start-competition.test.ts
+++ b/apps/api/e2e/tests/auto-start-competition.test.ts
@@ -1,0 +1,291 @@
+import { beforeEach, describe, expect, test } from "vitest";
+
+import {
+  BalancesResponse,
+  CompetitionDetailResponse,
+  CreateCompetitionResponse,
+  SnapshotResponse,
+} from "@/e2e/utils/api-types.js";
+import {
+  createTestClient,
+  getAdminApiKey,
+  registerUserAndAgentAndGetClient,
+  wait,
+} from "@/e2e/utils/test-helpers.js";
+import { ServiceRegistry } from "@/services/index.js";
+
+describe("Competition Start Date Processing", () => {
+  let adminApiKey: string;
+
+  beforeEach(async () => {
+    adminApiKey = await getAdminApiKey();
+  });
+
+  test("should automatically start competition when start date is reached", async () => {
+    const adminClient = createTestClient();
+    const loginSuccess = await adminClient.loginAsAdmin(adminApiKey);
+    expect(loginSuccess).toBe(true);
+
+    // Register agent and join the competition pre-start
+    const { agent, client: agentClient } =
+      await registerUserAndAgentAndGetClient({
+        adminApiKey,
+        agentName: "Auto Start Agent",
+      });
+
+    // Create a competition with a start date a few seconds in the future
+    const competitionName = `Auto Start Competition ${Date.now()}`;
+    const startDate = new Date(Date.now() + 4000); // 4 seconds from now
+
+    const createResponse = await adminClient.createCompetition({
+      name: competitionName,
+      description: "Competition that should auto-start",
+      sandboxMode: false,
+      startDate: startDate.toISOString(),
+    });
+
+    expect(createResponse.success).toBe(true);
+    const competition = (createResponse as CreateCompetitionResponse)
+      .competition;
+
+    // Pre-register agent by joining the pending competition
+    const joinResponse = await agentClient.joinCompetition(
+      competition.id,
+      agent.id,
+    );
+    expect(joinResponse.success).toBe(true);
+
+    // Wait beyond the start time (simulate cron delay)
+    await wait(6000);
+
+    const services = new ServiceRegistry();
+    await services.competitionService.processCompetitionStartDateChecks();
+
+    // Verify competition is active now
+    const updatedCompetition = await adminClient.getCompetition(competition.id);
+    expect(updatedCompetition.success).toBe(true);
+    const comp = (updatedCompetition as CompetitionDetailResponse).competition;
+    expect(comp.status).toBe("active");
+    expect(comp.startDate).toBeDefined();
+
+    // Verify an initial portfolio snapshot was taken
+    const snapshotsResponse = (await adminClient.request(
+      "get",
+      `/api/admin/competition/${competition.id}/snapshots`,
+    )) as SnapshotResponse;
+    expect(snapshotsResponse.success).toBe(true);
+    expect(snapshotsResponse.snapshots.length).toBeGreaterThan(0);
+
+    // Verify balances were initialized/reset for the agent
+    const balances = (await agentClient.getBalance()) as BalancesResponse;
+    expect(balances.success).toBe(true);
+    expect(balances.balances.length).toBeGreaterThan(0);
+  });
+
+  test("should not start competitions before start date or without agents", async () => {
+    const adminClient = createTestClient();
+    const loginSuccess = await adminClient.loginAsAdmin(adminApiKey);
+    expect(loginSuccess).toBe(true);
+
+    // Create a competition with a start date shortly in the future but WITHOUT agents
+    const startDate = new Date(Date.now() + 3000); // 3 seconds from now
+    const competitionName = `Pending Start Competition ${Date.now()}`;
+
+    const createResponse = await adminClient.createCompetition({
+      name: competitionName,
+      description: "Competition that should not auto-start yet",
+      sandboxMode: false,
+      startDate: startDate.toISOString(),
+    });
+
+    expect(createResponse.success).toBe(true);
+    const competition = (createResponse as CreateCompetitionResponse)
+      .competition;
+
+    // Wait for start time to pass
+    await wait(5000);
+
+    const services = new ServiceRegistry();
+    await services.competitionService.processCompetitionStartDateChecks();
+
+    // Competition should still be pending since no agents are registered
+    const stillPending = await adminClient.getCompetition(competition.id);
+    expect(stillPending.success).toBe(true);
+    expect((stillPending as CompetitionDetailResponse).competition.status).toBe(
+      "pending",
+    );
+  });
+
+  test("should not start competitions when another is already active", async () => {
+    const adminClient = createTestClient();
+    const loginSuccess = await adminClient.loginAsAdmin(adminApiKey);
+    expect(loginSuccess).toBe(true);
+
+    // Create and start an active competition
+    const { agent: activeAgent, client: activeAgentClient } =
+      await registerUserAndAgentAndGetClient({
+        adminApiKey,
+        agentName: "Active Comp Agent",
+      });
+
+    const activeCompCreate = await adminClient.createCompetition({
+      name: `Active Competition ${Date.now()}`,
+      description: "Active competition",
+      sandboxMode: false,
+    });
+    expect(activeCompCreate.success).toBe(true);
+    const activeCompId = (activeCompCreate as CreateCompetitionResponse)
+      .competition.id;
+
+    // Join the agent and start it
+    const joinActive = await activeAgentClient.joinCompetition(
+      activeCompId,
+      activeAgent.id,
+    );
+    expect(joinActive.success).toBe(true);
+
+    const startActive = await adminClient.startExistingCompetition({
+      competitionId: activeCompId,
+      agentIds: [activeAgent.id],
+    });
+    expect(startActive.success).toBe(true);
+
+    // Now create another competition that is eligible to start
+    const { agent: pendingAgent, client: pendingAgentClient } =
+      await registerUserAndAgentAndGetClient({
+        adminApiKey,
+        agentName: "Pending Start Agent",
+      });
+
+    const startNow = new Date(Date.now() + 2000);
+    const pendingCreate = await adminClient.createCompetition({
+      name: `Queued Competition ${Date.now()}`,
+      description: "Should not start due to existing active comp",
+      sandboxMode: false,
+      startDate: startNow.toISOString(),
+    });
+
+    const pendingComp = (pendingCreate as CreateCompetitionResponse)
+      .competition;
+    const joinPending = await pendingAgentClient.joinCompetition(
+      pendingComp.id,
+      pendingAgent.id,
+    );
+    expect(joinPending.success).toBe(true);
+
+    // Wait and attempt auto-start processing
+    const services = new ServiceRegistry();
+    await services.competitionService.processCompetitionStartDateChecks();
+
+    // The queued competition should still be pending
+    const queued = await adminClient.getCompetition(pendingComp.id);
+    expect(queued.success).toBe(true);
+    expect((queued as CompetitionDetailResponse).competition.status).toBe(
+      "pending",
+    );
+  });
+
+  test("should not start competitions when there are multiple competitions ready to start", async () => {
+    const adminClient = createTestClient();
+    const loginSuccess = await adminClient.loginAsAdmin(adminApiKey);
+    expect(loginSuccess).toBe(true);
+
+    const startDate = new Date(Date.now()).toISOString();
+
+    // Create two competitions
+    const { agent: activeAgent, client: activeAgentClient } =
+      await registerUserAndAgentAndGetClient({
+        adminApiKey,
+        agentName: "Competition Agent 1",
+      });
+
+    const pendingComp1Create = await adminClient.createCompetition({
+      name: `Active Competition ${startDate}`,
+      description: "Competition 1",
+      sandboxMode: false,
+      startDate,
+    });
+    expect(pendingComp1Create.success).toBe(true);
+    const pendingComp1Id = (pendingComp1Create as CreateCompetitionResponse)
+      .competition.id;
+    const joinActive = await activeAgentClient.joinCompetition(
+      pendingComp1Id,
+      activeAgent.id,
+    );
+    expect(joinActive.success).toBe(true);
+
+    // Now create another competition with the same start date
+    const pendingComp2Create = await adminClient.createCompetition({
+      name: `Queued Competition ${Date.now()}`,
+      description: "Should not start due to existing active comp",
+      sandboxMode: false,
+      startDate,
+    });
+    const pendingComp2 = (pendingComp2Create as CreateCompetitionResponse)
+      .competition;
+    const pendingComp2Id = pendingComp2.id;
+    const joinPending2 = await activeAgentClient.joinCompetition(
+      pendingComp2Id,
+      activeAgent.id,
+    );
+    expect(joinPending2.success).toBe(true);
+
+    // Attempt auto-start processing
+    const services = new ServiceRegistry();
+    await services.competitionService.processCompetitionStartDateChecks();
+
+    // Both pending competitions should still be pending because we avoid starting multiple competitions
+    const queued1 = await adminClient.getCompetition(pendingComp1Id);
+    expect(queued1.success).toBe(true);
+    expect((queued1 as CompetitionDetailResponse).competition.status).toBe(
+      "pending",
+    );
+    const queued2 = await adminClient.getCompetition(pendingComp2Id);
+    expect(queued2.success).toBe(true);
+    expect((queued2 as CompetitionDetailResponse).competition.status).toBe(
+      "pending",
+    );
+  });
+
+  test("should skip sandbox mode competitions during auto-start", async () => {
+    const adminClient = createTestClient();
+    const loginSuccess = await adminClient.loginAsAdmin(adminApiKey);
+    expect(loginSuccess).toBe(true);
+
+    // Create a sandbox competition eligible for start
+    const { agent, client: agentClient } =
+      await registerUserAndAgentAndGetClient({
+        adminApiKey,
+        agentName: "Sandbox Agent",
+      });
+
+    const startSoon = new Date(Date.now() + 2000);
+
+    const sandboxCreate = await adminClient.createCompetition({
+      name: `Sandbox Competition ${Date.now()}`,
+      description: "Sandbox should not auto-start",
+      sandboxMode: true,
+      startDate: startSoon.toISOString(),
+    });
+
+    const sandboxComp = (sandboxCreate as CreateCompetitionResponse)
+      .competition;
+
+    const joinSandbox = await agentClient.joinCompetition(
+      sandboxComp.id,
+      agent.id,
+    );
+    expect(joinSandbox.success).toBe(true);
+
+    // Wait and process
+    const services = new ServiceRegistry();
+    await services.competitionService.processCompetitionStartDateChecks();
+
+    // Competition should still be pending
+    const result = await adminClient.getCompetition(sandboxComp.id);
+    expect(result.success).toBe(true);
+    expect((result as CompetitionDetailResponse).competition.status).toBe(
+      "pending",
+    );
+  });
+});

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -61,8 +61,10 @@
     "cron:portfolio-snapshot": "tsx scripts/take-portfolio-snapshots.ts",
     "run:indexer": "tsx scripts/indexer.ts",
     "cron:auto-end-competitions": "tsx scripts/auto-end-competitions.ts",
+    "cron:auto-start-competitions": "tsx scripts/auto-start-competitions.ts",
     "cron:portfolio-snapshot:run-once": "tsx scripts/take-portfolio-snapshots.ts --run-once",
-    "cron:auto-end-competitions:run-once": "tsx scripts/auto-end-competitions.ts --run-once"
+    "cron:auto-end-competitions:run-once": "tsx scripts/auto-end-competitions.ts --run-once",
+    "cron:auto-start-competitions:run-once": "tsx scripts/auto-start-competitions.ts --run-once"
   },
   "keywords": [
     "solana",

--- a/apps/api/scripts/auto-start-competitions.ts
+++ b/apps/api/scripts/auto-start-competitions.ts
@@ -1,0 +1,56 @@
+import * as dotenv from "dotenv";
+import cron from "node-cron";
+import * as path from "path";
+
+import { createLogger } from "@/lib/logger.js";
+import { ServiceRegistry } from "@/services/index.js";
+
+// Load environment variables
+dotenv.config({ path: path.resolve(process.cwd(), ".env") });
+
+const services = new ServiceRegistry();
+const logger = createLogger("AutoStartCompetitions");
+
+/**
+ * Auto start competitions that have reached their start date
+ */
+async function autoStartCompetitions() {
+  const startTime = Date.now();
+  logger.info("Starting auto start competitions task...");
+
+  try {
+    // Process competition start date checks
+    logger.info("Checking competition start dates...");
+    await services.competitionService.processCompetitionStartDateChecks();
+
+    const duration = Date.now() - startTime;
+    logger.info(
+      `Auto start competitions completed successfully in ${duration}ms!`,
+    );
+  } catch (error) {
+    logger.error(
+      "Error checking competition start dates:",
+      error instanceof Error ? error.message : String(error),
+    );
+
+    throw error;
+  }
+}
+
+// Schedule the task to run every minute
+cron.schedule("* * * * *", async () => {
+  logger.info("Running scheduled auto start competitions task");
+  await autoStartCompetitions();
+});
+
+// Also run immediately if called directly
+if (process.argv.includes("--run-once")) {
+  logger.info("Running auto start competitions task once");
+  try {
+    await autoStartCompetitions();
+  } catch {
+    process.exit(1);
+  } finally {
+    process.exit(0);
+  }
+}

--- a/apps/api/src/database/repositories/competition-repository.ts
+++ b/apps/api/src/database/repositories/competition-repository.ts
@@ -267,6 +267,12 @@ export const findCompetitionsNeedingEnding = createTimedRepositoryFunction(
   "findCompetitionsNeedingEnding",
 );
 
+export const findCompetitionsNeedingStarting = createTimedRepositoryFunction(
+  repository.findCompetitionsNeedingStarting.bind(repository),
+  "CompetitionRepository",
+  "findCompetitionsNeedingStarting",
+);
+
 export const getAgentPortfolioTimeline = createTimedRepositoryFunction(
   repository.getAgentPortfolioTimeline.bind(repository),
   "CompetitionRepository",

--- a/apps/api/src/services/competition.service.ts
+++ b/apps/api/src/services/competition.service.ts
@@ -704,10 +704,7 @@ export class CompetitionService {
 
     // Check if we have any agents
     if (finalAgentIds.length === 0) {
-      throw new ApiError(
-        400,
-        "Cannot start competition: no valid active agents provided in agentIds and no agents have joined the competition",
-      );
+      throw new ApiError(400, `Cannot start competition: no registered agents`);
     }
 
     // Process all agent additions and activations
@@ -2334,15 +2331,18 @@ export class CompetitionService {
         },
         `[CompetitionManager] Successfully auto-started competition`,
       );
-      return;
     } catch (error) {
-      serviceLogger.error(
-        {
-          error: error instanceof Error ? error.message : String(error),
-        },
-        `[CompetitionManager] Error in processCompetitionStartDateChecks`,
-      );
-      throw error;
+      // Continue silently if the competition has no registered nor provided agents
+      if (
+        error instanceof ApiError &&
+        error.statusCode === 400 &&
+        error.message.includes("no registered agents")
+      ) {
+        serviceLogger.error(
+          `[CompetitionManager] No registered agents found for competition. Skipping auto-start.`,
+        );
+        return;
+      }
     }
   }
   /**

--- a/apps/api/src/services/competition.service.ts
+++ b/apps/api/src/services/competition.service.ts
@@ -2302,13 +2302,6 @@ export class CompetitionService {
         );
         return;
       }
-
-      // Ensure we're processing by earliest start date first (defensive, repository already orders)
-      competitionsToStart.sort((a, b) => {
-        const aTime = a.startDate ? new Date(a.startDate).getTime() : 0;
-        const bTime = b.startDate ? new Date(b.startDate).getTime() : 0;
-        return aTime - bTime;
-      });
       serviceLogger.debug(
         `[CompetitionManager] Found ${competitionsToStart.length} competitions ready to start`,
       );

--- a/apps/api/src/services/trading-constraints.service.ts
+++ b/apps/api/src/services/trading-constraints.service.ts
@@ -55,7 +55,12 @@ export class TradingConstraintsService {
       minTradesPerDay: input.minTradesPerDay ?? null,
     };
 
-    return await create(constraintsData, tx);
+    // Only pass the transaction parameter when it's provided to keep method signatures
+    // consistent with unit test expectations that spy on repository calls.
+    if (tx) {
+      return await create(constraintsData, tx);
+    }
+    return await create(constraintsData);
   }
 
   /**
@@ -93,7 +98,9 @@ export class TradingConstraintsService {
       updateData.minTradesPerDay = input.minTradesPerDay;
     }
 
-    const result = await update(competitionId, updateData, tx);
+    const result = tx
+      ? await update(competitionId, updateData, tx)
+      : await update(competitionId, updateData);
     if (!result) {
       throw new Error(
         `Failed to update trading constraints for competition ${competitionId}`,

--- a/apps/api/src/services/trading-constraints.service.ts
+++ b/apps/api/src/services/trading-constraints.service.ts
@@ -55,12 +55,7 @@ export class TradingConstraintsService {
       minTradesPerDay: input.minTradesPerDay ?? null,
     };
 
-    // Only pass the transaction parameter when it's provided to keep method signatures
-    // consistent with unit test expectations that spy on repository calls.
-    if (tx) {
-      return await create(constraintsData, tx);
-    }
-    return await create(constraintsData);
+    return await create(constraintsData, tx);
   }
 
   /**
@@ -98,9 +93,7 @@ export class TradingConstraintsService {
       updateData.minTradesPerDay = input.minTradesPerDay;
     }
 
-    const result = tx
-      ? await update(competitionId, updateData, tx)
-      : await update(competitionId, updateData);
+    const result = await update(competitionId, updateData, tx);
     if (!result) {
       throw new Error(
         `Failed to update trading constraints for competition ${competitionId}`,


### PR DESCRIPTION
## Summary

adds an "auto start" competition cron job, allowing competitions to both start and end without manual requiring admin API calls. closes [APP-200](https://linear.app/recall-labs/issue/APP-200/autostart-competition)