### PR TITLE
feat(contracts): add timeout, polling interval to wait logic

### DIFF
--- a/packages/staking-contracts/src/rewards-allocator.ts
+++ b/packages/staking-contracts/src/rewards-allocator.ts
@@ -37,12 +37,14 @@ interface ClaimResult {
 interface Options {
   timeout?: number;
   retryCount?: number;
+  pollingInterval?: number;
 }
 
 class RewardsAllocator {
   private walletClient: WalletClient;
   private publicClient: PublicClient;
   private contractAddress: Hex;
+  private timeout?: number;
 
   constructor(
     privateKey: Hex,
@@ -65,15 +67,18 @@ class RewardsAllocator {
     this.publicClient = createPublicClient({
       chain,
       transport: http(rpcProviderUrl, httpTransportOptions),
+      pollingInterval: options?.pollingInterval,
     });
 
     this.walletClient = createWalletClient({
       account,
       chain,
       transport: http(rpcProviderUrl, httpTransportOptions),
+      pollingInterval: options?.pollingInterval,
     });
 
     this.contractAddress = contractAddress;
+    this.timeout = options?.timeout;
   }
 
   async allocate(
@@ -93,6 +98,7 @@ class RewardsAllocator {
 
     const receipt = await this.publicClient.waitForTransactionReceipt({
       hash,
+      timeout: this.timeout,
     });
 
     if (receipt.status === "success") {

--- a/packages/staking-contracts/src/rewards-claimer.ts
+++ b/packages/staking-contracts/src/rewards-claimer.ts
@@ -31,12 +31,14 @@ interface ClaimResult {
 interface Options {
   timeout?: number;
   retryCount?: number;
+  pollingInterval?: number;
 }
 
 class RewardsClaimer {
   private walletClient: WalletClient;
   private publicClient: PublicClient;
   private contractAddress: Hex;
+  private timeout?: number;
 
   constructor(
     privateKey: Hex,
@@ -59,15 +61,18 @@ class RewardsClaimer {
     this.publicClient = createPublicClient({
       chain,
       transport: http(rpcProviderUrl, httpTransportOptions),
+      pollingInterval: options?.pollingInterval,
     });
 
     this.walletClient = createWalletClient({
       account,
       chain,
       transport: http(rpcProviderUrl, httpTransportOptions),
+      pollingInterval: options?.pollingInterval,
     });
 
     this.contractAddress = contractAddress;
+    this.timeout = options?.timeout;
   }
 
   /**
@@ -93,6 +98,7 @@ class RewardsClaimer {
 
     const receipt = await this.publicClient.waitForTransactionReceipt({
       hash,
+      timeout: this.timeout,
     });
 
     if (receipt.status === "success") {

--- a/packages/staking-contracts/test/rewards-allocator.test.ts
+++ b/packages/staking-contracts/test/rewards-allocator.test.ts
@@ -13,10 +13,10 @@ describe("Allocator Error Path", () => {
     // Mock a failed transaction to hit `allocate`
     const allocator = new RewardsAllocator(
       "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
-      "http://invalid-url", // Invalid RPC to trigger failure
+      "http://127.0.0.1:9999", // Invalid RPC to trigger failure
       "0x0000000000000000000000000000000000000000",
       Network.Hardhat,
-      { timeout: 100, retryCount: 0 },
+      { timeout: 100, retryCount: 0, pollingInterval: 100 },
     );
 
     await assert.rejects(

--- a/packages/staking-contracts/test/rewards-claimer.test.ts
+++ b/packages/staking-contracts/test/rewards-claimer.test.ts
@@ -5,28 +5,35 @@ import { Network } from "../src/rewards-allocator.js";
 import RewardsClaimer from "../src/rewards-claimer.js";
 
 describe("Claimer Error Path", () => {
-  it("should throw error on network failure", async () => {
-    // Test network-level failure (current working test)
-    const claimer = new RewardsClaimer(
-      "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
-      "http://invalid-url", // Invalid RPC to trigger failure
-      "0x0000000000000000000000000000000000000000",
-      Network.Hardhat,
-      { timeout: 100, retryCount: 0 },
-    );
+  it(
+    "should throw error on network failure",
+    {
+      timeout: 10_000,
+    },
+    async () => {
+      // Test network-level failure (current working test)
+      const claimer = new RewardsClaimer(
+        "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
+        "http://127.0.0.1:9999", // Invalid RPC to trigger failure
+        "0x0000000000000000000000000000000000000000",
+        Network.Hardhat,
+        { timeout: 100, retryCount: 0, pollingInterval: 100 },
+      );
 
-    await assert.rejects(
-      () =>
-        claimer.claim(
-          "0x0000000000000000000000000000000000000000000000000000000000000000", // 32-byte merkle root
-          1n,
-          [],
-        ),
-      (error: Error) =>
-        error.message.includes("fetch") ||
-        error.message.includes("ECONNREFUSED"),
-    );
-  });
+      await assert.rejects(
+        () =>
+          claimer.claim(
+            "0x0000000000000000000000000000000000000000000000000000000000000000", // 32-byte merkle root
+            1n,
+            [],
+          ),
+        (error: Error) =>
+          error.message.includes("fetch") ||
+          error.message.includes("ECONNREFUSED") ||
+          error.message.includes("timeout"),
+      );
+    },
+  );
 
   // Note: The transaction failure path (lines 94-95) requires a transaction to be
   // submitted successfully but then fail with status !== "success". This is complex


### PR DESCRIPTION
To [fix a unit test failure](https://github.com/recallnet/js-recall/actions/runs/18344656834/job/52248198376), this PR adds a polling interval, applies the timeout option to the wait for tx logic, and uses these in test (along w/ increased test timeout).