### PR TITLE
fix: hide conviction rewards card from ineligible users

### DIFF
--- a/apps/comps/providers/conviction-provider.tsx
+++ b/apps/comps/providers/conviction-provider.tsx
@@ -124,9 +124,13 @@ export function ConvictionProvider({
     }),
   );
 
-  // Determine eligibility: non-empty response means eligible
+  // Only show conviction UI if user has actionable or active claims
   const isConvictionEligible = useMemo(() => {
-    return Boolean(claimsData && claimsData.length > 0);
+    if (!claimsData || claimsData.length === 0) return false;
+    return claimsData.some(
+      (claim) =>
+        claim.type === "available" || claim.type === "claimed-and-staked",
+    );
   }, [claimsData]);
 
   // Find claims that trigger modals


### PR DESCRIPTION
## Summary
Only show the conviction staking UI to users with actionable airdrop claims. Users who have expired claims, claimed but not staked, or are ineligible for other reasons (sybil, flagged, etc.) should not see the conviction rewards card.

## Problem
A user on the genesis airdrop list had claimed and never staked their airdrop allocation, but was seeing the conviction rewards card. He mistakenly bought tokens and staked via the regular staking mechanism, thinking the card was telling him he needed to stake to be eligible—but the conviction rewards eligibility check only counts conviction stakes (airdrop allocations with duration > 0), not regular stakes.

## Solution
Filter `isConvictionEligible` to only return true for claims in actionable or active states:
- `available` — user can still claim & stake their airdrop
- `claimed-and-staked` — user already staked their airdrop

Exclude `expired`, `claimed-and-not-staked`, and `ineligible` claims from showing the card.

🤖 Generated with Claude Code