### PR TITLE
fix: Center hexagon trophy images

### DIFF
--- a/apps/comps/components/hexagon/index.tsx
+++ b/apps/comps/components/hexagon/index.tsx
@@ -9,7 +9,7 @@ export const Hexagon: React.FC<React.HTMLAttributes<HTMLDivElement>> = ({
   return (
     <div
       className={cn(
-        "h-13 w-13 flex items-center justify-center text-white",
+        "h-13 w-13 flex items-center justify-center overflow-hidden text-white",
         className,
       )}
       style={{
@@ -17,7 +17,6 @@ export const Hexagon: React.FC<React.HTMLAttributes<HTMLDivElement>> = ({
           "polygon(25% 0%, 75% 0%, 100% 50%, 75% 100%, 25% 100%, 0% 50%)",
         WebkitClipPath:
           "polygon(25% 0%, 75% 0%, 100% 50%, 75% 100%, 25% 100%, 0% 50%)",
-        transform: "rotate(90deg)",
         ...style,
       }}
       {...props}

--- a/apps/comps/components/trophy-badge/index.tsx
+++ b/apps/comps/components/trophy-badge/index.tsx
@@ -106,9 +106,11 @@ export const TrophyBadge: React.FC<TrophyBadgeProps> = ({ trophy, size }) => {
             style={{
               height: innerH,
               width: innerW,
+              position: "absolute",
+              left: `${borderThickness}px`,
+              top: `${borderThickness}px`,
             }}
             className={cn(
-              `relative left-[${borderThickness}px] top-[${borderThickness}px]`,
               "duration-330 transition-transform ease-in-out group-hover:scale-110",
             )}
           >
@@ -128,9 +130,10 @@ export const TrophyBadge: React.FC<TrophyBadgeProps> = ({ trophy, size }) => {
               src={imageUrl}
               alt="competition"
               fill
-              className="rotate-270 left-0 top-0 w-full object-cover"
+              className="object-cover"
               style={{
-                transform: `scale(${imageZoom})`, // Dynamically set scale
+                transform: `scale(${imageZoom})`,
+                objectPosition: "center",
               }}
             />
           </Hexagon>


### PR DESCRIPTION
Fix trophy centering on agent profile and table
<img width="1087" height="556" alt="Screenshot 2025-10-06 at 9 27 47 PM" src="https://github.com/user-attachments/assets/67c743a1-5b2e-4ed8-bdb9-24fc56c19fe8" />
