### PR TITLE
chore: Clean up auth controller

### DIFF
--- a/packages/services/src/user.service.ts
+++ b/packages/services/src/user.service.ts
@@ -1,3 +1,4 @@
+import type { PrivyClient } from "@privy-io/server-auth";
 import { randomUUID } from "crypto";
 import { Logger } from "pino";
 
@@ -9,7 +10,10 @@ import { InsertUser, SelectUser } from "@recallnet/db/schema/core/types";
 import { Database, Transaction } from "@recallnet/db/types";
 
 import { EmailService } from "./email.service.js";
+import { checkUserUniqueConstraintViolation } from "./lib/error-utils.js";
+import { verifyAndGetPrivyUserInfo } from "./lib/privy-verification.js";
 import { WalletWatchlist } from "./lib/watchlist.js";
+import { ApiError } from "./types/index.js";
 import { UserMetadata, UserSearchParams } from "./types/index.js";
 
 /**
@@ -415,6 +419,91 @@ export class UserService {
         error,
       );
       return null;
+    }
+  }
+
+  /**
+   * Authenticate user with Privy identity token and update/create user record.
+   *
+   * Handles the following scenarios:
+   * 1. Post-Privy users with existing privyId in database
+   * 2. Post-legacy but pre-Privy users (email exists)
+   * 3. Legacy users (only wallet address exists)
+   * 4. Brand new users (creates new record)
+   *
+   * @param identityToken - The Privy identity token to verify
+   * @param privyClient - The Privy client instance for user verification
+   * @returns The authenticated user record
+   * @throws {ApiError} 409 if unique constraint is violated (duplicate email/wallet/privyId)
+   */
+  async loginWithPrivyToken(
+    identityToken: string,
+    privyClient: PrivyClient,
+  ): Promise<SelectUser> {
+    try {
+      const { privyId, name, email, embeddedWallet, customWallets } =
+        await verifyAndGetPrivyUserInfo(identityToken, privyClient);
+      const embeddedWalletAddress = embeddedWallet.address;
+      const now = new Date();
+
+      // 1. Handle post-Privy migration users
+      const existingUserWithPrivyId = await this.getUserByPrivyId(privyId);
+      if (existingUserWithPrivyId) {
+        return await this.updateUser({
+          id: existingUserWithPrivyId.id,
+          lastLoginAt: now,
+        });
+      }
+
+      // 2. Handle post-legacy but pre-Privy users (an `email` always exists via legacy Loops emails)
+      // Note: we skip the explicit email branch and rely on repository UPSERT (email idempotency)
+      // in `registerUser` (called in the fallback below) to handle this case.
+
+      // 3. Handle legacy users (only a `walletAddress` exists, but it might not be connected to Privy)
+      // This is an edge case where a user never logged in nor set up an email, so our best guess is to
+      // use the "latest" connected wallet as the primary wallet address and see if the user exists.
+      const customWalletAddress = customWallets.sort(
+        (a, b) =>
+          (b.latestVerifiedAt?.getTime() ?? 0) -
+          (a.latestVerifiedAt?.getTime() ?? 0),
+      )[0]?.address;
+      if (customWalletAddress) {
+        const existingUserWithWallet =
+          await this.getUserByWalletAddress(customWalletAddress);
+        if (existingUserWithWallet) {
+          return await this.updateUser({
+            id: existingUserWithWallet.id,
+            name: existingUserWithWallet.name ?? name,
+            email,
+            privyId,
+            embeddedWalletAddress,
+            lastLoginAt: now,
+          });
+        }
+      }
+
+      // 4. Create completely new user, using the embedded wallet address as the primary wallet address
+      return await this.registerUser(
+        embeddedWalletAddress,
+        name,
+        email,
+        undefined,
+        undefined,
+        privyId,
+        embeddedWalletAddress,
+      );
+    } catch (error) {
+      // Check for unique constraint violations
+      const violatedField = checkUserUniqueConstraintViolation(error);
+      if (violatedField) {
+        throw new ApiError(
+          409,
+          `A user with this ${violatedField} already exists`,
+        );
+      }
+
+      // Re-throw other errors
+      throw error;
     }
   }
 


### PR DESCRIPTION
Throw errors instead of returning `success: false`, and move key business logic for `login` into `userService`