### PR TITLE
fix: remove annualization and ensure risk metrics rounding

### DIFF
--- a/apps/api/src/services/agent.service.ts
+++ b/apps/api/src/services/agent.service.ts
@@ -1564,10 +1564,16 @@ export class AgentService {
           return {
             ...baseMetrics,
             totalPositions: positionCountsMap.get(competition.id) || 0,
-            // Include risk metrics if available
-            calmarRatio: riskMetrics ? Number(riskMetrics.calmarRatio) : null,
-            simpleReturn: riskMetrics ? Number(riskMetrics.simpleReturn) : null,
-            maxDrawdown: riskMetrics ? Number(riskMetrics.maxDrawdown) : null,
+            // Include risk metrics if available (rounded for display)
+            calmarRatio: riskMetrics
+              ? Number(Number(riskMetrics.calmarRatio).toFixed(4))
+              : null,
+            simpleReturn: riskMetrics
+              ? Number(Number(riskMetrics.simpleReturn).toFixed(4))
+              : null,
+            maxDrawdown: riskMetrics
+              ? Number(Number(riskMetrics.maxDrawdown).toFixed(4))
+              : null,
             hasRiskMetrics: !!riskMetrics,
           };
         } else {

--- a/apps/api/src/services/calmar-ratio.service.ts
+++ b/apps/api/src/services/calmar-ratio.service.ts
@@ -175,8 +175,14 @@ export class CalmarRatioService {
       return new Decimal(0);
     }
 
-    // For very short periods (< 1 day), don't annualize
-    if (daysInPeriod < 1) {
+    // Don't annualize for competitions shorter than 30 days
+    // Annualization over short periods creates misleading astronomical values
+    // For 1-week competitions, we use raw return/drawdown ratio instead
+    const MIN_DAYS_FOR_ANNUALIZATION = 30;
+    if (daysInPeriod < MIN_DAYS_FOR_ANNUALIZATION) {
+      serviceLogger.debug(
+        `[CalmarRatio] Period too short for annualization (${daysInPeriod.toFixed(2)} days < ${MIN_DAYS_FOR_ANNUALIZATION} days). Using raw return.`,
+      );
       return periodReturn;
     }
 
@@ -200,9 +206,12 @@ export class CalmarRatioService {
    * Calculate Calmar Ratio with proper edge case handling
    * Calmar = Annualized Return / |Max Drawdown|
    *
-   * @param annualizedReturn Annualized return as Decimal
+   * Note: For competitions < 30 days, this is actually Return/Drawdown ratio
+   * since we don't annualize short periods to avoid distortion
+   *
+   * @param annualizedReturn Annualized return as Decimal (or raw return for short competitions)
    * @param maxDrawdown Maximum drawdown as decimal (negative or 0)
-   * @returns Calmar ratio as Decimal
+   * @returns Calmar ratio as Decimal (or Return/Drawdown ratio for short competitions)
    */
   private computeCalmarRatio(
     annualizedReturn: Decimal,

--- a/apps/api/src/services/calmar-ratio.service.ts
+++ b/apps/api/src/services/calmar-ratio.service.ts
@@ -29,6 +29,7 @@ export interface RiskMetricsResult {
  */
 export class CalmarRatioService {
   private readonly DAYS_PER_YEAR = 365; // Calendar days for annualization
+  private readonly MIN_DAYS_FOR_ANNUALIZATION = 30; // Minimum period before annualizing returns
 
   /**
    * Calculate and persist Calmar Ratio with all risk metrics
@@ -177,11 +178,10 @@ export class CalmarRatioService {
 
     // Don't annualize for competitions shorter than 30 days
     // Annualization over short periods creates misleading astronomical values
-    // For 1-week competitions, we use raw return/drawdown ratio instead
-    const MIN_DAYS_FOR_ANNUALIZATION = 30;
-    if (daysInPeriod < MIN_DAYS_FOR_ANNUALIZATION) {
+    // For competitions shorter than 30 days, we use raw return/drawdown ratio instead
+    if (daysInPeriod < this.MIN_DAYS_FOR_ANNUALIZATION) {
       serviceLogger.debug(
-        `[CalmarRatio] Period too short for annualization (${daysInPeriod.toFixed(2)} days < ${MIN_DAYS_FOR_ANNUALIZATION} days). Using raw return.`,
+        `[CalmarRatio] Period too short for annualization (${daysInPeriod.toFixed(2)} days < ${this.MIN_DAYS_FOR_ANNUALIZATION} days). Using raw return.`,
       );
       return periodReturn;
     }

--- a/apps/api/src/services/calmar-ratio.service.ts
+++ b/apps/api/src/services/calmar-ratio.service.ts
@@ -22,15 +22,12 @@ export interface RiskMetricsResult {
 
 /**
  * Service for calculating Calmar Ratio and other risk metrics
- * Calmar Ratio = Annualized Return / Max Drawdown
+ * Calmar Ratio = Return / Max Drawdown
  *
  * NOTE: Mid-competition transfers are now PROHIBITED
  * This service uses simple returns since agents cannot add/withdraw funds during competitions
  */
 export class CalmarRatioService {
-  private readonly DAYS_PER_YEAR = 365; // Calendar days for annualization
-  private readonly MIN_DAYS_FOR_ANNUALIZATION = 30; // Minimum period before annualizing returns
-
   /**
    * Calculate and persist Calmar Ratio with all risk metrics
    * Uses simple returns: (endValue/startValue) - 1
@@ -109,22 +106,19 @@ export class CalmarRatioService {
         `[CalmarRatio] Max drawdown calculated: ${(maxDrawdown * 100).toFixed(4)}%`,
       );
 
-      // 4. Annualize the return
-      // Use the actual snapshot period for accurate annualization
+      // 4. Process the return
+      // Calculate the period length for logging purposes
       const daysInPeriod =
         (endSnapshot.timestamp.getTime() - startSnapshot.timestamp.getTime()) /
         (1000 * 60 * 60 * 24);
-      const annualizedReturn = this.annualizeReturn(simpleReturn, daysInPeriod);
+      const processedReturn = this.processReturn(simpleReturn, daysInPeriod);
 
       serviceLogger.debug(
-        `[CalmarRatio] Annualized return: ${(annualizedReturn.toNumber() * 100).toFixed(4)}% over ${daysInPeriod.toFixed(1)} days`,
+        `[CalmarRatio] Processed return: ${(processedReturn.toNumber() * 100).toFixed(4)}% over ${daysInPeriod.toFixed(1)} days`,
       );
 
       // 5. Calculate Calmar Ratio
-      const calmarRatio = this.computeCalmarRatio(
-        annualizedReturn,
-        maxDrawdown,
-      );
+      const calmarRatio = this.computeCalmarRatio(processedReturn, maxDrawdown);
 
       serviceLogger.info(
         `[CalmarRatio] Calculated metrics for agent ${agentId}: Calmar=${calmarRatio.toFixed(4)}, Return=${(simpleReturn.toNumber() * 100).toFixed(2)}%, Drawdown=${(maxDrawdown * 100).toFixed(2)}%`,
@@ -136,7 +130,7 @@ export class CalmarRatioService {
         competitionId,
         simpleReturn: simpleReturn.toFixed(8),
         calmarRatio: calmarRatio.toFixed(8),
-        annualizedReturn: annualizedReturn.toFixed(8),
+        annualizedReturn: processedReturn.toFixed(8), // Store as "annualizedReturn" for DB compatibility, but it's actually raw return
         maxDrawdown: maxDrawdown.toFixed(8),
         snapshotCount: 2, // We only use first and last snapshots
       };
@@ -158,17 +152,14 @@ export class CalmarRatioService {
   }
 
   /**
-   * Annualize a return over a given period
-   * Uses compound annualization formula: (1 + r)^(365/days) - 1
+   * Process return for Calmar ratio calculation
+   * No annualization - uses raw return/drawdown ratio for all competition lengths
    *
    * @param periodReturn The return for the period (as Decimal)
-   * @param daysInPeriod Number of days in the period
-   * @returns Annualized return as Decimal
+   * @param daysInPeriod Number of days in the period (kept for logging)
+   * @returns Raw period return as Decimal
    */
-  private annualizeReturn(
-    periodReturn: Decimal,
-    daysInPeriod: number,
-  ): Decimal {
+  private processReturn(periodReturn: Decimal, daysInPeriod: number): Decimal {
     if (daysInPeriod <= 0) {
       serviceLogger.warn(
         `[CalmarRatio] Invalid period length: ${daysInPeriod} days`,
@@ -176,57 +167,38 @@ export class CalmarRatioService {
       return new Decimal(0);
     }
 
-    // Don't annualize for competitions shorter than 30 days
-    // Annualization over short periods creates misleading astronomical values
-    // For competitions shorter than 30 days, we use raw return/drawdown ratio instead
-    if (daysInPeriod < this.MIN_DAYS_FOR_ANNUALIZATION) {
-      serviceLogger.debug(
-        `[CalmarRatio] Period too short for annualization (${daysInPeriod.toFixed(2)} days < ${this.MIN_DAYS_FOR_ANNUALIZATION} days). Using raw return.`,
-      );
-      return periodReturn;
-    }
+    serviceLogger.debug(
+      `[CalmarRatio] Using raw return for ${daysInPeriod.toFixed(2)} days period`,
+    );
 
-    const yearsInPeriod = daysInPeriod / this.DAYS_PER_YEAR;
-
-    // If period is exactly 1 year, return the period return directly
-    // This avoids pow() operation for the common case
-    if (Math.abs(yearsInPeriod - 1) < 0.0001) {
-      return periodReturn;
-    }
-
-    // Use Decimal for precise calculation
-    const onePlusReturn = new Decimal(1).plus(periodReturn);
-    const exponent = new Decimal(1).div(yearsInPeriod);
-    const annualized = onePlusReturn.pow(exponent).minus(1);
-
-    return annualized;
+    return periodReturn;
   }
 
   /**
    * Calculate Calmar Ratio with proper edge case handling
-   * Calmar = Annualized Return / |Max Drawdown|
+   * Calmar = Return / |Max Drawdown|
    *
-   * Note: For competitions < 30 days, this is actually Return/Drawdown ratio
-   * since we don't annualize short periods to avoid distortion
+   * Note: We use raw returns
+   * for short-duration competitions
    *
-   * @param annualizedReturn Annualized return as Decimal (or raw return for short competitions)
+   * @param periodReturn Period return as Decimal
    * @param maxDrawdown Maximum drawdown as decimal (negative or 0)
-   * @returns Calmar ratio as Decimal (or Return/Drawdown ratio for short competitions)
+   * @returns Calmar ratio as Decimal (Return/Drawdown ratio)
    */
   private computeCalmarRatio(
-    annualizedReturn: Decimal,
+    periodReturn: Decimal,
     maxDrawdown: number,
   ): Decimal {
     // Handle edge cases
     if (maxDrawdown === 0) {
       // No drawdown
-      if (annualizedReturn.greaterThan(0)) {
+      if (periodReturn.greaterThan(0)) {
         // Positive return with no drawdown - cap at 100
         serviceLogger.debug(
           `[CalmarRatio] No drawdown with positive return, capping Calmar at 100`,
         );
         return new Decimal(100);
-      } else if (annualizedReturn.lessThan(0)) {
+      } else if (periodReturn.lessThan(0)) {
         // Negative return with no drawdown - shouldn't happen but handle it
         return new Decimal(-100);
       } else {
@@ -237,6 +209,6 @@ export class CalmarRatioService {
 
     // Normal case: divide return by absolute value of drawdown
     // Since drawdown is negative, we use Math.abs
-    return annualizedReturn.dividedBy(Math.abs(maxDrawdown));
+    return periodReturn.dividedBy(Math.abs(maxDrawdown));
   }
 }

--- a/apps/api/src/services/competition.service.ts
+++ b/apps/api/src/services/competition.service.ts
@@ -1186,10 +1186,19 @@ export class CompetitionService {
         change24h: metrics.change24h,
         change24hPercent: metrics.change24hPercent,
         voteCount,
-        // Risk metrics from leaderboard (perps competitions only)
-        calmarRatio: leaderboardEntry?.calmarRatio ?? null,
-        simpleReturn: leaderboardEntry?.simpleReturn ?? null,
-        maxDrawdown: leaderboardEntry?.maxDrawdown ?? null,
+        // Risk metrics from leaderboard (perps competitions only, rounded for display)
+        calmarRatio:
+          leaderboardEntry?.calmarRatio != null
+            ? Number(Number(leaderboardEntry.calmarRatio).toFixed(4))
+            : null,
+        simpleReturn:
+          leaderboardEntry?.simpleReturn != null
+            ? Number(Number(leaderboardEntry.simpleReturn).toFixed(4))
+            : null,
+        maxDrawdown:
+          leaderboardEntry?.maxDrawdown != null
+            ? Number(Number(leaderboardEntry.maxDrawdown).toFixed(4))
+            : null,
         hasRiskMetrics: leaderboardEntry?.hasRiskMetrics ?? false,
       };
     });
@@ -1250,9 +1259,15 @@ export class CompetitionService {
           agentId: entry.agentId,
           value: portfolioValue,
           pnl: Number(entry.totalPnl) || 0, // Use PnL from risk-adjusted leaderboard
-          calmarRatio: entry.calmarRatio ? Number(entry.calmarRatio) : null,
-          simpleReturn: entry.simpleReturn ? Number(entry.simpleReturn) : null,
-          maxDrawdown: entry.maxDrawdown ? Number(entry.maxDrawdown) : null,
+          calmarRatio: entry.calmarRatio
+            ? Number(Number(entry.calmarRatio).toFixed(4))
+            : null,
+          simpleReturn: entry.simpleReturn
+            ? Number(Number(entry.simpleReturn).toFixed(4))
+            : null,
+          maxDrawdown: entry.maxDrawdown
+            ? Number(Number(entry.maxDrawdown).toFixed(4))
+            : null,
           hasRiskMetrics: entry.hasRiskMetrics,
         });
       }
@@ -1302,10 +1317,16 @@ export class CompetitionService {
         agentId: entry.agentId,
         value: Number(entry.totalEquity) || 0, // Keep as portfolio value for API compatibility
         pnl: Number(entry.totalPnl) || 0,
-        // Include risk-adjusted metrics
-        calmarRatio: entry.calmarRatio ? Number(entry.calmarRatio) : null,
-        simpleReturn: entry.simpleReturn ? Number(entry.simpleReturn) : null,
-        maxDrawdown: entry.maxDrawdown ? Number(entry.maxDrawdown) : null,
+        // Include risk-adjusted metrics (rounded for display)
+        calmarRatio: entry.calmarRatio
+          ? Number(Number(entry.calmarRatio).toFixed(4))
+          : null,
+        simpleReturn: entry.simpleReturn
+          ? Number(Number(entry.simpleReturn).toFixed(4))
+          : null,
+        maxDrawdown: entry.maxDrawdown
+          ? Number(Number(entry.maxDrawdown).toFixed(4))
+          : null,
         hasRiskMetrics: entry.hasRiskMetrics,
       }));
     }
@@ -1516,9 +1537,15 @@ export class CompetitionService {
         activeAgents: activeLeaderboard.map((entry) => ({
           agentId: entry.agentId,
           value: entry.value,
-          calmarRatio: entry.calmarRatio,
-          simpleReturn: entry.simpleReturn,
-          maxDrawdown: entry.maxDrawdown,
+          calmarRatio: entry.calmarRatio
+            ? Number(Number(entry.calmarRatio).toFixed(4))
+            : entry.calmarRatio,
+          simpleReturn: entry.simpleReturn
+            ? Number(Number(entry.simpleReturn).toFixed(4))
+            : entry.simpleReturn,
+          maxDrawdown: entry.maxDrawdown
+            ? Number(Number(entry.maxDrawdown).toFixed(4))
+            : entry.maxDrawdown,
           hasRiskMetrics: entry.hasRiskMetrics,
         })),
         inactiveAgents,
@@ -2305,7 +2332,7 @@ export class CompetitionService {
       if (competitionsToStart.length > 1 || !competition) {
         serviceLogger.warn(
           {
-            competitions: competitionsToStart.map((c) => ({
+            competitions: competitionsToStart.map((c: SelectCompetition) => ({
               id: c.id,
               name: c.name,
               startDate: c.startDate?.toISOString(),
@@ -2425,10 +2452,16 @@ export class CompetitionService {
             portfolioValue: entry.value,
             active: true,
             deactivationReason: null,
-            // Include risk metrics if available
-            calmarRatio: entry.calmarRatio,
-            simpleReturn: entry.simpleReturn,
-            maxDrawdown: entry.maxDrawdown,
+            // Include risk metrics if available (rounded for display)
+            calmarRatio: entry.calmarRatio
+              ? Number(Number(entry.calmarRatio).toFixed(4))
+              : null,
+            simpleReturn: entry.simpleReturn
+              ? Number(Number(entry.simpleReturn).toFixed(4))
+              : null,
+            maxDrawdown: entry.maxDrawdown
+              ? Number(Number(entry.maxDrawdown).toFixed(4))
+              : null,
             hasRiskMetrics: entry.hasRiskMetrics,
           };
         },


### PR DESCRIPTION
# Summary

- Removes annualization altogether in calmar service (api)
- Ensure rounding for risk metrics in frontend