### PR TITLE
Tests tsc + rewards package fixes

### DIFF
--- a/apps/api/vitest.config.ts
+++ b/apps/api/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
   plugins: [tsconfigPaths()],
   test: {
     passWithNoTests: true,
+    typecheck: { enabled: true, include: ["**/*.test.ts"] },
     coverage: {
       provider: "v8",
       reporter: ["text", "json", "json-summary"],
@@ -28,6 +29,7 @@ export default defineConfig({
           dir: "./src",
           include: ["**/*.test.ts"],
           exclude: ["**/*.integration.test.ts", "**/*.e2e.test.ts"],
+          typecheck: { enabled: true, include: ["**/*.test.ts"] },
         },
       },
       {
@@ -37,6 +39,7 @@ export default defineConfig({
           root: "./",
           dir: "./src",
           include: ["**/*.integration.test.ts"],
+          typecheck: { enabled: true, include: ["**/*.test.ts"] },
           testTimeout: 30_000, // Longer timeout for DB operations
           sequence: {
             concurrent: false,
@@ -58,6 +61,7 @@ export default defineConfig({
           root: "./",
           dir: "./e2e",
           include: ["**/*.test.ts"],
+          typecheck: { enabled: true, include: ["**/*.test.ts"] },
           globalSetup: "./e2e/setup.ts",
           setupFiles: "./e2e/utils/test-setup.ts",
           testTimeout: 120_000,

--- a/apps/comps/lib/db.ts
+++ b/apps/comps/lib/db.ts
@@ -22,4 +22,4 @@ const pool = new Pool({
   ssl: sslConfig(),
 });
 
-export const db = drizzle(pool, { schema, logger: false });
+export const db = drizzle(pool, { schema });

--- a/apps/comps/lib/db.ts
+++ b/apps/comps/lib/db.ts
@@ -22,4 +22,4 @@ const pool = new Pool({
   ssl: sslConfig(),
 });
 
-export const db = drizzle(pool, { schema });
+export const db = drizzle(pool, { schema, logger: false });

--- a/apps/comps/rpc/router/competitions/get-agents.ts
+++ b/apps/comps/rpc/router/competitions/get-agents.ts
@@ -5,8 +5,10 @@ import { z } from "zod/v4";
 import { ApiError, PagingParamsSchema } from "@recallnet/services/types";
 
 import { base } from "@/rpc/context/base";
+import { cacheMiddleware } from "@/rpc/middleware/cache";
 
 export const getAgents = base
+  // .use(cacheMiddleware({ revalidate: 20 }))
   .input(
     z.object({
       competitionId: z.uuid(),

--- a/apps/comps/rpc/router/competitions/get-agents.ts
+++ b/apps/comps/rpc/router/competitions/get-agents.ts
@@ -1,14 +1,11 @@
 import { ORPCError } from "@orpc/client";
-import { unstable_cache } from "next/cache";
 import { z } from "zod/v4";
 
 import { ApiError, PagingParamsSchema } from "@recallnet/services/types";
 
 import { base } from "@/rpc/context/base";
-import { cacheMiddleware } from "@/rpc/middleware/cache";
 
 export const getAgents = base
-  // .use(cacheMiddleware({ revalidate: 20 }))
   .input(
     z.object({
       competitionId: z.uuid(),

--- a/apps/comps/vitest.config.ts
+++ b/apps/comps/vitest.config.ts
@@ -4,6 +4,7 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     environment: "jsdom",
+    typecheck: { enabled: true, include: ["**/*.test.ts"] },
     coverage: {
       provider: "v8",
       reporter: ["text", "json", "json-summary"],

--- a/packages/conversions/vitest.config.ts
+++ b/packages/conversions/vitest.config.ts
@@ -4,6 +4,7 @@ import { coverageConfigDefaults, defineConfig } from "vitest/config";
 export default defineConfig({
   plugins: [tsconfigPaths()],
   test: {
+    typecheck: { enabled: true, include: ["**/*.test.ts"] },
     root: "./",
     dir: "./src",
     include: ["**/*.test.ts"],

--- a/packages/db/vitest.config.ts
+++ b/packages/db/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
   plugins: [tsconfigPaths()],
   test: {
     passWithNoTests: true,
+    typecheck: { enabled: true, include: ["**/*.test.ts"] },
     coverage: {
       provider: "v8",
       reporter: ["text", "json", "json-summary"],
@@ -20,6 +21,7 @@ export default defineConfig({
           dir: "./src",
           include: ["**/*.test.ts"],
           exclude: ["**/*.integration.test.ts"],
+          typecheck: { enabled: true, include: ["**/*.test.ts"] },
         },
       },
       {
@@ -29,6 +31,7 @@ export default defineConfig({
           root: "./",
           dir: "./src",
           include: ["**/*.integration.test.ts"],
+          typecheck: { enabled: true, include: ["**/*.test.ts"] },
           testTimeout: 30_000, // Longer timeout for DB operations
           sequence: {
             concurrent: false,

--- a/packages/rewards/examples/test-case-with-ties.json
+++ b/packages/rewards/examples/test-case-with-ties.json
@@ -1,9 +1,21 @@
 {
   "prizePool": "1000000000000000000000",
   "leaderBoard": [
-    { "competitor": "Competitor A", "rank": 1 },
-    { "competitor": "Competitor B", "rank": 1 },
-    { "competitor": "Competitor C", "rank": 3 }
+    {
+      "competitor": "Competitor A",
+      "rank": 1,
+      "wallet": "0x8e3a2b7c4f1d9e6a5b2c3d4e5f6a7b8c9d0e1f2a"
+    },
+    {
+      "competitor": "Competitor B",
+      "rank": 2,
+      "wallet": "0x4f7b6c8d2e1a3b5c7d9e0f1a2b3c4d5e6f7a8b9c"
+    },
+    {
+      "competitor": "Competitor C",
+      "rank": 3,
+      "wallet": "0x1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b"
+    }
   ],
   "window": {
     "start": "2024-01-01T00:00:00Z",

--- a/packages/rewards/examples/test-case-with-ties.json
+++ b/packages/rewards/examples/test-case-with-ties.json
@@ -8,7 +8,7 @@
     },
     {
       "competitor": "Competitor B",
-      "rank": 2,
+      "rank": 1,
       "wallet": "0x4f7b6c8d2e1a3b5c7d9e0f1a2b3c4d5e6f7a8b9c"
     },
     {

--- a/packages/rewards/examples/test-case.json
+++ b/packages/rewards/examples/test-case.json
@@ -1,9 +1,21 @@
 {
   "prizePool": "1000000000000000000000",
   "leaderBoard": [
-    { "competitor": "Competitor A", "rank": 1 },
-    { "competitor": "Competitor B", "rank": 2 },
-    { "competitor": "Competitor C", "rank": 3 }
+    {
+      "competitor": "Competitor A",
+      "rank": 1,
+      "wallet": "0x8e3a2b7c4f1d9e6a5b2c3d4e5f6a7b8c9d0e1f2a"
+    },
+    {
+      "competitor": "Competitor B",
+      "rank": 2,
+      "wallet": "0x4f7b6c8d2e1a3b5c7d9e0f1a2b3c4d5e6f7a8b9c"
+    },
+    {
+      "competitor": "Competitor C",
+      "rank": 3,
+      "wallet": "0x1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b"
+    }
   ],
   "window": {
     "start": "2024-01-01T00:00:00Z",

--- a/packages/rewards/package.json
+++ b/packages/rewards/package.json
@@ -44,7 +44,8 @@
     "generate": "tsx scripts/generate.ts"
   },
   "dependencies": {
-    "decimal.js-light": "^2.5.1"
+    "decimal.js-light": "^2.5.1",
+    "zod": "3.25.76"
   },
   "devDependencies": {
     "@recallnet/eslint-config": "workspace:*",

--- a/packages/rewards/src/helpers.test.ts
+++ b/packages/rewards/src/helpers.test.ts
@@ -648,16 +648,16 @@ describe("splitPrizePool", () => {
   it("should split 1000 amount among 10 competitors with decay rate 0.5", () => {
     const amount = 1000n; // Using bigint for WEI
     const leaderBoard = [
-      { competitor: "competitor1", rank: 1 },
-      { competitor: "competitor2", rank: 2 },
-      { competitor: "competitor3", rank: 3 },
-      { competitor: "competitor4", rank: 4 },
-      { competitor: "competitor5", rank: 5 },
-      { competitor: "competitor6", rank: 6 },
-      { competitor: "competitor7", rank: 7 },
-      { competitor: "competitor8", rank: 8 },
-      { competitor: "competitor9", rank: 9 },
-      { competitor: "competitor10", rank: 10 },
+      { competitor: "competitor1", rank: 1, wallet: "0xabc" },
+      { competitor: "competitor2", rank: 2, wallet: "0xdef" },
+      { competitor: "competitor3", rank: 3, wallet: "0xghi" },
+      { competitor: "competitor4", rank: 4, wallet: "0xjkl" },
+      { competitor: "competitor5", rank: 5, wallet: "0xmnop" },
+      { competitor: "competitor6", rank: 6, wallet: "0xqrst" },
+      { competitor: "competitor7", rank: 7, wallet: "0xuvw" },
+      { competitor: "competitor8", rank: 8, wallet: "0xyz" },
+      { competitor: "competitor9", rank: 9, wallet: "0xabc" },
+      { competitor: "competitor10", rank: 10, wallet: "0xdef" },
     ];
     const r = 0.5;
 
@@ -738,9 +738,9 @@ describe("splitPrizePool", () => {
   it("should handle ties correctly by splitting combined pools equally among tied competitors", () => {
     const amount = 1000n; // Using bigint for WEI
     const leaderBoard = [
-      { competitor: "A", rank: 1 }, // Tied for 1st place
-      { competitor: "B", rank: 1 }, // Tied for 1st place
-      { competitor: "C", rank: 3 }, // 3rd place
+      { competitor: "A", rank: 1, wallet: "0x123" }, // Tied for 1st place
+      { competitor: "B", rank: 1, wallet: "0x456" }, // Tied for 1st place
+      { competitor: "C", rank: 3, wallet: "0x789" }, // 3rd place
     ];
     const r = 0.5;
 
@@ -818,11 +818,11 @@ describe("splitPrizePool", () => {
   it("should handle multiple ties at different ranks correctly", () => {
     const amount = 1000n;
     const leaderBoard = [
-      { competitor: "A", rank: 1 }, // Tied for 1st place
-      { competitor: "B", rank: 1 }, // Tied for 1st place
-      { competitor: "C", rank: 3 }, // Tied for 3rd place
-      { competitor: "D", rank: 3 }, // Tied for 3rd place
-      { competitor: "E", rank: 3 }, // Tied for 3rd place
+      { competitor: "A", rank: 1, wallet: "0x1" }, // Tied for 1st place
+      { competitor: "B", rank: 1, wallet: "0x2" }, // Tied for 1st place
+      { competitor: "C", rank: 3, wallet: "0x3" }, // Tied for 3rd place
+      { competitor: "D", rank: 3, wallet: "0x4" }, // Tied for 3rd place
+      { competitor: "E", rank: 3, wallet: "0x5" }, // Tied for 3rd place
     ];
     const r = 0.5;
 

--- a/packages/rewards/vitest.config.ts
+++ b/packages/rewards/vitest.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
     environment: "node",
     include: ["src/**/*.test.ts"],
     exclude: ["node_modules", "dist"],
+    typecheck: { enabled: true, include: ["**/*.test.ts"] },
     coverage: {
       provider: "v8",
       reporter: ["text", "json", "json-summary"],

--- a/packages/services/src/__tests__/trade-simulator.constraints.test.ts
+++ b/packages/services/src/__tests__/trade-simulator.constraints.test.ts
@@ -15,6 +15,7 @@ import { TradingConstraintsRepository } from "@recallnet/db/repositories/trading
 
 import { BalanceService } from "../balance.service.js";
 import { CompetitionService } from "../competition.service.js";
+import { specificChainTokens } from "../lib/config-utils.js";
 import {
   PriceTrackerService,
   PriceTrackerServiceConfig,
@@ -23,7 +24,11 @@ import { MultiChainProvider } from "../providers/multi-chain.provider.js";
 import { DexScreenerProvider } from "../providers/price/dexscreener.provider.js";
 import { SimulatedTradeExecutionService } from "../simulated-trade-execution.service.js";
 import { TradeSimulatorService } from "../trade-simulator.service.js";
-import { BlockchainType, PriceReport } from "../types/index.js";
+import {
+  BlockchainType,
+  PriceReport,
+  SpecificChainTokens,
+} from "../types/index.js";
 
 // Mock dependencies for unit tests
 vi.mock("../balance.service.js");
@@ -83,7 +88,7 @@ describe("SimulatedTradeExecutionService - Trading Constraints", () => {
       isStablecoin: ReturnType<typeof vi.fn>;
     };
     let mockConfig: {
-      specificChainTokens: Record<string, Record<string, string>>;
+      specificChainTokens: SpecificChainTokens;
       maxTradePercentage: number;
       tradingConstraints: {
         defaultMinimumPairAgeHours: number;
@@ -143,38 +148,7 @@ describe("SimulatedTradeExecutionService - Trading Constraints", () => {
       };
 
       mockConfig = {
-        specificChainTokens: {
-          eth: {
-            eth: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2", // WETH on Ethereum
-            usdc: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48", // USDC on Ethereum
-            usdt: "0xdAC17F958D2ee523a2206206994597C13D831ec7", // USDT on Ethereum
-          },
-          polygon: {
-            eth: "0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619", // Weth on Polygon
-            usdc: "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174", // USDC on Polygon
-            usdt: "0xc2132D05D31c914a87C6611C10748AEb04B58e8F", // USDT on Polygon
-          },
-          base: {
-            eth: "0x4200000000000000000000000000000000000006", // WETH on Base
-            usdc: "0xd9aAEc86B65D86f6A7B5B1b0c42FFA531710b6CA", // USDbC on Base
-            usdt: "0x50c5725949A6F0c72E6C4a641F24049A917DB0Cb", // USDT on Base
-          },
-          svm: {
-            sol: "So11111111111111111111111111111111111111112",
-            usdc: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
-            usdt: "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB",
-          },
-          arbitrum: {
-            eth: "0x82af49447d8a07e3bd95bd0d56f35241523fbab1", // WETH on Arbitrum
-            usdc: "0xaf88d065e77c8cc2239327c5edb3a432268e5831", // Native USDC on Arbitrum
-            usdt: "0xfd086bc7cd5c481dcc9c85ebe478a1c0b69fcbb9", // USDT on Arbitrum
-          },
-          optimism: {
-            eth: "0x4200000000000000000000000000000000000006", // WETH on Optimism
-            usdc: "0x7f5c764cbc14f9669b88837ca1490cca17c31607", // USDC on Optimism
-            usdt: "0x94b008aa00579c1307b0ef2c499ad98a8ce58e58", // USDT on Optimism
-          },
-        },
+        specificChainTokens,
         maxTradePercentage: 25,
         tradingConstraints: {
           defaultMinimumPairAgeHours: MINIMUM_PAIR_AGE_HOURS,

--- a/packages/services/src/providers/__tests__/chain-override.test.ts
+++ b/packages/services/src/providers/__tests__/chain-override.test.ts
@@ -4,11 +4,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { MockProxy, mock } from "vitest-mock-extended";
 
 import { specificChainTokens } from "../../lib/config-utils.js";
-import {
-  BlockchainType,
-  SpecificChain,
-  SpecificChainTokens,
-} from "../../types/index.js";
+import { BlockchainType, SpecificChain } from "../../types/index.js";
 import { MultiChainProvider } from "../multi-chain.provider.js";
 
 // Load environment variables for API access

--- a/packages/services/src/providers/__tests__/chain-override.test.ts
+++ b/packages/services/src/providers/__tests__/chain-override.test.ts
@@ -3,6 +3,7 @@ import { Logger } from "pino";
 import { beforeEach, describe, expect, it } from "vitest";
 import { MockProxy, mock } from "vitest-mock-extended";
 
+import { specificChainTokens } from "../../lib/config-utils.js";
 import {
   BlockchainType,
   SpecificChain,
@@ -21,17 +22,6 @@ const runTests = !!apiKey;
 const mockLogger: MockProxy<Logger> = mock<Logger>();
 
 const specificChains: SpecificChain[] = ["arbitrum", "base", "eth"];
-const specificChainTokens: SpecificChainTokens = {
-  arbitrum: {
-    arb: "0x912CE59144191C1204E64559FE8253a0e49E6548", // Arbitrum
-  },
-  base: {
-    tos: "0x532f27101965dd16442E59d40670FaF5eBB142E4", // TOSHI Token
-  },
-  eth: {
-    link: "0x514910771af9ca656af840dff83e8264ecf986ca", // Chainlink
-  },
-};
 
 // Known test tokens from different chains
 const testTokens = [

--- a/packages/services/src/providers/__tests__/dexscreener.provider.batch.test.ts
+++ b/packages/services/src/providers/__tests__/dexscreener.provider.batch.test.ts
@@ -2,6 +2,7 @@ import { Logger } from "pino";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { MockProxy, mock } from "vitest-mock-extended";
 
+import { specificChainTokens } from "../../lib/config-utils.js";
 import { BlockchainType } from "../../types/index.js";
 import { DexScreenerProvider } from "../price/dexscreener.provider.js";
 
@@ -10,25 +11,6 @@ vi.setConfig({ testTimeout: 15_000 });
 
 describe("Batch Functionality Tests", () => {
   let provider: DexScreenerProvider;
-
-  // SpecificChainTokens for the constructor
-  const specificChainTokens = {
-    eth: {
-      eth: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2", // WETH on Ethereum
-      usdc: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48", // USDC on Ethereum
-      usdt: "0xdAC17F958D2ee523a2206206994597C13D831ec7", // USDT on Ethereum
-      shib: "0x95aD61b0a150d79219dCF64E1E6Cc01f0B64C4cE",
-    },
-    base: {
-      eth: "0x4200000000000000000000000000000000000006", // WETH on Base
-      usdc: "0xd9aAEc86B65D86f6A7B5B1b0c42FFA531710b6CA", // USDbC on Base
-    },
-    svm: {
-      sol: "So11111111111111111111111111111111111111112",
-      usdc: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
-      bonk: "DezXAZ8z7PnrnRJjz3wXBoRgixCa6xjnB7YaB1pPB263",
-    },
-  };
 
   // Mock logger for the constructor
   const mockLogger: MockProxy<Logger> = mock<Logger>();

--- a/packages/services/src/providers/__tests__/dexscreener.provider.test.ts
+++ b/packages/services/src/providers/__tests__/dexscreener.provider.test.ts
@@ -3,6 +3,7 @@ import { Logger } from "pino";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { MockProxy, mock } from "vitest-mock-extended";
 
+import { specificChainTokens } from "../../lib/config-utils.js";
 import { BlockchainType } from "../../types/index.js";
 import { DexScreenerProvider } from "../price/dexscreener.provider.js";
 
@@ -14,25 +15,6 @@ vi.setConfig({ testTimeout: 30_000 });
 
 describe("DexScreenerProvider", () => {
   let provider: DexScreenerProvider;
-
-  // SpecificChainTokens for the constructor
-  const specificChainTokens = {
-    eth: {
-      eth: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2", // WETH on Ethereum
-      usdc: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48", // USDC on Ethereum
-      usdt: "0xdAC17F958D2ee523a2206206994597C13D831ec7", // USDT on Ethereum
-      shib: "0x95aD61b0a150d79219dCF64E1E6Cc01f0B64C4cE",
-    },
-    base: {
-      eth: "0x4200000000000000000000000000000000000006", // WETH on Base
-      usdc: "0xd9aAEc86B65D86f6A7B5B1b0c42FFA531710b6CA", // USDbC on Base
-    },
-    svm: {
-      sol: "So11111111111111111111111111111111111111112",
-      usdc: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
-      bonk: "DezXAZ8z7PnrnRJjz3wXBoRgixCa6xjnB7YaB1pPB263",
-    },
-  };
 
   // Mock logger for the constructor
   const mockLogger: MockProxy<Logger> = mock<Logger>();

--- a/packages/services/src/providers/__tests__/multi-chain.provider.batch.test.ts
+++ b/packages/services/src/providers/__tests__/multi-chain.provider.batch.test.ts
@@ -2,6 +2,7 @@ import { Logger } from "pino";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { MockProxy, mock } from "vitest-mock-extended";
 
+import { specificChainTokens } from "../../lib/config-utils.js";
 import { BlockchainType, SpecificChain } from "../../types/index.js";
 import { MultiChainProvider } from "../multi-chain.provider.js";
 
@@ -12,25 +13,6 @@ describe("Batch Functionality Tests", () => {
   let provider: MultiChainProvider;
 
   const specificChains: SpecificChain[] = ["eth", "base", "svm"];
-
-  // SpecificChainTokens for the constructor
-  const specificChainTokens = {
-    eth: {
-      eth: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2", // WETH on Ethereum
-      usdc: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48", // USDC on Ethereum
-      usdt: "0xdAC17F958D2ee523a2206206994597C13D831ec7", // USDT on Ethereum
-      shib: "0x95aD61b0a150d79219dCF64E1E6Cc01f0B64C4cE",
-    },
-    base: {
-      eth: "0x4200000000000000000000000000000000000006", // WETH on Base
-      usdc: "0xd9aAEc86B65D86f6A7B5B1b0c42FFA531710b6CA", // USDbC on Base
-    },
-    svm: {
-      sol: "So11111111111111111111111111111111111111112",
-      usdc: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
-      bonk: "DezXAZ8z7PnrnRJjz3wXBoRgixCa6xjnB7YaB1pPB263",
-    },
-  };
 
   // Mock logger for the constructor
   const mockLogger: MockProxy<Logger> = mock<Logger>();

--- a/packages/services/src/providers/__tests__/multi-chain.provider.test.ts
+++ b/packages/services/src/providers/__tests__/multi-chain.provider.test.ts
@@ -3,6 +3,7 @@ import { Logger } from "pino";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { MockProxy, mock } from "vitest-mock-extended";
 
+import { specificChainTokens } from "../../lib/config-utils.js";
 import { BlockchainType, SpecificChain } from "../../types/index.js";
 import { MultiChainProvider } from "../multi-chain.provider.js";
 
@@ -13,20 +14,6 @@ dotenv.config();
 vi.setConfig({ testTimeout: 30_000 });
 
 const evmChains: SpecificChain[] = ["svm", "eth", "base"];
-const specificChainTokens = {
-  svm: {
-    sol: "So11111111111111111111111111111111111111112",
-    usdc: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
-  },
-  eth: {
-    eth: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2", // WETH
-    usdc: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
-  },
-  base: {
-    eth: "0x4200000000000000000000000000000000000006", // WETH on Base
-    usdc: "0xd9aAEc86B65D86f6A7B5B1b0c42FFA531710b6CA", // USDbC on Base
-  },
-};
 
 // Mock logger for the constructor
 const mockLogger: MockProxy<Logger> = mock<Logger>();

--- a/packages/services/src/providers/__tests__/price-tracker.service.batch.test.ts
+++ b/packages/services/src/providers/__tests__/price-tracker.service.batch.test.ts
@@ -2,6 +2,7 @@ import { Logger } from "pino";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { MockProxy, mock } from "vitest-mock-extended";
 
+import { specificChainTokens } from "../../lib/config-utils.js";
 import { PriceTrackerService } from "../../price-tracker.service.js";
 import { SpecificChain } from "../../types/index.js";
 import { MultiChainProvider } from "../multi-chain.provider.js";
@@ -13,25 +14,6 @@ describe("Batch Functionality Tests", () => {
   let priceTracker: PriceTrackerService;
 
   const specificChains: SpecificChain[] = ["eth", "base", "svm"];
-
-  // SpecificChainTokens for the constructor
-  const specificChainTokens = {
-    eth: {
-      eth: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2", // WETH on Ethereum
-      usdc: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48", // USDC on Ethereum
-      usdt: "0xdAC17F958D2ee523a2206206994597C13D831ec7", // USDT on Ethereum
-      shib: "0x95aD61b0a150d79219dCF64E1E6Cc01f0B64C4cE",
-    },
-    base: {
-      eth: "0x4200000000000000000000000000000000000006", // WETH on Base
-      usdc: "0xd9aAEc86B65D86f6A7B5B1b0c42FFA531710b6CA", // USDbC on Base
-    },
-    svm: {
-      sol: "So11111111111111111111111111111111111111112",
-      usdc: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
-      bonk: "DezXAZ8z7PnrnRJjz3wXBoRgixCa6xjnB7YaB1pPB263",
-    },
-  };
 
   // Mock logger for the constructor
   const mockLogger: MockProxy<Logger> = mock<Logger>();

--- a/packages/services/vitest.config.ts
+++ b/packages/services/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
   plugins: [tsconfigPaths()],
   test: {
     passWithNoTests: true,
+    typecheck: { enabled: true, include: ["**/*.test.ts"] },
     coverage: {
       provider: "v8",
       reporter: ["text", "json", "json-summary"],
@@ -20,6 +21,7 @@ export default defineConfig({
           dir: "./src",
           include: ["**/*.test.ts"],
           exclude: ["**/*.integration.test.ts"],
+          typecheck: { enabled: true, include: ["**/*.test.ts"] },
         },
       },
       {
@@ -29,6 +31,7 @@ export default defineConfig({
           root: "./",
           dir: "./src",
           include: ["**/*.integration.test.ts"],
+          typecheck: { enabled: true, include: ["**/*.test.ts"] },
           testTimeout: 30_000, // Longer timeout for DB operations
           sequence: {
             concurrent: false,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -659,6 +659,9 @@ importers:
       decimal.js-light:
         specifier: ^2.5.1
         version: 2.5.1
+      zod:
+        specifier: 3.25.76
+        version: 3.25.76
     devDependencies:
       '@recallnet/eslint-config':
         specifier: workspace:*

--- a/turbo.json
+++ b/turbo.json
@@ -24,12 +24,15 @@
   ],
   "tasks": {
     "test": {
+      "dependsOn": ["^build"],
       "cache": false
     },
     "test:integration": {
+      "dependsOn": ["^build"],
       "cache": false
     },
     "test:e2e": {
+      "dependsOn": ["^build"],
       "cache": false
     },
     "build": {


### PR DESCRIPTION
We had a strange situation that I just discovered that resulted in som packages not compiling when running `pnpm dev` and tests running and passing even though they contained typescript compilation errors. This was caused by these factors:

- Vitest, by default, doesn't check that your typescript written test actually compile and will just transpile and run them. These tests may still run an succeed despite the typescript errors in the source file.
- We run  our `dev` mode using `tsc --watch` which compiles all files, including test files, so compilation was failing for some tests in dev mode.
- We run `build` using `tsup` which ignores test files, so we were never aware of the typescript problems in the tests.

This PR cleans all that up by making Vitest fail if there are typescript errors in tests. It fixes all the resulting typescript errors in tests.

It also fixes some legit problems that somehow snuck into the `rewards` package. Some types were updated with new/different properties a couple days ago, but code using the types wasn't updated. 