### PR TITLE
feat: updates activate boost logic

### DIFF
--- a/apps/api/src/services/index.ts
+++ b/apps/api/src/services/index.ts
@@ -317,16 +317,7 @@ class ServiceRegistry {
       serviceLogger,
     );
 
-    // Initialize BoostService with its dependencies
-    // TODO: Consider the best practice for services depending on repositories and/or other services.
-    this._boostService = new BoostService(
-      this._boostRepository,
-      this._competitionRepository,
-      this._userRepository,
-      config,
-      serviceLogger,
-    );
-
+    // Initialize BoostAwardService first (needed by BoostService)
     this._boostAwardService = new BoostAwardService(
       db,
       this._competitionRepository,
@@ -334,6 +325,18 @@ class ServiceRegistry {
       this._stakesRepository,
       this._userService,
       config,
+    );
+
+    // Initialize BoostService with its dependencies
+    // TODO: Consider the best practice for services depending on repositories and/or other services.
+    this._boostService = new BoostService(
+      this._boostRepository,
+      this._competitionRepository,
+      this._userRepository,
+      this._boostAwardService,
+      db,
+      config,
+      serviceLogger,
     );
 
     // Initialize RewardsService with its dependencies

--- a/apps/comps/lib/services.ts
+++ b/apps/comps/lib/services.ts
@@ -51,14 +51,6 @@ export const walletWatchList = new WalletWatchlist(
   createLogger("WalletWatchlist"),
 );
 
-export const boostService = new BoostService(
-  boostRepository,
-  competitionRepository,
-  userRepository,
-  config,
-  createLogger("BoostService"),
-);
-
 export const balanceService = new BalanceService(
   balanceRepository,
   config,
@@ -107,6 +99,16 @@ export const boostAwardService = new BoostAwardService(
   stakesRepository,
   userService,
   config,
+);
+
+export const boostService = new BoostService(
+  boostRepository,
+  competitionRepository,
+  userRepository,
+  boostAwardService,
+  db,
+  config,
+  createLogger("BoostService"),
 );
 
 export const agentService = new AgentService(

--- a/apps/comps/rpc/router/boost/claim-staked-boost.ts
+++ b/apps/comps/rpc/router/boost/claim-staked-boost.ts
@@ -1,0 +1,37 @@
+import { z } from "zod";
+
+import { base } from "@/rpc/context/base";
+import { authMiddleware } from "@/rpc/middleware/auth";
+import { assertNever } from "@/rpc/router/utils/assert-never";
+
+export const claimStakedBoost = base
+  .use(authMiddleware)
+  .errors({
+    BOOST_ALREADY_CLAIMED: {
+      message: "Boost already claimed",
+    },
+  })
+  .input(
+    z.object({
+      competitionId: z.string().uuid(),
+    }),
+  )
+  .handler(async ({ context, input, errors }) => {
+    const res = await context.boostService.claimStakedBoost(
+      context.user.id,
+      context.user.walletAddress,
+      input.competitionId,
+    );
+    if (res.isErr()) {
+      switch (res.error.type) {
+        case "RepositoryError":
+          throw errors.INTERNAL({ message: res.error.message });
+        case "AlreadyClaimedBoost":
+          throw errors.BOOST_ALREADY_CLAIMED();
+        default:
+          assertNever(res.error);
+      }
+    } else {
+      return res.value;
+    }
+  });

--- a/apps/comps/rpc/router/boost/index.ts
+++ b/apps/comps/rpc/router/boost/index.ts
@@ -3,10 +3,12 @@ import { availableAwards } from "./available-awards";
 import { balance } from "./balance";
 import { boostAgent } from "./boost-agent";
 import { claimBoost } from "./claim-boost";
+import { claimStakedBoost } from "./claim-staked-boost";
 import { userBoosts } from "./user-boosts";
 
 export const router = {
   claimBoost,
+  claimStakedBoost,
   agentBoostTotals,
   balance,
   boostAgent,


### PR DESCRIPTION
# Context

Changes the logic of the "Start boosting" button that allocates some boosts to the user, with a feature flag. We now should consider the stakes to determine how much boost to allocate. 

Closes [APP-599](https://linear.app/recall-labs/issue/APP-599/update-activate-boost-logic-for-tge)

This was manually tested by inserting stakes in the database, and manually changing the code to activate one logic or the other.

