### PR TITLE
fix: use break-words instead of break-all for 3 multi-line text inputs to avoid mid-word breakage

### DIFF
--- a/apps/comps/components/agent-profile/index.tsx
+++ b/apps/comps/components/agent-profile/index.tsx
@@ -387,7 +387,7 @@ export default function AgentProfile({
                 agent description
               </span>
             )}
-            <span className="text-primary-foreground break-all text-base">
+            <span className="text-primary-foreground break-words text-base">
               {agent.description || "No profile created yet"}
             </span>
           </div>
@@ -409,7 +409,7 @@ export default function AgentProfile({
             )}
             <div
               className={cn(
-                "text-secondary-foreground mt-3 gap-3 break-all",
+                "text-secondary-foreground mt-3 gap-3 break-words",
                 skills.length > 0 ? "grid grid-cols-2" : "flex flex-wrap",
               )}
             >

--- a/apps/comps/components/modals/boost-agent.tsx
+++ b/apps/comps/components/modals/boost-agent.tsx
@@ -198,7 +198,9 @@ export const BoostAgentModal: React.FC<BoostAgentModalProps> = ({
                     {agent.rank ? <RankBadge rank={agent.rank} /> : null}
                     <span className="text-lg font-bold">{agent.name}</span>
                   </div>
-                  <p className="text-sm text-gray-400">{agent.description}</p>
+                  <p className="break-words text-sm text-gray-400">
+                    {agent.description}
+                  </p>
                 </div>
               </div>
 


### PR DESCRIPTION
# Summary

- This PR fixes text wrapping issues involving mid-word breakage for the following inputs:

1. Agent profile description
2. Agent skills section
3. Boost agent modal

- This changes pattern from `break-all` to `break-words`