### PR TITLE
fix(ui,competitions): reduce shimmer effect opacity on landing hero v…

### DIFF
--- a/apps/comps/app/competitions/page.tsx
+++ b/apps/comps/app/competitions/page.tsx
@@ -374,8 +374,8 @@ const RainbowStripes: React.FC<RainbowStripesProps> = ({
                   "absolute z-20 h-full w-full",
                   "bg-[length:250%_250%,100%_100%] bg-no-repeat",
                   direction === "right"
-                    ? `bg-[linear-gradient(60deg,transparent_47%,rgba(255,255,255)_50%,transparent_52%,transparent_100%)]`
-                    : `bg-[linear-gradient(120deg,transparent_47%,rgba(255,255,255)_50%,transparent_52%,transparent_100%)]`,
+                    ? `bg-[linear-gradient(60deg,transparent_47%,rgba(255,255,255,0.4)_50%,transparent_52%,transparent_100%)]`
+                    : `bg-[linear-gradient(120deg,transparent_47%,rgba(255,255,255,0.4)_50%,transparent_52%,transparent_100%)]`,
                 )}
                 style={{
                   animation: "shine 6s ease-in-out infinite",


### PR DESCRIPTION
  Reduced rainbow stripe shimmer opacity from fully opaque white to 40% opacity for better visual balance
  https://linear.app/recall-labs/issue/APP-528/reduce-opacity-on-shimmer-effect