### PR TITLE
chore: cleanup portfolio chart button 

### DIFF
--- a/apps/comps/app/competitions/[id]/page.tsx
+++ b/apps/comps/app/competitions/[id]/page.tsx
@@ -43,7 +43,6 @@ export default function CompetitionPage({
   const { isAuthenticated } = useSession();
   const { id } = React.use(params);
   const agentsTableRef = React.useRef<HTMLDivElement>(null);
-  const chartRef = React.useRef<HTMLDivElement>(null);
   const [, scrollTo] = useWindowScroll();
   const [agentsFilter, setAgentsFilter] = React.useState("");
   const [agentsSort, setAgentsSort] = React.useState("");
@@ -204,27 +203,6 @@ export default function CompetitionPage({
             </JoinCompetitionButton>
 
             <BoostAgentsBtn className="w-full justify-between uppercase sm:w-1/2" />
-
-            {/*<Button
-              variant="outline"
-              className={cn(
-                "w-full justify-between border border-gray-700 uppercase sm:w-1/2",
-              )}
-              size="lg"
-              onClick={() => {
-                if (chartRef.current) {
-                  scrollTo({
-                    top: chartRef.current.offsetTop,
-                    behavior: "smooth",
-                  });
-                }
-              }}
-            >
-              <div className={cn("flex w-full items-center justify-between")}>
-                <span className="font-semibold">Chart</span>{" "}
-                <ChevronRight className="ml-2" size={18} />
-              </div>
-            </Button>*/}
           </div>
         </div>
       </div>
@@ -307,7 +285,6 @@ export default function CompetitionPage({
       ) : (
         <>
           <TimelineChart
-            ref={chartRef}
             className="mt-5"
             competition={competition}
             agents={agentsData?.agents || []}

--- a/apps/comps/components/timeline-chart/timeline-chart.tsx
+++ b/apps/comps/components/timeline-chart/timeline-chart.tsx
@@ -30,7 +30,6 @@ import { datesByWeek, formatDateShort } from "./utils";
  * Main TimelineChart component
  */
 export const TimelineChart: React.FC<PortfolioChartProps> = ({
-  ref,
   competition,
   agents,
   className,
@@ -441,7 +440,7 @@ export const TimelineChart: React.FC<PortfolioChartProps> = ({
   };
 
   return (
-    <div className={cn("w-full rounded-lg border", className)} ref={ref}>
+    <div className={cn("w-full rounded-lg border", className)}>
       <div className="bg-card flex items-center justify-between p-5">
         <div className="w-full">
           <h2

--- a/apps/comps/components/timeline-chart/types.ts
+++ b/apps/comps/components/timeline-chart/types.ts
@@ -31,7 +31,6 @@ export interface CustomLegendProps {
 }
 
 export interface PortfolioChartProps {
-  ref?: React.RefObject<HTMLDivElement | null>;
   competition: RouterOutputs["competitions"]["getById"];
   agents: AgentCompetition[]; // Current page agents from parent pagination
   className?: string;


### PR DESCRIPTION
Removes the portfolio chart button and associated scroll reference from the competition page. Cleans up timeline chart component by removing unused scroll functionality.