### PR TITLE
Don't fetch leaderboard data if it won't be displayed

### DIFF
--- a/apps/comps/app/competitions/page.tsx
+++ b/apps/comps/app/competitions/page.tsx
@@ -35,6 +35,7 @@ export default function CompetitionsPage() {
   const { data: leaderboard, isLoading: isLoadingLeaderboard } =
     useLeaderboards({
       limit: 25,
+      enabled: !DISABLE_LEADERBOARD,
     });
   const session = useSession();
 

--- a/apps/comps/hooks/useLeaderboards.ts
+++ b/apps/comps/hooks/useLeaderboards.ts
@@ -14,5 +14,6 @@ export const useLeaderboards = (params: GetLeaderboardParams = {}) =>
     queryFn: async (): Promise<LeaderboardResponse> => {
       return apiClient.getGlobalLeaderboard(params);
     },
+    enabled: params.enabled !== false,
     placeholderData: (prev) => prev,
   });

--- a/apps/comps/types/api.ts
+++ b/apps/comps/types/api.ts
@@ -45,6 +45,7 @@ export interface GetAgentCompetitionsParams {
 
 // GET /leaderboard query parameters
 export interface GetLeaderboardParams {
+  enabled?: boolean;
   type?: string;
   limit?: number;
   offset?: number;


### PR DESCRIPTION
We currently don't display the leaderboard carousel (it's controlled by an env var), but the fetch of the leaderboard happens anyway. This is on the main landing page, so this happens every time someone visits the site. The change will only load the data if it will be displayed.