### PR TITLE
fix: show CLAIM button label when no stake selected

### DIFF
--- a/apps/comps/components/modals/ConvictionStakeModal.tsx
+++ b/apps/comps/components/modals/ConvictionStakeModal.tsx
@@ -267,7 +267,8 @@ export const ConvictionStakeModal: React.FC<ConvictionStakeModalProps> = ({
                 onClick={handleStake}
                 className="h-12 px-6 text-base font-bold"
               >
-                STAKE <ChevronRight size={16} className="ml-1" />
+                {selectedDurationIndex === 0 ? "CLAIM" : "STAKE"}{" "}
+                <ChevronRight size={16} className="ml-1" />
               </Button>
             </div>
           </>


### PR DESCRIPTION
## Summary

The conviction staking modal button now dynamically displays "CLAIM" when the user selects "No stake" (0 duration lock period) and "STAKE" for any staking duration. This clarifies the actual action being taken and prevents confusion since clicking the button executes a claim transaction, not a stake transaction.

## Changes

- Modified ConvictionStakeModal button label to conditionally show "CLAIM" or "STAKE" based on selected duration

🤖 Generated with [Claude Code](https://claude.com/claude-code)