### PR TITLE
fix(ui): prevent horizontal overflow on mobile screens

### DIFF
--- a/apps/comps/app/layout.tsx
+++ b/apps/comps/app/layout.tsx
@@ -51,7 +51,7 @@ export default function RootLayout({
         />
       </head>
       <body
-        className={`${fontSans.variable} ${fontMono.variable} overflow-x-hidden bg-black antialiased`}
+        className={`${fontSans.variable} ${fontMono.variable} bg-black antialiased`}
       >
         <Tracking />
         <Toaster position="top-right" />

--- a/packages/ui2/src/components/tabs.tsx
+++ b/packages/ui2/src/components/tabs.tsx
@@ -13,7 +13,10 @@ function TabsList({ className, ref, ...props }: TabsListProps) {
   return (
     <TabsPrimitive.List
       ref={ref}
-      className={cn("inline-flex h-10 items-center justify-start", className)}
+      className={cn(
+        "inline-flex min-h-10 items-center justify-start",
+        className,
+      )}
       {...props}
     />
   );

--- a/packages/ui2/src/styles/globals.css
+++ b/packages/ui2/src/styles/globals.css
@@ -90,8 +90,12 @@
   * {
     @apply border-border outline-ring/50;
   }
+  html {
+    overflow-x: clip;
+  }
   body {
     @apply bg-background text-foreground font-sans tracking-wider;
+    overflow-x: clip;
   }
   button {
     @apply font-mono;


### PR DESCRIPTION
## Summary
  Fixes horizontal overflow on mobile and small screen sizes (APP-506) by preventing the hero carousel from causing page-wide scrolling.

## Changes
- Add `overflow-x: clip` to html/body to prevent horizontal scroll
- Change TabsList from fixed height to min-height for proper wrapping on mobile

## Test Plan
- [x] No horizontal scrolling on mobile viewports
- [x] Hero section design preserved on desktop
- [x] Tabs wrap correctly on small screens
- [x] Overlays (modals, tooltips, dropdowns) still work correctly