### PR TITLE
feat: add navbar hover states

### DIFF
--- a/apps/comps/components/navbar/index.tsx
+++ b/apps/comps/components/navbar/index.tsx
@@ -23,8 +23,18 @@ const formattedNumber = new Intl.NumberFormat();
 export const Navbar: React.FunctionComponent = () => {
   const pathname = usePathname();
   const navItems = [
-    { label: "COMPETITIONS", href: "/competitions" },
-    { label: "LEADERBOARDS", href: "/leaderboards" },
+    {
+      label: "COMPETITIONS",
+      href: "/competitions",
+      activeColor: "border-b-yellow-500",
+      hoverShadow: "hover:shadow-[0_-4px_12px_rgba(251,191,36,0.4)]",
+    },
+    {
+      label: "LEADERBOARDS",
+      href: "/leaderboards",
+      activeColor: "border-b-green-400",
+      hoverShadow: "hover:shadow-[0_-4px_12px_rgba(34,197,94,0.4)]",
+    },
   ];
 
   const { isAuthenticated } = useSession();
@@ -36,7 +46,10 @@ export const Navbar: React.FunctionComponent = () => {
       <div className="mx-auto flex w-full max-w-screen-lg items-center justify-between px-5 sm:px-20">
         <div className="flex items-center">
           {/* Logo */}
-          <Link href="/" className="flex items-center border-x p-1">
+          <Link
+            href="/"
+            className="flex items-center border-x p-1 transition-colors hover:bg-gray-900/50"
+          >
             <Avatar className="h-12 w-12">
               <AvatarImage
                 src="/logo_white.svg"
@@ -55,13 +68,13 @@ export const Navbar: React.FunctionComponent = () => {
                   href={item.href}
                   key={item.href}
                   className={cn(
-                    "px-15 flex h-14 items-center justify-center border-b-2 border-r",
-                    isActive ? "border-b-yellow-500" : "border-b-transparent",
+                    "px-15 flex h-14 items-center justify-center border-b-2 border-r transition-colors",
+                    !isActive && "hover:bg-gray-900/50",
+                    isActive ? item.activeColor : "border-b-transparent",
+                    !isActive && item.hoverShadow,
                   )}
                 >
-                  <span
-                    className={`font-mono text-xs font-medium tracking-widest text-white transition-colors`}
-                  >
+                  <span className="font-mono text-xs font-medium tracking-widest text-white">
                     {item.label}
                   </span>
                 </Link>
@@ -108,7 +121,7 @@ export const Navbar: React.FunctionComponent = () => {
               tooltipClassName="max-w-xs"
               content="Boost available per competition. Visit any active compeition page to activate yours and start boosting agents."
             >
-              <div className="flex flex-row items-center space-x-2 font-bold text-yellow-500">
+              <div className="flex cursor-pointer flex-row items-center space-x-2 rounded px-2 py-1 font-bold text-yellow-500 transition-colors hover:bg-gray-900/50">
                 <Zap className="size-4" />
                 <span>
                   {formattedNumber.format(
@@ -120,10 +133,13 @@ export const Navbar: React.FunctionComponent = () => {
           )}
           <div
             className={cn(
-              "flex h-full items-center border-b-2",
+              "flex h-full items-center border-b-2 transition-colors",
+              isAuthenticated && nonStakeBoostAmount && "border-l pl-4",
               pathname === "/profile"
                 ? "border-b-yellow-500"
                 : "border-b-transparent",
+              pathname !== "/profile" &&
+                "hover:shadow-[0_-4px_12px_rgba(251,191,36,0.4)]",
             )}
           >
             <PrivyAuthButton />

--- a/apps/comps/components/navbar/index.tsx
+++ b/apps/comps/components/navbar/index.tsx
@@ -26,14 +26,16 @@ export const Navbar: React.FunctionComponent = () => {
     {
       label: "COMPETITIONS",
       href: "/competitions",
-      activeColor: "border-b-yellow-500",
-      hoverShadow: "hover:shadow-[0_-4px_12px_rgba(251,191,36,0.4)]",
+      underlineColor: "bg-yellow-500",
+      glowColor:
+        "bg-[radial-gradient(ellipse_at_center,rgba(251,191,36,0.3)_0%,rgba(251,191,36,0.15)_45%,rgba(251,191,36,0)_70%)]",
     },
     {
       label: "LEADERBOARDS",
       href: "/leaderboards",
-      activeColor: "border-b-green-400",
-      hoverShadow: "hover:shadow-[0_-4px_12px_rgba(34,197,94,0.4)]",
+      underlineColor: "bg-green-400",
+      glowColor:
+        "bg-[radial-gradient(ellipse_at_center,rgba(34,197,94,0.3)_0%,rgba(34,197,94,0.15)_45%,rgba(34,197,94,0)_70%)]",
     },
   ];
 
@@ -48,7 +50,7 @@ export const Navbar: React.FunctionComponent = () => {
           {/* Logo */}
           <Link
             href="/"
-            className="flex items-center border-x p-1 transition-colors hover:bg-gray-900/50"
+            className="flex items-center border-x p-1 transition-colors hover:bg-white/5"
           >
             <Avatar className="h-12 w-12">
               <AvatarImage
@@ -67,16 +69,29 @@ export const Navbar: React.FunctionComponent = () => {
                 <Link
                   href={item.href}
                   key={item.href}
-                  className={cn(
-                    "px-15 flex h-14 items-center justify-center border-b-2 border-r transition-colors",
-                    !isActive && "hover:bg-gray-900/50",
-                    isActive ? item.activeColor : "border-b-transparent",
-                    !isActive && item.hoverShadow,
-                  )}
+                  className="px-15 group relative flex h-14 items-center justify-center border-r transition-colors hover:bg-white/5"
                 >
                   <span className="font-mono text-xs font-medium tracking-widest text-white">
                     {item.label}
                   </span>
+                  <span
+                    className={cn(
+                      "pointer-events-none absolute inset-x-0 bottom-0 h-0.5 origin-center transition-transform duration-300",
+                      item.underlineColor,
+                      isActive ? "scale-x-100" : "scale-x-0",
+                    )}
+                    aria-hidden="true"
+                  />
+                  <span
+                    className={cn(
+                      "pointer-events-none absolute -bottom-px left-1/2 h-5 w-44 -translate-x-1/2 blur-sm transition-opacity duration-300",
+                      item.glowColor,
+                      isActive
+                        ? "opacity-60"
+                        : "opacity-0 group-hover:opacity-50",
+                    )}
+                    aria-hidden="true"
+                  />
                 </Link>
               );
             })}
@@ -121,7 +136,7 @@ export const Navbar: React.FunctionComponent = () => {
               tooltipClassName="max-w-xs"
               content="Boost available per competition. Visit any active compeition page to activate yours and start boosting agents."
             >
-              <div className="flex cursor-pointer flex-row items-center space-x-2 rounded px-2 py-1 font-bold text-yellow-500 transition-colors hover:bg-gray-900/50">
+              <div className="flex cursor-pointer flex-row items-center space-x-2 rounded px-2 py-1 font-bold text-yellow-500 transition-colors hover:bg-white/5">
                 <Zap className="size-4" />
                 <span>
                   {formattedNumber.format(
@@ -133,16 +148,27 @@ export const Navbar: React.FunctionComponent = () => {
           )}
           <div
             className={cn(
-              "flex h-full items-center border-b-2 transition-colors",
+              "group relative flex h-full items-center transition-colors hover:bg-white/5",
               isAuthenticated && nonStakeBoostAmount && "border-l pl-4",
-              pathname === "/profile"
-                ? "border-b-yellow-500"
-                : "border-b-transparent",
-              pathname !== "/profile" &&
-                "hover:shadow-[0_-4px_12px_rgba(251,191,36,0.4)]",
             )}
           >
             <PrivyAuthButton />
+            <span
+              className={cn(
+                "pointer-events-none absolute inset-x-0 bottom-0 h-0.5 origin-center bg-yellow-500 transition-transform duration-300",
+                pathname === "/profile" ? "scale-x-100" : "scale-x-0",
+              )}
+              aria-hidden="true"
+            />
+            <span
+              className={cn(
+                "pointer-events-none absolute -bottom-px left-1/2 h-5 w-44 -translate-x-1/2 bg-[radial-gradient(ellipse_at_center,rgba(251,191,36,0.3)_0%,rgba(251,191,36,0.15)_45%,rgba(251,191,36,0)_70%)] blur-sm transition-opacity duration-300",
+                pathname === "/profile"
+                  ? "opacity-60"
+                  : "opacity-0 group-hover:opacity-50",
+              )}
+              aria-hidden="true"
+            />
           </div>
         </div>
       </div>

--- a/apps/comps/components/privy-auth-button.tsx
+++ b/apps/comps/components/privy-auth-button.tsx
@@ -2,7 +2,7 @@
 
 import { useQueryClient } from "@tanstack/react-query";
 import { LogOut } from "lucide-react";
-import { useRouter } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import React, { useEffect } from "react";
 
 import {
@@ -30,6 +30,7 @@ import { Identicon } from "./identicon/index";
  */
 export const PrivyAuthButton: React.FunctionComponent = () => {
   const router = useRouter();
+  const pathname = usePathname();
 
   const { login, backendUser, isAuthenticated, isPending, logout, error } =
     useSession();
@@ -74,7 +75,12 @@ export const PrivyAuthButton: React.FunctionComponent = () => {
     return (
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
-          <div className="flex cursor-pointer items-center justify-between">
+          <div
+            className={cn(
+              "flex cursor-pointer items-center justify-between rounded px-2 py-1 transition-colors",
+              pathname !== "/profile" && "hover:bg-gray-900/50",
+            )}
+          >
             <Avatar className="h-10 w-10">
               <AvatarImage
                 src={avatarUrl}


### PR DESCRIPTION
https://linear.app/recall-labs/issue/APP-469/missing-hover-states

Note: I am not good with front-end design stuff!!! I tried to follow the design as close as possible (with the help of ai) 

  - Added hover states to navbar navigation items with color-specific glow effects (yellow for COMPETITIONS, green for LEADERBOARDS)
  - Added hover background (`gray-900/50`) to logo, boost display, and profile button
  - Conditional hover effects on profile button (disabled when on `/profile` page)
  - Conditional left border on profile section (only shows when boost is visible)
  - Refactored nav items to use data-driven color configuration