### PR TITLE
fix: adjust trophy widths to match design

### DIFF
--- a/apps/comps/components/trophy-badge/index.tsx
+++ b/apps/comps/components/trophy-badge/index.tsx
@@ -22,21 +22,45 @@ interface TrophyBadgeProps {
   size?: number;
 }
 
+const DEFAULT_SIZE = 64;
+const BORDER_THICKNESS = 2;
+const IMAGE_ZOOM = 1.2;
+const ASPECT_RATIO_HEIGHT_FACTOR = 0.859375;
+
 const rankColors: Record<number, string> = {
   1: "bg-trophy-first",
   2: "bg-trophy-second",
   3: "bg-trophy-third",
 };
 
+const getDimensions = (size: number | undefined) => {
+  const effectiveW = size || DEFAULT_SIZE;
+  const effectiveH = effectiveW * ASPECT_RATIO_HEIGHT_FACTOR;
+  const borderThickness = BORDER_THICKNESS;
+
+  const innerW = effectiveW - borderThickness * 2;
+  const innerH = effectiveH - borderThickness * 2;
+
+  return {
+    outerW: effectiveW,
+    outerH: effectiveH,
+    innerW: innerW,
+    innerH: innerH,
+    borderThickness: borderThickness,
+    imageZoom: IMAGE_ZOOM, // Pass the zoom level
+  };
+};
+
 export const TrophyBadge: React.FC<TrophyBadgeProps> = ({ trophy, size }) => {
   const { competitionId, rank, imageUrl, name } = trophy;
   const router = useRouter();
-
   const isTop3 = rank >= 1 && rank <= 3;
   const colorClass = rankColors[rank] || "bg-gray-700";
-
   const Icon =
     rank === 1 ? Trophy : rank <= 3 ? AwardIcon : () => <div className="w-4" />;
+
+  const { outerW, outerH, innerW, innerH, borderThickness, imageZoom } =
+    getDimensions(size);
 
   return (
     <>
@@ -62,11 +86,15 @@ export const TrophyBadge: React.FC<TrophyBadgeProps> = ({ trophy, size }) => {
         <div
           className="group relative cursor-pointer"
           onClick={() => router.push(`/competitions/${competitionId}`)}
+          style={{
+            height: outerH,
+            width: outerW,
+          }}
         >
           <Hexagon
             style={{
-              height: size || 64,
-              width: size || 64,
+              height: outerH,
+              width: outerW,
             }}
             className={cn(
               "absolute left-0 top-0 -z-10",
@@ -76,11 +104,11 @@ export const TrophyBadge: React.FC<TrophyBadgeProps> = ({ trophy, size }) => {
           />
           <Hexagon
             style={{
-              height: size ? size - 8 : 56,
-              width: size ? size - 8 : 56,
+              height: innerH,
+              width: innerW,
             }}
             className={cn(
-              "relative left-[4px] top-[4px]",
+              `relative left-[${borderThickness}px] top-[${borderThickness}px]`,
               "duration-330 transition-transform ease-in-out group-hover:scale-110",
             )}
           >
@@ -96,12 +124,14 @@ export const TrophyBadge: React.FC<TrophyBadgeProps> = ({ trophy, size }) => {
                 />
               </>
             )}
-
             <Image
               src={imageUrl}
               alt="competition"
               fill
               className="rotate-270 left-0 top-0 w-full object-cover"
+              style={{
+                transform: `scale(${imageZoom})`, // Dynamically set scale
+              }}
             />
           </Hexagon>
         </div>


### PR DESCRIPTION
Fixes APP-476

[Link to task ](https://linear.app/recall-labs/issue/APP-476/trophies-are-too-wide)